### PR TITLE
using Statement instead of Select 

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
@@ -62,7 +62,7 @@ public interface CassandraOperations extends CqlOperations {
 	 * @param type must not be {@literal null}, mapped entity type.
 	 * @return
 	 */
-	<T> List<T> select(Statement select, Class<T> type);
+	<T> List<T> select(Statement statement, Class<T> type);
 
 	<T> T selectOneById(Class<T> type, Object id);
 
@@ -82,7 +82,7 @@ public interface CassandraOperations extends CqlOperations {
 	 * @param type The type of entity to retrieve.
 	 * @return A {@link Cancellable} that can be used to cancel the query.
 	 */
-	<T> Cancellable selectOneAsynchronously(Statement select, Class<T> type, QueryForObjectListener<T> listener);
+	<T> Cancellable selectOneAsynchronously(Statement statement, Class<T> type, QueryForObjectListener<T> listener);
 
 	/**
 	 * Executes the string CQL query asynchronously.
@@ -101,7 +101,7 @@ public interface CassandraOperations extends CqlOperations {
 	 * @param options The {@link QueryOptions} to use.
 	 * @return A {@link Cancellable} that can be used to cancel the query.
 	 */
-	<T> Cancellable selectOneAsynchronously(Statement select, Class<T> type, QueryForObjectListener<T> listener,
+	<T> Cancellable selectOneAsynchronously(Statement statement, Class<T> type, QueryForObjectListener<T> listener,
 			QueryOptions options);
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -321,11 +321,11 @@ public class CassandraTemplate extends CqlTemplate implements CassandraOperation
 	}
 
 	@Override
-	public <T> List<T> select(Statement select, Class<T> type) {
+	public <T> List<T> select(Statement statement, Class<T> type) {
 
-		Assert.notNull(select);
+		Assert.notNull(statement);
 
-		return select(select, new CassandraConverterRowCallback<T>(cassandraConverter, type));
+		return select(statement, new CassandraConverterRowCallback<T>(cassandraConverter, type));
 	}
 
 	@Override
@@ -983,8 +983,8 @@ public class CassandraTemplate extends CqlTemplate implements CassandraOperation
 	}
 
 	@Override
-	public <T> Cancellable selectOneAsynchronously(Statement select, Class<T> type, QueryForObjectListener<T> listener) {
-		return selectOneAsynchronously(select, type, listener, null);
+	public <T> Cancellable selectOneAsynchronously(Statement statement, Class<T> type, QueryForObjectListener<T> listener) {
+		return selectOneAsynchronously(statement, type, listener, null);
 	}
 
 	@Override
@@ -993,9 +993,9 @@ public class CassandraTemplate extends CqlTemplate implements CassandraOperation
 	}
 
 	@Override
-	public <T> Cancellable selectOneAsynchronously(Statement select, Class<T> type, QueryForObjectListener<T> listener,
+	public <T> Cancellable selectOneAsynchronously(Statement statement, Class<T> type, QueryForObjectListener<T> listener,
 			QueryOptions options) {
-		return doSelectOneAsync(select, type, listener, options);
+		return doSelectOneAsync(statement, type, listener, options);
 	}
 
 	@Override


### PR DESCRIPTION
It was not possible to call cassandraTemplate.select() method after creating a Statement via QueryBuilder, as it takes only Select as an argument

//example
val select: Statement = QueryBuilder.select().all().from(tableName).setFetchSize(maxResults)

Statement appears as a Base Class for Select and others,  I havent look much why cassandraTemplate was tailored specifically for Select, but the tests are passing with Statement so hopefully this change make sense. 
