### PR TITLE
Change default DataType mapping for properties of type Long

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CassandraSimpleTypeHolder.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CassandraSimpleTypeHolder.java
@@ -73,6 +73,8 @@ public class CassandraSimpleTypeHolder extends SimpleTypeHolder {
 		}
 
 		dataTypesByJavaClass.put(String.class, DataType.text());
+		dataTypesByJavaClass.put(Long.class, DataType.bigint());
+		dataTypesByJavaClass.put(long.class, DataType.bigint());
 
 		CASSANDRA_SIMPLE_TYPES = Collections.unmodifiableSet(simpleTypes);
 	}


### PR DESCRIPTION
Change mapping of Longs from COUNTER to BIGINT, as its a more common use case. Counter properties can be annotated with @CassandraType(type=DataType.Name.COUNTER) to map to COUNTER.
Added unit test for all standard mappings
