### PR TITLE
DATACMNS-542: Updating getTargetRepository signature to match Reposit…

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/EnableCassandraRepositories.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/EnableCassandraRepositories.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.cassandra.core.CassandraTemplate;
 import org.springframework.data.cassandra.repository.support.CassandraRepositoryFactoryBean;
+import org.springframework.data.cassandra.repository.support.SimpleCassandraRepository;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.QueryLookupStrategy.Key;
 
@@ -113,4 +114,12 @@ public @interface EnableCassandraRepositories {
 	 * @return
 	 */
 	String cassandraTemplateRef() default "cassandraTemplate";
+	
+	/**
+	 * Configure the repository base class to be used to create repository proxies.  Defaults to {@link SimpleCassandraRepository}
+	 * 
+	 * @return
+	 * @since 1.3
+	 */
+	Class<?> repositoryBaseClass() default SimpleCassandraRepository.class;
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/CassandraRepositoryFactory.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/CassandraRepositoryFactory.java
@@ -28,6 +28,7 @@ import org.springframework.data.cassandra.repository.query.CassandraQueryMethod;
 import org.springframework.data.cassandra.repository.query.StringBasedCassandraQuery;
 import org.springframework.data.mapping.model.MappingException;
 import org.springframework.data.repository.core.NamedQueries;
+import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.query.QueryLookupStrategy;
@@ -70,12 +71,11 @@ public class CassandraRepositoryFactory extends RepositoryFactorySupport {
 
 	@Override
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	protected Object getTargetRepository(RepositoryMetadata metadata) {
+	protected Object getTargetRepository(RepositoryInformation information) {
+	    
+		CassandraEntityInformation<?, Serializable> entityInformation = getEntityInformation(information.getDomainType());
 
-		CassandraEntityInformation<?, Serializable> entityInformation = getEntityInformation(metadata.getDomainType());
-
-		return new SimpleCassandraRepository(entityInformation, cassandraTemplate);
-
+		return getTargetRepositoryViaReflection(information, entityInformation, cassandraTemplate);
 	}
 
 	@Override


### PR DESCRIPTION
Updating getTargetRepository signature to match RepositoryInformation change.  Using getTargetRepositoryViaReflection to fix attribute propertyBaseClass not found exceptions.  Adding repositoryBaseClass() to the EnableCassandraRepositories annotation.