### PR TITLE
Throw IllegalArgumentException if a column is requested that isn't in the table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build
 .project
 .settings
 .cassandra
+.idea

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/ColumnReader.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/ColumnReader.java
@@ -34,10 +34,11 @@ public class ColumnReader {
 	 * Returns the row's column value.
 	 */
 	public Object get(String name) {
-		return get(columns.getIndexOf(name));
+        int indexOf = getColumnIndex(name);
+        return get(indexOf);
 	}
 
-	public Object get(int i) {
+    public Object get(int i) {
 
 		if (row.isNull(i)) {
 			return null;
@@ -110,7 +111,7 @@ public class ColumnReader {
 	 * @throws ClassCastException if the value cannot be converted to the requested type.
 	 */
 	public <T> T get(CqlIdentifier name, Class<T> requestedType) {
-		return get(columns.getIndexOf(name.toCql()), requestedType);
+		return get(getColumnIndex(name.toCql()), requestedType);
 	}
 
 	/**
@@ -138,5 +139,15 @@ public class ColumnReader {
 
 		return (T) o;
 	}
+
+
+    private int getColumnIndex(String name) {
+        int indexOf = columns.getIndexOf(name);
+        if (indexOf == -1) {
+            throw new IllegalArgumentException("Column does not exist in Cassandra table: " + name);
+        }
+        return indexOf;
+    }
+
 
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/unit/convert/ColumnReaderTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/unit/convert/ColumnReaderTest.java
@@ -1,0 +1,74 @@
+package org.springframework.data.cassandra.test.unit.convert;
+
+import com.datastax.driver.core.ColumnDefinitions;
+import com.datastax.driver.core.Row;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.convert.ColumnReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ColumnReaderTest {
+
+    public static final String NON_EXISTENT_COLUMN = "column_name";
+
+    @Mock
+    private Row row;
+
+    @Mock
+    private ColumnDefinitions columnDefinitions;
+
+    private ColumnReader underTest;
+
+    @Before
+    public void setup() {
+        given(row.getColumnDefinitions()).willReturn(columnDefinitions);
+        underTest = new ColumnReader(row);
+    }
+
+    @Test
+    public void throwsIllegalArgumentExceptionIfColumnDoesNotExistByName() throws Exception {
+        given(columnDefinitions.contains(NON_EXISTENT_COLUMN)).willReturn(false);
+        given(columnDefinitions.getIndexOf(NON_EXISTENT_COLUMN)).willReturn(-1);
+
+        try {
+            underTest.get(NON_EXISTENT_COLUMN);
+            fail("Expected illegal argument exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Column does not exist in Cassandra table: " + NON_EXISTENT_COLUMN, e.getMessage());
+        }
+    }
+
+    @Test
+    public void throwsIllegalArgumentExceptionIfColumnDoesNotExistByCqlIdentifier() throws Exception {
+        given(columnDefinitions.contains(NON_EXISTENT_COLUMN)).willReturn(false);
+        given(columnDefinitions.getIndexOf(NON_EXISTENT_COLUMN)).willReturn(-1);
+
+        try {
+            underTest.get(new CqlIdentifier(NON_EXISTENT_COLUMN));
+            fail("Expected illegal argument exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Column does not exist in Cassandra table: " + NON_EXISTENT_COLUMN, e.getMessage());
+        }
+    }
+
+    @Test
+    public void throwsIllegalArgumentExceptionIfColumnDoesNotExistByCqlIdentifierAndType() throws Exception {
+        given(columnDefinitions.contains(NON_EXISTENT_COLUMN)).willReturn(false);
+        given(columnDefinitions.getIndexOf(NON_EXISTENT_COLUMN)).willReturn(-1);
+
+        try {
+            underTest.get(new CqlIdentifier(NON_EXISTENT_COLUMN), String.class);
+            fail("Expected illegal argument exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Column does not exist in Cassandra table: " + NON_EXISTENT_COLUMN, e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
I was evaluating spring-data-cassandra and I made the mistake of overriding the column name in the @Column when the column in question is part of the @PrimaryKey e.g

@PrimaryKeyColumn(ordinal = 0, type = PrimaryKeyType.PARTITIONED)
@Column("app_name")
private String appName;

This gave me an ArrayOutOfBoundsException from the Datastax Java driver

java.lang.ArrayIndexOutOfBoundsException: Array index out of range: -1
    at com.datastax.driver.core.ColumnDefinitions.checkBounds(ColumnDefinitions.java:284)
    at com.datastax.driver.core.ArrayBackedRow.isNull(ArrayBackedRow.java:51)
    at org.springframework.data.cassandra.convert.ColumnReader.get(ColumnReader.java:42)
    at org.springframework.data.cassandra.convert.ColumnReader.get(ColumnReader.java:37)
    at org.springframework.data.cassandra.convert.ColumnReader.get(ColumnReader.java:30)

This also happens if you have it in the @PrimaryKeyColumn but typo it.

A longer term solution may be to do some validation of the Java object vs the table but in the mean time to allow people to quickly diagnose this I've just added an IllegalArgumentException with a nice error message so new adopters quickly fix it and move on e.g

java.lang.IllegalArgumentException: Column does not exist in Cassandra table: appname
    at org.springframework.data.cassandra.convert.ColumnReader.getColumnIndex(ColumnReader.java:147)
    at org.springframework.data.cassandra.convert.ColumnReader.get(ColumnReader.java:37)

Keep up the good work - awesome project
