### PR TITLE
Fixing the bug in the file CassandraCqlClusterFactoryBean

### DIFF
--- a/spring-cql/src/main/java/org/springframework/cassandra/config/PoolingOptionsFactoryBean.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/PoolingOptionsFactoryBean.java
@@ -58,40 +58,40 @@ public class PoolingOptionsFactoryBean implements FactoryBean<PoolingOptions>, I
 
 		poolingOptions = new PoolingOptions();
 
-		if (localMinSimultaneousRequests != null) {
-			poolingOptions.setMinSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL, localMinSimultaneousRequests);
-		}
-
-		if (localMaxSimultaneousRequests != null) {
-			poolingOptions.setMaxSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL, localMaxSimultaneousRequests);
-		}
-
-		if (localCoreConnections != null) {
-			poolingOptions.setCoreConnectionsPerHost(HostDistance.LOCAL, localCoreConnections);
-		}
-
 		if (localMaxConnections != null) {
 			poolingOptions.setMaxConnectionsPerHost(HostDistance.LOCAL, localMaxConnections);
 		}
-
-		if (remoteMinSimultaneousRequests != null) {
-			poolingOptions.setMinSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE,
-					remoteMinSimultaneousRequests);
+		
+		if (localCoreConnections != null) {
+			poolingOptions.setCoreConnectionsPerHost(HostDistance.LOCAL, localCoreConnections);
 		}
-
-		if (remoteMaxSimultaneousRequests != null) {
-			poolingOptions.setMaxSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE,
-					remoteMaxSimultaneousRequests);
+		
+		if (localMaxSimultaneousRequests != null) {
+			poolingOptions.setMaxSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL, localMaxSimultaneousRequests);
 		}
-
-		if (remoteCoreConnections != null) {
-			poolingOptions.setCoreConnectionsPerHost(HostDistance.REMOTE, remoteCoreConnections);
+		
+		if (localMinSimultaneousRequests != null) {
+			poolingOptions.setMinSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL, localMinSimultaneousRequests);
 		}
 
 		if (remoteMaxConnections != null) {
 			poolingOptions.setMaxConnectionsPerHost(HostDistance.REMOTE, remoteMaxConnections);
 		}
-
+		
+		if (remoteCoreConnections != null) {
+			poolingOptions.setCoreConnectionsPerHost(HostDistance.REMOTE, remoteCoreConnections);
+		}
+		
+		if (remoteMaxSimultaneousRequests != null) {
+			poolingOptions.setMaxSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE,
+					remoteMaxSimultaneousRequests);
+		}
+		
+		if (remoteMinSimultaneousRequests != null) {
+			poolingOptions.setMinSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE,
+					remoteMinSimultaneousRequests);
+		}
+		
 	}
 
 	@Override

--- a/spring-cql/src/test/java/org/springframework/cassandra/test/unit/config/PollingOptionsFactoryBeanTest.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/test/unit/config/PollingOptionsFactoryBeanTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cassandra.test.unit.config;
+
+import junit.framework.Assert;
+import org.junit.Test;
+import org.springframework.cassandra.config.PoolingOptionsFactoryBean;
+
+/**
+ * Pooling Options Factory Bean Test.
+ * https://jira.spring.io/browse/DATACASS-176
+ * 
+ * @author Sumit Kumar
+ */
+public class PollingOptionsFactoryBeanTest {
+	
+	/**
+	 * The max values should be set before setting core values.
+	 * Otherwise the core values will be compared with the default max values which is 8.
+	 * Same for other min-max properties pairs. This test checks the same.
+	 */
+	@Test
+	public void testAfterPropertiesSet() {
+		boolean gotException = false;
+		PoolingOptionsFactoryBean factoryBean = new PoolingOptionsFactoryBean();
+		factoryBean.setLocalMaxConnections(200);
+		factoryBean.setLocalCoreConnections(100);
+		factoryBean.setLocalMaxSimultaneousRequests(128);
+		factoryBean.setLocalMinSimultaneousRequests(101);
+		factoryBean.setRemoteMaxConnections(200);
+		factoryBean.setRemoteCoreConnections(100);
+		factoryBean.setRemoteMaxSimultaneousRequests(128);
+		factoryBean.setRemoteMinSimultaneousRequests(101);
+		try {
+			factoryBean.afterPropertiesSet();
+		} catch (Exception e) {
+			e.printStackTrace();
+			gotException = true;
+		}
+		Assert.assertFalse(gotException);
+	}
+
+}


### PR DESCRIPTION
The max values should be set before setting core values.
Otherwise the core values will be compared with the default max values which is 8.
The stacktrace as below
Caused by: java.lang.IllegalArgumentException: Core connections for LOCAL hosts must be less than max (100 > 8)
at com.datastax.driver.core.PoolingOptions.checkConnectionsPerHostOrder(PoolingOptions.java:323)
at com.datastax.driver.core.PoolingOptions.setCoreConnectionsPerHost(PoolingOptions.java:203)
at org.springframework.cassandra.config.PoolingOptionsFactoryBean.afterPropertiesSet(PoolingOptionsFactoryBean.java:70)
at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1613)
at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1550)
... 19 more
Also when modifying min & max simultaneous connections
Caused by: java.lang.IllegalArgumentException: Min simultaneous requests per connection for LOCAL hosts must be less than max (110 > 100)
at com.datastax.driver.core.PoolingOptions.checkRequestsPerConnectionOrder(PoolingOptions.java:317)
at com.datastax.driver.core.PoolingOptions.setMinSimultaneousRequestsPerConnectionThreshold(PoolingOptions.java:118)
at org.springframework.cassandra.config.PoolingOptionsFactoryBean.afterPropertiesSet(PoolingOptionsFactoryBean.java:62)
at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1613)
at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1550)
... 19 more
