### PR TITLE
DATACASS-202: Misspelled ConsistencyLevel enum constants

### DIFF
--- a/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevel.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevel.java
@@ -22,6 +22,6 @@ package org.springframework.cassandra.core;
  */
 public enum ConsistencyLevel {
 
-	ANY, ONE, TWO, THREE, QUOROM, LOCAL_QUOROM, EACH_QUOROM, ALL, LOCAL_ONE, SERIAL, LOCAL_SERIAL
+	ANY, ONE, TWO, THREE, QUORUM, LOCAL_QUORUM, EACH_QUORUM, ALL, LOCAL_ONE, SERIAL, LOCAL_SERIAL, @Deprecated QUOROM, @Deprecated LOCAL_QUOROM, @Deprecated EACH_QUOROM
 
 }

--- a/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevelResolver.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/core/ConsistencyLevelResolver.java
@@ -53,12 +53,15 @@ public final class ConsistencyLevelResolver {
 			case ANY:
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.ANY;
 				break;
+			case EACH_QUORUM:
 			case EACH_QUOROM:
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.EACH_QUORUM;
 				break;
+			case LOCAL_QUORUM:
 			case LOCAL_QUOROM:
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.LOCAL_QUORUM;
 				break;
+			case QUORUM:
 			case QUOROM:
 				resolvedLevel = com.datastax.driver.core.ConsistencyLevel.QUORUM;
 				break;


### PR DESCRIPTION
Deprecates all mispelled consistency level enum values.
Adds new consistency level enum values with correct spellings.
In ConsistencyLevelResolver, added the new enum values next to the old ones.