### PR TITLE
DATACASS-202 Misspelled ConsistencyLevel enum constants and DATACASS-217 Add support for LZ4 compression

### DIFF
--- a/spring-cql/src/main/java/org/springframework/cassandra/config/CassandraCqlClusterFactoryBean.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/CassandraCqlClusterFactoryBean.java
@@ -340,6 +340,8 @@ public class CassandraCqlClusterFactoryBean implements FactoryBean<Cluster>, Ini
 				return Compression.NONE;
 			case SNAPPY:
 				return Compression.SNAPPY;
+			case LZ4:
+				return Compression.LZ4;
 		}
 		throw new IllegalArgumentException("unknown compression type " + type);
 	}

--- a/spring-cql/src/main/java/org/springframework/cassandra/config/CompressionType.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/CompressionType.java
@@ -21,5 +21,5 @@ package org.springframework.cassandra.config;
  * @author Alex Shvid
  */
 public enum CompressionType {
-	NONE, SNAPPY;
+	NONE, SNAPPY, LZ4;
 }

--- a/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevel.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevel.java
@@ -22,6 +22,6 @@ package org.springframework.cassandra.core;
  */
 public enum ConsistencyLevel {
 
-	ANY, ONE, TWO, THREE, QUOROM, LOCAL_QUOROM, EACH_QUOROM, ALL, LOCAL_ONE, SERIAL, LOCAL_SERIAL
+	ANY, ONE, TWO, THREE, QUORUM, LOCAL_QUORUM, EACH_QUORUM, ALL, LOCAL_ONE, SERIAL, LOCAL_SERIAL
 
 }

--- a/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevelResolver.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevelResolver.java
@@ -30,7 +30,7 @@ public final class ConsistencyLevelResolver {
 	/**
 	 * Decode the generic spring data cassandra enum to the type required by the DataStax Driver.
 	 * 
-	 * @param level
+	 * @param level Spring consistency level equivalent
 	 * @return The DataStax Driver Consistency Level.
 	 */
 	public static com.datastax.driver.core.ConsistencyLevel resolve(ConsistencyLevel level) {
@@ -53,13 +53,13 @@ public final class ConsistencyLevelResolver {
 			case ANY:
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.ANY;
 				break;
-			case EACH_QUOROM:
+			case EACH_QUORUM:
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.EACH_QUORUM;
 				break;
-			case LOCAL_QUOROM:
+			case LOCAL_QUORUM:
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.LOCAL_QUORUM;
 				break;
-			case QUOROM:
+			case QUORUM:
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.QUORUM;
 				break;
 			case THREE:


### PR DESCRIPTION
-  Fix for DATACASS-202
   - Fixed incorrect spelling for quorum
- Fix for DATACASS-217
   - Add support for LZ4 compression