### PR TITLE
Remove redundant dependency on Liquibase from spring-cql

### DIFF
--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -114,11 +114,6 @@
 			<artifactId>guava</artifactId>
 			<version>15.0</version>
 		</dependency>
-		<dependency>
-			<groupId>org.liquibase</groupId>
-			<artifactId>liquibase-core</artifactId>
-			<version>3.1.1</version>
-		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Commit 54910a1 added a dependency on org.liquibase:liquibase-core however it does not appear to be used anywhere and mvn clean package completes successfully without it.

The presence of this dependency causes problems in Spring Boot as it activates auto-configuration of Liquibase when a user does not expect it. See http://stackoverflow.com/questions/29594497/spring-boot-spring-boot-starter-data-jpa-database-type-none-or-cannot-find-cha, for example.