### PR TITLE
DATACASS-211 - Adapt to changes in Spring Data Commons.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>1.3.0.BUILD-SNAPSHOT</version>
+	<version>1.3.0.DATACASS-211-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Cassandra</name>

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.3.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.DATACASS-211-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.3.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.DATACASS-211-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.3.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.DATACASS-211-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/EnableCassandraRepositories.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/EnableCassandraRepositories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2015 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.cassandra.core.CassandraTemplate;
 import org.springframework.data.cassandra.repository.support.CassandraRepositoryFactoryBean;
+import org.springframework.data.repository.config.DefaultRepositoryBaseClass;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.QueryLookupStrategy.Key;
 
@@ -35,6 +36,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy.Key;
  * 
  * @author Alex Shvid
  * @author Matthew T. Adams
+ * @author Thomas Darimont
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -106,6 +108,14 @@ public @interface EnableCassandraRepositories {
 	 * @return
 	 */
 	Class<?> repositoryFactoryBeanClass() default CassandraRepositoryFactoryBean.class;
+
+	/**
+	 * Configure the repository base class to be used to create repository proxies for this particular configuration.
+	 * 
+	 * @return
+	 * @since 1.3
+	 */
+	Class<?> repositoryBaseClass() default DefaultRepositoryBaseClass.class;
 
 	/**
 	 * Configures the name of the {@link CassandraTemplate} bean to be used with the repositories detected.

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/UserRepositoryJavaConfigCustomRepositoryBaseClassIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/UserRepositoryJavaConfigCustomRepositoryBaseClassIntegrationTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 the original author or authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.test.integration.repository;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.io.Serializable;
+
+import org.junit.Test;
+import org.springframework.aop.framework.Advised;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.repository.config.EnableCassandraRepositories;
+import org.springframework.data.cassandra.repository.query.CassandraEntityInformation;
+import org.springframework.data.cassandra.repository.support.SimpleCassandraRepository;
+import org.springframework.data.cassandra.test.integration.support.IntegrationTestConfig;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Java config tests for {@link UserRepository}.
+ * 
+ * @author Thomas Darimont
+ */
+@ContextConfiguration
+public class UserRepositoryJavaConfigCustomRepositoryBaseClassIntegrationTests extends
+		UserRepositoryIntegrationTestsDelegator {
+
+	@Configuration
+	@EnableCassandraRepositories(basePackageClasses = UserRepository.class,
+			repositoryBaseClass = CustomCassandraRepository.class)
+	public static class Config extends IntegrationTestConfig {
+
+		@Override
+		public String[] getEntityBasePackages() {
+			return new String[] { User.class.getPackage().getName() };
+		}
+	}
+
+	/**
+	 * @see DATACASS-211
+	 */
+	@Test
+	public void targetRepositoryClassShouldBeConfiguredCustomBaseRepositoryClass() throws Exception {
+		assertThat(((Advised) repository).getTargetSource().getTarget(), is(instanceOf(CustomCassandraRepository.class)));
+	}
+
+	public static class CustomCassandraRepository<T, ID extends Serializable> extends SimpleCassandraRepository<T, ID> {
+
+		public CustomCassandraRepository(CassandraEntityInformation<T, ID> metadata, CassandraOperations operations) {
+			super(metadata, operations);
+		}
+
+	}
+}


### PR DESCRIPTION
Tweaked method signatures in CassandraRepositoryFactory after some signature changes in Spring Data Commons. Use newly introduced getTragetRepositoryViaReflection(…) to obtain the repository instance via the super class.
Added repositoryBaseClass() attribute to @EnableCassandraRepositories.

Related tickets: DATACMNS-542.