### PR TITLE
Fixing BasicMapId constructor

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/BasicMapId.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/BasicMapId.java
@@ -54,10 +54,10 @@ public class BasicMapId implements MapId {
 
 	public BasicMapId() {}
 
-	public BasicMapId(Map<String, Serializable> map) {
+	public BasicMapId(Map<String, Serializable> mapId) {
 
-		Assert.notNull(map);
-		map.putAll(map);
+		Assert.notNull(mapId);
+		map.putAll(mapId);
 	}
 
 	@Override

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/unit/mapid/BasicMapIdTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/unit/mapid/BasicMapIdTest.java
@@ -1,0 +1,24 @@
+package org.springframework.data.cassandra.test.unit.mapid;
+
+import org.junit.Test;
+import org.springframework.data.cassandra.repository.support.BasicMapId;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class BasicMapIdTest {
+    @Test
+    public void testMapConstructor() {
+        Map<String, Serializable> map = new HashMap<String, Serializable>();
+        map.put("field1", "value1");
+        map.put("field2", 2);
+
+        BasicMapId basicMapId = new BasicMapId(map);
+
+        assertEquals(basicMapId.get("field1"), map.get("field1"));
+        assertEquals(basicMapId.get("field2"), map.get("field2"));
+    }
+}


### PR DESCRIPTION
There is a really silly bug in the BasicMapId constructor that takes a Map.   The constructor just ends up copying the map into itself due to scoping.
