### PR TITLE
DATACASS-239 - Latest cassandra-unit and dse-driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,12 +191,14 @@
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
 				<version>3.1</version>
+				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.hectorclient</groupId>
 				<artifactId>hector-core</artifactId>
 				<version>1.1-4</version>
+				<scope>test</scope>
 			</dependency>
 
 		</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -29,11 +30,12 @@
 		<project.type>multi</project.type>
 		<dist.id>spring-data-cassandra</dist.id>
 		<springdata.commons>1.12.0.BUILD-SNAPSHOT</springdata.commons>
-		<cassandra-unit.version>2.0.2.2</cassandra-unit.version>
+		<cassandra-unit.version>2.1.9.2</cassandra-unit.version>
 		<el.version>1.0</el.version>
 		<failsafe.version>2.16</failsafe.version>
-		<jamm.version>0.2.5</jamm.version>
-		<cassandra>2.1.5</cassandra>
+		<jamm.version>0.3.1</jamm.version>
+		<cassandra.version>2.1.11</cassandra.version>
+		<cassandra-driver-dse.version>2.1.7.1</cassandra-driver-dse.version>
 	</properties>
 
 	<developers>
@@ -78,7 +80,7 @@
 			<dependency>
 				<groupId>com.datastax.cassandra</groupId>
 				<artifactId>cassandra-driver-dse</artifactId>
-				<version>${cassandra}</version>
+				<version>${cassandra-driver-dse.version}</version>
 				<exclusions>
 					<exclusion>
 						<artifactId>slf4j-log4j12</artifactId>
@@ -92,23 +94,20 @@
 						<artifactId>guava</artifactId>
 						<groupId>com.google.guava</groupId>
 					</exclusion>
+					<exclusion>
+						<artifactId>netty-handler</artifactId>
+						<groupId>io.netty</groupId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>com.github.stephenc</groupId>
+				<groupId>com.github.jbellis</groupId>
 				<artifactId>jamm</artifactId>
 				<version>${jamm.version}</version>
 				<scope>test</scope>
 			</dependency>
 
 			<!-- Logging Dependencies -->
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>log4j-over-slf4j</artifactId>
-				<version>${slf4j}</version>
-				<scope>test</scope>
-			</dependency>
-
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>jul-to-slf4j</artifactId>
@@ -148,9 +147,8 @@
 
 			<dependency>
 				<groupId>org.cassandraunit</groupId>
-				<artifactId>cassandra-unit</artifactId>
+				<artifactId>cassandra-unit-spring</artifactId>
 				<version>${cassandra-unit.version}</version>
-				<scope>test</scope>
 				<exclusions>
 					<exclusion>
 						<artifactId>cassandra-all</artifactId>
@@ -160,13 +158,11 @@
 						<groupId>com.datastax.cassandra</groupId>
 						<artifactId>cassandra-driver-core</artifactId>
 					</exclusion>
+					<exclusion>
+						<artifactId>slf4j-log4j12</artifactId>
+						<groupId>org.slf4j</groupId>
+					</exclusion>
 				</exclusions>
-			</dependency>
-
-			<dependency>
-				<groupId>org.cassandraunit</groupId>
-				<artifactId>cassandra-unit-spring</artifactId>
-				<version>${cassandra-unit.version}</version>
 				<scope>test</scope>
 			</dependency>
 
@@ -190,6 +186,19 @@
 				<version>${jodatime}</version>
 				<scope>test</scope>
 			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>3.1</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.hectorclient</groupId>
+				<artifactId>hector-core</artifactId>
+				<version>1.1-4</version>
+			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 
@@ -213,16 +222,26 @@
 			<artifactId>cassandra-driver-dse</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.github.stephenc</groupId>
+			<groupId>com.github.jbellis</groupId>
 			<artifactId>jamm</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.cassandraunit</groupId>
-			<artifactId>cassandra-unit</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.cassandraunit</groupId>
 			<artifactId>cassandra-unit-spring</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>spring-context</artifactId>
+					<groupId>org.springframework</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>spring-test</artifactId>
+					<groupId>org.springframework</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>slf4j-log4j12</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 
@@ -266,7 +285,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.8</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -293,8 +311,7 @@
 				<version>${failsafe.version}</version>
 				<configuration>
 					<forkCount>1</forkCount>
-					<argLine>-Xmx1024m -Xss512m
-						-javaagent:${com.github.stephenc:jamm:jar}</argLine>
+					<argLine>-Xms1g -Xmx1g -Xss256k -javaagent:${com.github.jbellis:jamm:jar}</argLine>
 					<reuseForks>true</reuseForks>
 					<useFile>false</useFile>
 					<includes>

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -99,6 +99,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -72,22 +73,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.cassandraunit</groupId>
-			<artifactId>cassandra-unit</artifactId>
-			<exclusions>
-				<exclusion>
-					<artifactId>slf4j-log4j12</artifactId>
-					<groupId>org.slf4j</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>guava</artifactId>
-					<groupId>com.google.guava</groupId>
-				</exclusion>
-			</exclusions>
+			<artifactId>cassandra-unit-spring</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cassandra</groupId>
 			<artifactId>cassandra-all</artifactId>
-			<version>${cassandra}</version>
+			<version>${cassandra.version}</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -101,19 +92,13 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.cassandraunit</groupId>
-			<artifactId>cassandra-unit-spring</artifactId>
-			<exclusions>
-				<exclusion>
-					<artifactId>guava</artifactId>
-					<groupId>com.google.guava</groupId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>${guava}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
 		</dependency>
 	</dependencies>
 
@@ -121,7 +106,6 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.3.1</version>
 				<executions>
 					<execution>
 						<id>test-jar</id>

--- a/spring-cql/src/test/java/org/springframework/cassandra/test/integration/AbstractKeyspaceCreatingIntegrationTest.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/test/integration/AbstractKeyspaceCreatingIntegrationTest.java
@@ -18,15 +18,20 @@ package org.springframework.cassandra.test.integration;
 import org.junit.After;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cassandra.core.CqlOperations;
+import org.springframework.cassandra.core.CqlTemplate;
 import org.springframework.util.StringUtils;
 
+import com.datastax.driver.core.Host;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Session.State;
 
 /**
  * Abstract base integration test class that creates a keyspace
  * 
  * @author Matthew T. Adams
+ * @author David Webb
  */
 public abstract class AbstractKeyspaceCreatingIntegrationTest extends AbstractEmbeddedCassandraIntegrationTest {
 
@@ -81,7 +86,7 @@ public abstract class AbstractKeyspaceCreatingIntegrationTest extends AbstractEm
 			if (kmd == null) { // then create keyspace
 
 				String cql = "CREATE KEYSPACE " + keyspace
-						+ " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1};";
+						+ " WITH durable_writes = false AND replication = {'class': 'SimpleStrategy', 'replication_factor' : 1};";
 				log.info("creating keyspace {} via CQL [{}]", keyspace, cql);
 
 				system.execute(cql);
@@ -99,13 +104,40 @@ public abstract class AbstractKeyspaceCreatingIntegrationTest extends AbstractEm
 
 		} else {
 
+			debugSession();
+
 			log.info("session already connected to a keyspace; attempting to change to use {}", keyspace);
 
 			String cql = "USE " + (keyspace == null ? "system" : keyspace) + ";";
-			session.execute(cql);
+
+			log.debug(cql);
+
+			getTemplate().execute(cql);
 
 			log.info("now using keyspace " + keyspace);
+
 		}
+	}
+
+	protected static CqlOperations getTemplate() {
+
+		return new CqlTemplate(session);
+	}
+
+	protected static void debugSession() {
+		if (session == null) {
+			log.warn("Session is null...cannot debug that");
+			return;
+		}
+
+		State state = session.getState();
+
+		for (Host h : state.getConnectedHosts()) {
+
+			log.debug(String.format("Session Host dc [%s], rack [%s], ver [%s], state [%s]", h.getDatacenter(), h.getRack(),
+					h.getCassandraVersion(), h.getState()));
+		}
+
 	}
 
 	@After

--- a/spring-cql/src/test/java/org/springframework/cassandra/test/integration/config/xml/TestLatencyTracker.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/test/integration/config/xml/TestLatencyTracker.java
@@ -29,13 +29,10 @@ import com.datastax.driver.core.Statement;
 public class TestLatencyTracker implements LatencyTracker {
 
 	private final static Logger LOG = LoggerFactory.getLogger(TestLatencyTracker.class);
-	
-	/* 
-	 * (non-Javadoc)
-	 * @see com.datastax.driver.core.LatencyTracker#update(com.datastax.driver.core.Host, long)
-	 */
+
 	@Override
-	public void update(Host host, long newLatencyNanos) {
+	public void update(Host host, Statement statement, Exception exception, long newLatencyNanos) {
 		LOG.info("Latency Tracker: " + host.getAddress() + ", " + newLatencyNanos + " nanoseconds.");
 	}
+
 }

--- a/spring-cql/src/test/java/org/springframework/cassandra/test/integration/core/cql/generator/CreateIndexCqlGeneratorIntegrationTests.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/test/integration/core/cql/generator/CreateIndexCqlGeneratorIntegrationTests.java
@@ -63,7 +63,7 @@ public class CreateIndexCqlGeneratorIntegrationTests {
 		@Rule
 		public CassandraCQLUnit cassandraCQLUnit = new CassandraCQLUnit(new ClassPathCQLDataSet(
 				"integration/cql/generator/CreateIndexCqlGeneratorIntegrationTests-BasicTest.cql", this.keyspace),
-				CASSANDRA_CONFIG, CASSANDRA_HOST, CASSANDRA_NATIVE_PORT);
+				CASSANDRA_CONFIG);
 
 		@Override
 		public BasicTest unit() {

--- a/spring-cql/src/test/java/org/springframework/cassandra/test/integration/core/cql/generator/IndexLifecycleCqlGeneratorIntegrationTests.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/test/integration/core/cql/generator/IndexLifecycleCqlGeneratorIntegrationTests.java
@@ -44,7 +44,7 @@ public class IndexLifecycleCqlGeneratorIntegrationTests extends AbstractKeyspace
 	@Rule
 	public CassandraCQLUnit cassandraCQLUnit = new CassandraCQLUnit(new ClassPathCQLDataSet(
 			"integration/cql/generator/CreateIndexCqlGeneratorIntegrationTests-BasicTest.cql", this.keyspace),
-			CASSANDRA_CONFIG, CASSANDRA_HOST, CASSANDRA_NATIVE_PORT);
+			CASSANDRA_CONFIG);
 
 	@Test
 	public void lifecycleTest() {

--- a/spring-cql/src/test/java/org/springframework/cassandra/test/integration/core/cql/generator/TableLifecycleIntegrationTest.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/test/integration/core/cql/generator/TableLifecycleIntegrationTest.java
@@ -52,12 +52,9 @@ public class TableLifecycleIntegrationTest extends AbstractKeyspaceCreatingInteg
 		return true;
 	}
 
-	// This only ensures the keyspace exists before each test, while using a static session from the parent object.
-	// TODO - DW Make this better.
 	@Rule
 	public CassandraCQLUnit cassandraCQLUnit = new CassandraCQLUnit(new ClassPathCQLDataSet(
-			"cassandraOperationsTest-cql-dataload.cql", this.keyspace), CASSANDRA_CONFIG, CASSANDRA_HOST,
-			CASSANDRA_NATIVE_PORT);
+			"cassandraOperationsTest-cql-dataload.cql", this.keyspace), CASSANDRA_CONFIG);
 
 	@Test
 	public void testDrop() {
@@ -100,21 +97,24 @@ public class TableLifecycleIntegrationTest extends AbstractKeyspaceCreatingInteg
 
 		// assertTable(alterTest.specification, keyspace, session);
 
+		DropTableTest dropTest = new DropTableTest();
+		dropTest.prepare();
+
+		log.info(dropTest.cql);
+
+		session.execute(dropTest.cql);
+
+		assertNoTable(dropTest.specification, keyspace, session);
+
 	}
 
 	public class DropTableTest extends DropTableCqlGeneratorTests.DropTableTest {
 
-		/* (non-Javadoc)
-		 * @see org.springframework.cassandra.test.unit.core.cql.generator.TableOperationCqlGeneratorTest#specification()
-		 */
 		@Override
 		public DropTableSpecification specification() {
 			return DropTableSpecification.dropTable().name(createTableTest.specification.getName());
 		}
 
-		/* (non-Javadoc)
-		 * @see org.springframework.cassandra.test.unit.core.cql.generator.TableOperationCqlGeneratorTest#generator()
-		 */
 		@Override
 		public DropTableCqlGenerator generator() {
 			return new DropTableCqlGenerator(specification);

--- a/spring-cql/src/test/java/org/springframework/cassandra/test/integration/core/template/CQLOperationsTest.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/test/integration/core/template/CQLOperationsTest.java
@@ -96,8 +96,7 @@ public class CQLOperationsTest extends AbstractKeyspaceCreatingIntegrationTest {
 	 */
 	@Rule
 	public CassandraCQLUnit cassandraCQLUnit = new CassandraCQLUnit(new ClassPathCQLDataSet(
-			"cassandraOperationsTest-cql-dataload.cql", this.keyspace), CASSANDRA_CONFIG, CASSANDRA_HOST,
-			CASSANDRA_NATIVE_PORT);
+			"cassandraOperationsTest-cql-dataload.cql", this.keyspace), CASSANDRA_CONFIG);
 
 	@Before
 	public void setupTemplate() {

--- a/spring-cql/src/test/java/org/springframework/cassandra/test/integration/core/template/async/AsynchronousTest.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/test/integration/core/template/async/AsynchronousTest.java
@@ -22,7 +22,7 @@ import org.springframework.cassandra.core.QueryForMapListener;
 import org.springframework.cassandra.core.QueryForObjectListener;
 import org.springframework.cassandra.core.QueryOptions;
 import org.springframework.cassandra.core.RetryPolicy;
-import org.springframework.cassandra.support.exception.CassandraInsufficientReplicasAvailableException;
+import org.springframework.cassandra.support.exception.CassandraConnectionFailureException;
 import org.springframework.util.StringUtils;
 
 import com.datastax.driver.core.DataType;
@@ -238,7 +238,7 @@ public class AsynchronousTest extends AbstractAsynchronousTest {
 		testString_AsynchronousQueryListener_QueryOptions(ConsistencyLevel.ONE);
 	}
 
-	@Test(expected = CassandraInsufficientReplicasAvailableException.class)
+	@Test(expected = CassandraConnectionFailureException.class)
 	public void testString_AsynchronousQueryListener_QueryOptionsWithConsistencyLevel2() throws InterruptedException {
 		testString_AsynchronousQueryListener_QueryOptions(ConsistencyLevel.TWO);
 	}
@@ -284,7 +284,7 @@ public class AsynchronousTest extends AbstractAsynchronousTest {
 		testString_QueryForObjectListener_QueryOptions(ConsistencyLevel.ONE);
 	}
 
-	@Test(expected = CassandraInsufficientReplicasAvailableException.class)
+	@Test(expected = CassandraConnectionFailureException.class)
 	public void testString_QueryForObjectListener_QueryOptionsWithConsistencyLevel2() throws Exception {
 		testString_QueryForObjectListener_QueryOptions(ConsistencyLevel.TWO);
 	}
@@ -324,7 +324,7 @@ public class AsynchronousTest extends AbstractAsynchronousTest {
 		testString_QueryForMapListener_QueryOptions(ConsistencyLevel.ONE);
 	}
 
-	@Test(expected = CassandraInsufficientReplicasAvailableException.class)
+	@Test(expected = CassandraConnectionFailureException.class)
 	public void testString_QueryForMapListener_QueryOptionsWithConsistencyLevel2() throws Exception {
 		testString_QueryForMapListener_QueryOptions(ConsistencyLevel.TWO);
 	}
@@ -381,7 +381,7 @@ public class AsynchronousTest extends AbstractAsynchronousTest {
 		testString_QueryForListListener_QueryOptions(ConsistencyLevel.ONE);
 	}
 
-	@Test(expected = CassandraInsufficientReplicasAvailableException.class)
+	@Test(expected = CassandraConnectionFailureException.class)
 	public void testString_QueryForListListener_QueryOptionsWithConsistencyLevel2() throws Exception {
 		testString_QueryForListListener_QueryOptions(ConsistencyLevel.TWO);
 	}

--- a/spring-cql/src/test/java/org/springframework/cassandra/test/integration/support/SpringCqlBuildProperties.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/test/integration/support/SpringCqlBuildProperties.java
@@ -76,9 +76,18 @@ public class SpringCqlBuildProperties extends Properties {
 		return getInt("build.cassandra.ssl_storage_port");
 	}
 
+	public long getCqlInitializationTimeout() {
+		return getLong("build.cql.init.timeout");
+	}
+
 	public int getInt(String key) {
 		String property = getProperty(key);
 		return Integer.parseInt(property);
+	}
+
+	public long getLong(String key) {
+		String property = getProperty(key);
+		return Long.parseLong(property);
 	}
 
 	public boolean getBoolean(String key) {

--- a/spring-cql/src/test/java/org/springframework/cassandra/test/unit/core/cql/generator/DropKeyspaceCqlGeneratorTests.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/test/unit/core/cql/generator/DropKeyspaceCqlGeneratorTests.java
@@ -35,7 +35,8 @@ public class DropKeyspaceCqlGeneratorTests {
 	 * Convenient base class that other test classes can use so as not to repeat the generics declarations.
 	 */
 	public static abstract class DropTableTest extends
-			KeyspaceOperationCqlGeneratorTest<DropKeyspaceSpecification, DropKeyspaceCqlGenerator> {}
+			KeyspaceOperationCqlGeneratorTest<DropKeyspaceSpecification, DropKeyspaceCqlGenerator> {
+	}
 
 	public static class BasicTest extends DropTableTest {
 

--- a/spring-cql/src/test/java/org/springframework/cassandra/test/unit/core/cql/generator/KeyspaceOperationCqlGeneratorTest.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/test/unit/core/cql/generator/KeyspaceOperationCqlGeneratorTest.java
@@ -17,7 +17,7 @@ package org.springframework.cassandra.test.unit.core.cql.generator;
 
 import java.util.UUID;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.springframework.cassandra.core.cql.generator.KeyspaceNameCqlGenerator;
 import org.springframework.cassandra.core.cql.generator.TableNameCqlGenerator;

--- a/spring-cql/src/test/resources/cassandraOperationsTest-cql-dataload.cql
+++ b/spring-cql/src/test/resources/cassandraOperationsTest-cql-dataload.cql
@@ -1,3 +1,3 @@
-create table book (isbn text, title text, author text, pages int, PRIMARY KEY (isbn));
-create table book_alt (isbn text, title text, author text, pages int, PRIMARY KEY (isbn));
+create table if not exists book (isbn text, title text, author text, pages int, PRIMARY KEY (isbn));
+create table if not exists book_alt (isbn text, title text, author text, pages int, PRIMARY KEY (isbn));
 insert into book (isbn, title, author, pages) values ('999999999', 'Book of Nines', 'Nine Nine', 999);

--- a/spring-cql/src/test/resources/org.springframework.cassandra.test.integration.support.SpringCqlBuildProperties.properties
+++ b/spring-cql/src/test/resources/org.springframework.cassandra.test.integration.support.SpringCqlBuildProperties.properties
@@ -2,3 +2,4 @@ build.cassandra.native_transport_port=@build.cassandra.native_transport_port@
 build.cassandra.rpc_port=@build.cassandra.rpc_port@
 build.cassandra.storage_port=@build.cassandra.storage_port@
 build.cassandra.ssl_storage_port=@build.cassandra.ssl_storage_port@
+build.cql.init.timeout=60000

--- a/spring-cql/src/test/resources/spring-cassandra.yaml
+++ b/spring-cql/src/test/resources/spring-cassandra.yaml
@@ -36,7 +36,8 @@ cluster_name: 'Test Cluster'
 initial_token:
 
 # See http://wiki.apache.org/cassandra/HintedHandoff
-hinted_handoff_enabled: true
+hinted_handoff_enabled: false
+
 # this defines the maximum amount of time a dead host will have hints
 # generated.  After it has been dead this long, new hints for it will not be
 # created until it has been seen alive and gone down again.
@@ -185,7 +186,7 @@ saved_caches_directory: target/embeddedCassandra/saved_caches
 # and the CommitLog is simply synced every commitlog_sync_period_in_ms
 # milliseconds.
 commitlog_sync: periodic
-commitlog_sync_period_in_ms: 10000
+commitlog_sync_period_in_ms: 5000
 
 # The size of the individual commitlog file segments.  A commitlog
 # segment may be archived, deleted, or recycled once all the data
@@ -196,7 +197,7 @@ commitlog_sync_period_in_ms: 10000
 # archiving commitlog segments (see commitlog_archiving.properties),
 # then you probably want a finer granularity of archiving; 8 or 16 MB
 # is reasonable.
-commitlog_segment_size_in_mb: 32
+commitlog_segment_size_in_mb: 8
 
 # any class that implements the SeedProvider interface and has a
 # constructor that takes a Map<String, String> of parameters will do.
@@ -220,8 +221,8 @@ seed_provider:
 # On the other hand, since writes are almost never IO bound, the ideal
 # number of "concurrent_writes" is dependent on the number of cores in
 # your system; (8 * number_of_cores) is a good rule of thumb.
-concurrent_reads: 32
-concurrent_writes: 32
+concurrent_reads: 4
+concurrent_writes: 4
 
 # Total memory to use for memtables.  Cassandra will flush the largest
 # memtable when this much memory is used.
@@ -293,7 +294,7 @@ native_transport_port: ${build.cassandra.native_transport_port}
 #native_transport_max_threads: 48
 
 # Whether to start the thrift rpc server.
-start_rpc: true
+start_rpc: false
 
 # The address to bind the Thrift RPC service to -- clients connect
 # here. Unlike ListenAddress above, you _can_ specify 0.0.0.0 here if
@@ -379,7 +380,7 @@ snapshot_before_compaction: false
 # or dropping of column families. The STRONGLY advised default of true 
 # should be used to provide data safety. If you set this flag to false, you will
 # lose data on truncation or drop.
-auto_snapshot: true
+auto_snapshot: false
 
 # Add column indexes to a row after its contents reach this size.
 # Increase if your column values are large, or if you have a very large
@@ -419,17 +420,17 @@ compaction_throughput_mb_per_sec: 16
 # stream_throughput_outbound_megabits_per_sec: 200
 
 # How long the coordinator should wait for read operations to complete
-read_request_timeout_in_ms: 10000
+read_request_timeout_in_ms: 120000
 # How long the coordinator should wait for seq or index scans to complete
-range_request_timeout_in_ms: 10000
+range_request_timeout_in_ms: 120000
 # How long the coordinator should wait for writes to complete
-write_request_timeout_in_ms: 10000
+write_request_timeout_in_ms: 120000
 # How long the coordinator should wait for truncates to complete
 # (This can be much longer, because unless auto_snapshot is disabled
 # we need to flush first so we can snapshot before removing the data.)
-truncate_request_timeout_in_ms: 60000
+truncate_request_timeout_in_ms: 120000
 # The default timeout for other, miscellaneous operations
-request_timeout_in_ms: 10000
+request_timeout_in_ms: 120000
 
 # Enable operation timeout information exchange between nodes to accurately
 # measure request timeouts, If disabled cassandra will assuming the request
@@ -615,7 +616,7 @@ client_encryption_options:
 # can be:  all  - all traffic is compressed
 #          dc   - traffic between different datacenters is compressed
 #          none - nothing is compressed.
-internode_compression: all
+internode_compression: none
 
 # Enable or disable tcp_nodelay for inter-dc communication.
 # Disabling it will result in larger (but fewer) network packets being sent,

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -72,7 +73,7 @@
 
 		<dependency>
 			<groupId>org.cassandraunit</groupId>
-			<artifactId>cassandra-unit</artifactId>
+			<artifactId>cassandra-unit-spring</artifactId>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -81,11 +82,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.apache.cassandra</groupId>
 			<artifactId>cassandra-all</artifactId>
-			<version>${cassandra}</version>
+			<version>${cassandra.version}</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -117,6 +118,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.hectorclient</groupId>
+			<artifactId>hector-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- JSR 303 Validation -->
 		<dependency>
 			<groupId>javax.validation</groupId>
@@ -144,18 +151,18 @@
 			<scope>test</scope>
 		</dependency>
 
-        <dependency>
-            <groupId>org.apache.openwebbeans.test</groupId>
-            <artifactId>cditest-owb</artifactId>
-            <version>${webbeans}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>3.0-alpha-1</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.openwebbeans.test</groupId>
+			<artifactId>cditest-owb</artifactId>
+			<version>${webbeans}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<version>3.0-alpha-1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/template/async/AsynchronousCassandraTemplateTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/template/async/AsynchronousCassandraTemplateTest.java
@@ -34,7 +34,7 @@ import org.springframework.cassandra.core.ConsistencyLevel;
 import org.springframework.cassandra.core.PrimaryKeyType;
 import org.springframework.cassandra.core.RetryPolicy;
 import org.springframework.cassandra.core.WriteOptions;
-import org.springframework.cassandra.support.exception.CassandraInsufficientReplicasAvailableException;
+import org.springframework.cassandra.support.exception.CassandraConnectionFailureException;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.data.cassandra.core.CassandraTemplate;
@@ -59,7 +59,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class AsynchronousCassandraTemplateTest extends AbstractSpringDataEmbeddedCassandraIntegrationTest {
 
 	@Configuration
-	public static class Config extends IntegrationTestConfig {}
+	public static class Config extends IntegrationTestConfig {
+	}
 
 	@Table
 	public static class Thing {
@@ -80,7 +81,8 @@ public class AsynchronousCassandraTemplateTest extends AbstractSpringDataEmbedde
 		@Column
 		public int number;
 
-		public Thing() {}
+		public Thing() {
+		}
 
 		public Thing(String stuff, int number) {
 			this.stuff = stuff;
@@ -176,7 +178,7 @@ public class AsynchronousCassandraTemplateTest extends AbstractSpringDataEmbedde
 		testInsertAsynchronously(ConsistencyLevel.ONE);
 	}
 
-	@Test(expected = CassandraInsufficientReplicasAvailableException.class)
+	@Test(expected = CassandraConnectionFailureException.class)
 	public void testInsertAsynchronouslyThrows() throws Exception {
 		testInsertAsynchronously(ConsistencyLevel.TWO);
 	}
@@ -221,7 +223,7 @@ public class AsynchronousCassandraTemplateTest extends AbstractSpringDataEmbedde
 		testUpdateAsynchronously(ConsistencyLevel.ONE);
 	}
 
-	@Test(expected = CassandraInsufficientReplicasAvailableException.class)
+	@Test(expected = CassandraConnectionFailureException.class)
 	public void testUpdateAsynchronouslyThrows() throws Exception {
 		testUpdateAsynchronously(ConsistencyLevel.TWO);
 	}
@@ -243,7 +245,7 @@ public class AsynchronousCassandraTemplateTest extends AbstractSpringDataEmbedde
 		testDeleteAsynchronously(ConsistencyLevel.ONE);
 	}
 
-	@Test(expected = CassandraInsufficientReplicasAvailableException.class)
+	@Test(expected = CassandraConnectionFailureException.class)
 	public void testDeleteAsynchronouslyThrows() throws Exception {
 		testDeleteAsynchronously(ConsistencyLevel.TWO);
 	}

--- a/spring-data-cassandra/src/test/resources/org.springframework.data.cassandra.test.integration.support.SpringCassandraBuildProperties.properties
+++ b/spring-data-cassandra/src/test/resources/org.springframework.data.cassandra.test.integration.support.SpringCassandraBuildProperties.properties
@@ -2,3 +2,4 @@ build.cassandra.native_transport_port=@build.cassandra.native_transport_port@
 build.cassandra.rpc_port=@build.cassandra.rpc_port@
 build.cassandra.storage_port=@build.cassandra.storage_port@
 build.cassandra.ssl_storage_port=@build.cassandra.ssl_storage_port@
+build.cql.init.timeout=60000

--- a/spring-data-cassandra/src/test/resources/spring-cassandra.yaml
+++ b/spring-data-cassandra/src/test/resources/spring-cassandra.yaml
@@ -1,6 +1,5 @@
 # Cassandra storage config YAML 
 
-# NOTE:
 #   See http://wiki.apache.org/cassandra/StorageConfiguration for
 #   full explanations of configuration directives
 # /NOTE
@@ -37,7 +36,8 @@ cluster_name: 'Test Cluster'
 initial_token:
 
 # See http://wiki.apache.org/cassandra/HintedHandoff
-hinted_handoff_enabled: true
+hinted_handoff_enabled: false
+
 # this defines the maximum amount of time a dead host will have hints
 # generated.  After it has been dead this long, new hints for it will not be
 # created until it has been seen alive and gone down again.
@@ -186,7 +186,7 @@ saved_caches_directory: target/embeddedCassandra/saved_caches
 # and the CommitLog is simply synced every commitlog_sync_period_in_ms
 # milliseconds.
 commitlog_sync: periodic
-commitlog_sync_period_in_ms: 10000
+commitlog_sync_period_in_ms: 5000
 
 # The size of the individual commitlog file segments.  A commitlog
 # segment may be archived, deleted, or recycled once all the data
@@ -197,7 +197,7 @@ commitlog_sync_period_in_ms: 10000
 # archiving commitlog segments (see commitlog_archiving.properties),
 # then you probably want a finer granularity of archiving; 8 or 16 MB
 # is reasonable.
-commitlog_segment_size_in_mb: 32
+commitlog_segment_size_in_mb: 8
 
 # any class that implements the SeedProvider interface and has a
 # constructor that takes a Map<String, String> of parameters will do.
@@ -221,8 +221,8 @@ seed_provider:
 # On the other hand, since writes are almost never IO bound, the ideal
 # number of "concurrent_writes" is dependent on the number of cores in
 # your system; (8 * number_of_cores) is a good rule of thumb.
-concurrent_reads: 32
-concurrent_writes: 32
+concurrent_reads: 4
+concurrent_writes: 4
 
 # Total memory to use for memtables.  Cassandra will flush the largest
 # memtable when this much memory is used.
@@ -291,10 +291,10 @@ native_transport_port: ${build.cassandra.native_transport_port}
 # transport is used. They are similar to rpc_min_threads and rpc_max_threads,
 # though the defaults differ slightly.
 # native_transport_min_threads: 16
-# native_transport_max_threads: 128
+#native_transport_max_threads: 48
 
 # Whether to start the thrift rpc server.
-start_rpc: true
+start_rpc: false
 
 # The address to bind the Thrift RPC service to -- clients connect
 # here. Unlike ListenAddress above, you _can_ specify 0.0.0.0 here if
@@ -380,7 +380,7 @@ snapshot_before_compaction: false
 # or dropping of column families. The STRONGLY advised default of true 
 # should be used to provide data safety. If you set this flag to false, you will
 # lose data on truncation or drop.
-auto_snapshot: true
+auto_snapshot: false
 
 # Add column indexes to a row after its contents reach this size.
 # Increase if your column values are large, or if you have a very large
@@ -420,17 +420,17 @@ compaction_throughput_mb_per_sec: 16
 # stream_throughput_outbound_megabits_per_sec: 200
 
 # How long the coordinator should wait for read operations to complete
-read_request_timeout_in_ms: 10000
+read_request_timeout_in_ms: 120000
 # How long the coordinator should wait for seq or index scans to complete
-range_request_timeout_in_ms: 10000
+range_request_timeout_in_ms: 120000
 # How long the coordinator should wait for writes to complete
-write_request_timeout_in_ms: 10000
+write_request_timeout_in_ms: 120000
 # How long the coordinator should wait for truncates to complete
 # (This can be much longer, because unless auto_snapshot is disabled
 # we need to flush first so we can snapshot before removing the data.)
-truncate_request_timeout_in_ms: 60000
+truncate_request_timeout_in_ms: 120000
 # The default timeout for other, miscellaneous operations
-request_timeout_in_ms: 10000
+request_timeout_in_ms: 120000
 
 # Enable operation timeout information exchange between nodes to accurately
 # measure request timeouts, If disabled cassandra will assuming the request
@@ -616,7 +616,7 @@ client_encryption_options:
 # can be:  all  - all traffic is compressed
 #          dc   - traffic between different datacenters is compressed
 #          none - nothing is compressed.
-internode_compression: all
+internode_compression: none
 
 # Enable or disable tcp_nodelay for inter-dc communication.
 # Disabling it will result in larger (but fewer) network packets being sent,


### PR DESCRIPTION
Updated Cassandra-Unit, DSE Driver and Cassandra version to latest
stable version.  Changed the Test Cases to support the API changes on
the driver by DataStax.  They changed the exception hierarchy for failed
replication factor quorum.  The embedded spring-cassandra.yaml files
were tuned to turn of unneeded features that were causing overhead in
the testing.