### PR TITLE
Fix StackOverflowError in CassandraAdminTemplate#dropTable(Class<?>)

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraAdminTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraAdminTemplate.java
@@ -114,7 +114,7 @@ public class CassandraAdminTemplate extends CassandraTemplate implements Cassand
 	}
 
 	public void dropTable(Class<?> entityClass) {
-		dropTable(determineTableName(entityClass));
+		dropTable(getTableName(entityClass));
 	}
 
 	@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -515,10 +515,6 @@ public class CassandraTemplate extends CqlTemplate implements CassandraOperation
 		return doUpdateAsync(entity, listener, options);
 	}
 
-	protected <T> CqlIdentifier determineTableName(T obj) {
-		return obj == null ? null : determineTableName(obj.getClass());
-	}
-
 	protected <T> List<T> select(final String query, CassandraConverterRowCallback<T> readRowCallback) {
 
 		ResultSet resultSet = doExecute(new SessionCallback<ResultSet>() {

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/template/CassandraAdminTemplateTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/template/CassandraAdminTemplateTest.java
@@ -94,4 +94,19 @@ public class CassandraAdminTemplateTest extends AbstractSpringDataEmbeddedCassan
 		cassandraAdminTemplate.createTable(true, CqlIdentifier.cqlId("book"), Book.class, null);
 		assertThat(getKeyspaceMetadata().getTables().size(), is(1));
 	}
+
+	@Test
+	public void testDropTable() throws Exception {
+
+		cassandraAdminTemplate.createTable(true, CqlIdentifier.cqlId("book"), Book.class, null);
+		assertThat(getKeyspaceMetadata().getTables().size(), is(1));
+
+		cassandraAdminTemplate.dropTable(Book.class);
+		assertThat(getKeyspaceMetadata().getTables().size(), is(0));
+
+		cassandraAdminTemplate.createTable(true, CqlIdentifier.cqlId("book"), Book.class, null);
+		cassandraAdminTemplate.dropTable(CqlIdentifier.cqlId("book"));
+
+		assertThat(getKeyspaceMetadata().getTables().size(), is(0));
+	}
 }


### PR DESCRIPTION
Deletes recursive function to determine table name from entity class and reuse getTableName(...)

Reference: DATACASS-174