### PR TITLE
Update CqlTemplate.java: add missing 'throws'

### DIFF
--- a/spring-cql/src/main/java/org/springframework/cassandra/core/CqlTemplate.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/core/CqlTemplate.java
@@ -756,7 +756,7 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 				rch.processRow(row);
 			}
 		} catch (DriverException dx) {
-			translateExceptionIfPossible(dx);
+			throw translateExceptionIfPossible(dx);
 		}
 	}
 
@@ -769,7 +769,7 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 				mappedRows.add(rowMapper.mapRow(row, i++));
 			}
 		} catch (DriverException dx) {
-			translateExceptionIfPossible(dx);
+			throw translateExceptionIfPossible(dx);
 		}
 		return mappedRows;
 	}
@@ -784,7 +784,7 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 			Assert.isTrue(rows.size() == 1, "row list has " + rows.size() + " rows instead of one");
 			row = rowMapper.mapRow(rows.get(0), 0);
 		} catch (DriverException dx) {
-			translateExceptionIfPossible(dx);
+			throw translateExceptionIfPossible(dx);
 		}
 		return row;
 	}


### PR DESCRIPTION
While these process methods have quite a few problems and inconsistencies with respect to the exception handling, only the more egregious 'throw' omissions are addressed in this pull request.