### PR TITLE
Fix DATACLASS-110 and remove obsolete code

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/MappingCassandraConverter.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/MappingCassandraConverter.java
@@ -65,7 +65,6 @@ public class MappingCassandraConverter extends AbstractCassandraConverter implem
 	protected final CassandraMappingContext mappingContext;
 	protected ApplicationContext applicationContext;
 	protected SpELContext spELContext;
-	protected boolean useFieldAccessOnly = true;
 
 	protected ClassLoader beanClassLoader;
 
@@ -187,14 +186,6 @@ public class MappingCassandraConverter extends AbstractCassandraConverter implem
 
 		return instantiator.createInstance(entity, new CassandraPersistentEntityParameterValueProvider(entity,
 				propertyProvider, null));
-	}
-
-	public boolean getUseFieldAccessOnly() {
-		return useFieldAccessOnly;
-	}
-
-	public void setUseFieldAccessOnly(boolean useFieldAccessOnly) {
-		this.useFieldAccessOnly = useFieldAccessOnly;
 	}
 
 	@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -62,7 +62,6 @@ public class CassandraTemplate extends CqlTemplate implements CassandraOperation
 
 	protected CassandraConverter cassandraConverter;
 	protected CassandraMappingContext mappingContext;
-	protected boolean useFieldAccessOnly = false;
 
 	/**
 	 * Default Constructor for wiring in the required components later
@@ -96,19 +95,6 @@ public class CassandraTemplate extends CqlTemplate implements CassandraOperation
 
 	public CassandraMappingContext getCassandraMappingContext() {
 		return mappingContext;
-	}
-
-	public boolean getUseFieldAccessOnly() {
-		return useFieldAccessOnly;
-	}
-
-	/**
-	 * Whether only fields should be used when accessing a persistent entity's data.
-	 * 
-	 * @param useFieldAccessOnly
-	 */
-	public void setUseFieldAccessOnly(boolean useFieldAccessOnly) {
-		this.useFieldAccessOnly = useFieldAccessOnly;
 	}
 
 	@Override


### PR DESCRIPTION
Spring Core removed useFieldAccess from BeanWrapper's getProperty in https://github.com/spring-projects/spring-data-commons/commit/4c6afc5c30fe35a22e8c3534dd6601ff5f84c0a4
This pull request updates spring-data-cassandra to the new BeanWrapper.
