### PR TITLE
DATACASS-219 - On startup CREATE TABLE from entities should only add 'if not exists'.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-
-	<groupId>org.springframework.data</groupId>
-	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>1.5.0.BUILD-SNAPSHOT</version>
-	<packaging>pom</packaging>
-
-	<name>Spring Data Cassandra</name>
-	<description>Spring Data Cassandra</description>
-	<url>http://www.springsource.org/spring-data/cassandra</url>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
@@ -19,29 +12,14 @@
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
-	<modules>
-		<module>spring-cql</module>
-		<module>spring-data-cassandra</module>
-		<module>spring-data-cassandra-distribution</module>
-	</modules>
+	<groupId>org.springframework.data</groupId>
+	<artifactId>spring-data-cassandra-parent</artifactId>
+	<version>1.5.0.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
 
-	<properties>
-		<project.type>multi</project.type>
-		<dist.id>spring-data-cassandra</dist.id>
-		<springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
-		<cassandra-unit.version>2.1.9.2</cassandra-unit.version>
-		<el.version>1.0</el.version>
-		<failsafe.version>2.16</failsafe.version>
-		<cassandra.version>2.1.11</cassandra.version>
-		<cassandra-driver-dse.version>2.1.7.1</cassandra-driver-dse.version>
-
-		<build.cassandra.mode>embedded</build.cassandra.mode>
-		<build.cassandra.host>localhost</build.cassandra.host>
-		<build.cassandra.native_transport_port>19042</build.cassandra.native_transport_port>
-		<build.cassandra.rpc_port>19160</build.cassandra.rpc_port>
-		<build.cassandra.storage_port>17000</build.cassandra.storage_port>
-		<build.cassandra.ssl_storage_port>17001</build.cassandra.ssl_storage_port>
-	</properties>
+	<name>Spring Data Cassandra</name>
+	<description>Spring Data Cassandra</description>
+	<url>http://projects.spring.io/spring-data-cassandra/</url>
 
 	<developers>
 		<developer>
@@ -79,6 +57,43 @@
 			<timezone>-8</timezone>
 		</developer>
 	</developers>
+
+	<modules>
+		<module>spring-cql</module>
+		<module>spring-data-cassandra</module>
+		<module>spring-data-cassandra-distribution</module>
+	</modules>
+
+	<properties>
+		<build.cassandra.host>localhost</build.cassandra.host>
+		<build.cassandra.mode>embedded</build.cassandra.mode>
+		<build.cassandra.native_transport_port>19042</build.cassandra.native_transport_port>
+		<build.cassandra.rpc_port>19160</build.cassandra.rpc_port>
+		<build.cassandra.ssl_storage_port>17001</build.cassandra.ssl_storage_port>
+		<build.cassandra.storage_port>17000</build.cassandra.storage_port>
+		<cassandra.version>2.1.11</cassandra.version>
+		<cassandra-driver-dse.version>2.1.7.1</cassandra-driver-dse.version>
+		<cassandra-unit.version>2.1.9.2</cassandra-unit.version>
+		<dist.id>spring-data-cassandra</dist.id>
+		<el.version>1.0</el.version>
+		<failsafe.version>2.16</failsafe.version>
+		<project.type>multi</project.type>
+		<springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-plugins-release</id>
+			<url>https://repo.spring.io/plugins-release</url>
+		</pluginRepository>
+	</pluginRepositories>
 
 	<dependencyManagement>
 		<dependencies>
@@ -173,20 +188,6 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
-	<repositories>
-		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
-		</repository>
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-plugins-release</id>
-			<url>https://repo.spring.io/plugins-release</url>
-		</pluginRepository>
-	</pluginRepositories>
 
 	<dependencies>
 		<dependency>
@@ -291,6 +292,7 @@
 	<profiles>
 		<profile>
 			<id>release</id>
+
 			<build>
 				<plugins>
 					<plugin>
@@ -301,9 +303,9 @@
 				</plugins>
 			</build>
 		</profile>
-
 		<profile>
 			<id>embedded-cassandra</id>
+
 			<activation>
     			<activeByDefault>true</activeByDefault>
   			</activation>

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-
-	<artifactId>spring-cql</artifactId>
-
-	<name>Spring CQL</name>
-	<description>Raw Cassandra CQL Support for Spring Core</description>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
@@ -15,6 +11,12 @@
 		<version>1.5.0.BUILD-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
+	<artifactId>spring-cql</artifactId>
+
+	<name>Spring CQL</name>
+	<description>Raw Cassandra CQL Support for Spring Core</description>
+	<url>https://github.com/spring-projects/spring-data-cassandra/tree/master/spring-cql</url>
 
 	<properties>
 		<validation>1.0.0.GA</validation>

--- a/spring-cql/src/main/java/org/springframework/cassandra/config/CassandraCqlSessionFactoryBean.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/CassandraCqlSessionFactoryBean.java
@@ -40,7 +40,7 @@ import com.datastax.driver.core.Session;
 /**
  * Factory for creating and configuring a Cassandra {@link Session}, which is a thread-safe singleton.
  * As such, it is sufficient to have one {@link Session} per application and keyspace.
- * 
+ *
  * @author Alex Shvid
  * @author Matthew T. Adams
  * @author John Blum

--- a/spring-cql/src/main/java/org/springframework/cassandra/config/java/AbstractSessionConfiguration.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/java/AbstractSessionConfiguration.java
@@ -19,28 +19,32 @@ import org.springframework.cassandra.config.CassandraCqlSessionFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.datastax.driver.core.Cluster;
-
 /**
- * Base class for Spring Cassandra configuration that can handle creating namespaces, execute arbitrary CQL on startup &
- * shutdown, and optionally drop namespaces.
- * 
+ * Spring {@link @Configuration} class used to configure a Cassandra client application
+ * {@link com.datastax.driver.core.Session} connected to a Cassandra {@link com.datastax.driver.core.Cluster}.
+ *
+ * Enables a Cassandra Keyspace to be specified along with the ability to execute arbitrary CQL on startup
+ * as well as shutdown.
+ *
  * @author Matthew T. Adams
+ * @author John Blum
+ * @see org.springframework.cassandra.config.java.AbstractClusterConfiguration
+ * @see org.springframework.context.annotation.Configuration
  */
 @Configuration
 public abstract class AbstractSessionConfiguration extends AbstractClusterConfiguration {
 
-	protected abstract String getKeyspaceName();
-
 	@Bean
 	public CassandraCqlSessionFactoryBean session() throws Exception {
 
-		Cluster cluster = cluster().getObject();
-
 		CassandraCqlSessionFactoryBean bean = new CassandraCqlSessionFactoryBean();
-		bean.setCluster(cluster);
+
+		bean.setCluster(cluster().getObject());
 		bean.setKeyspaceName(getKeyspaceName());
 
 		return bean;
 	}
+
+	protected abstract String getKeyspaceName();
+
 }

--- a/spring-cql/src/main/java/org/springframework/cassandra/core/util/CollectionUtils.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/core/util/CollectionUtils.java
@@ -13,64 +13,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cassandra.core.util;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-public class CollectionUtils {
+public abstract class CollectionUtils extends org.springframework.util.CollectionUtils {
 
-	@SuppressWarnings("unchecked")
-	public static <T> T[] toArray(Iterable<T> i) {
-		return (T[]) toList(i).toArray();
+	public static Object[] toArray(Iterable<?> iterable) {
+		return toList(iterable).toArray();
 	}
 
-	public static <T> List<T> toList(Iterable<T> i) {
+	public static <T> List<T> toList(T... elements) {
+		List<T> list = Collections.emptyList();
 
-		List<T> list = null;
-		if (i instanceof List) {
-			list = (List<T>) i;
-		} else {
-			list = new ArrayList<T>();
-			for (T t : i) {
-				list.add(t);
-			}
+		if (elements != null) {
+			list = new ArrayList<T>(elements.length);
+			Collections.addAll(list, elements);
 		}
 
 		return list;
 	}
 
-	public static List<?> toList(Object thing) {
-		List<Object> list = new ArrayList<Object>();
-		list.add(thing);
-		return list;
-	}
+	public static <T> List<T> toList(Iterable<T> iterable) {
+		if (!(iterable instanceof List)) {
+			List<T> list = new ArrayList<T>();
 
-	public static List<?> toList(Object thing1, Object thing2) {
-		List<Object> list = new ArrayList<Object>();
-		list.add(thing1);
-		list.add(thing2);
-		return list;
-	}
-
-	public static List<?> toList(Object thing1, Object thing2, Object thing3) {
-		List<Object> list = new ArrayList<Object>();
-		list.add(thing1);
-		list.add(thing2);
-		list.add(thing3);
-		return list;
-	}
-
-	public static List<?> toList(Object thing1, Object thing2, Object thing3, Object... rest) {
-		List<Object> list = new ArrayList<Object>();
-		list.add(thing1);
-		list.add(thing2);
-		list.add(thing3);
-		if (rest != null) {
-			for (Object thing : rest) {
-				list.add(thing);
+			if (iterable != null) {
+				for (T element : iterable) {
+					list.add(element);
+				}
 			}
+
+			iterable = list;
 		}
-		return list;
+
+		return (List<T>) iterable;
 	}
+
 }

--- a/spring-cql/src/test/java/org/springframework/cassandra/config/CassandraCqlSessionFactoryBeanUnitTests.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/config/CassandraCqlSessionFactoryBeanUnitTests.java
@@ -1,0 +1,349 @@
+/*
+ *  Copyright 2013-2016 the original author or authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cassandra.config;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.cassandra.core.CqlOperations;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+
+/**
+ * The CassandraCqlSessionFactoryBeanUnitTests class is a test suite of test cases testing the contract
+ * and functionality of the {@link CassandraCqlSessionFactoryBean} class.
+ *
+ * @author John Blum
+ * @see org.junit.Rule
+ * @see org.junit.Test
+ * @see org.junit.rules.ExpectedException
+ * @see org.junit.runner.RunWith
+ * @see org.mockito.Mock
+ * @see org.mockito.Mockito
+ * @see org.mockito.runners.MockitoJUnitRunner
+ * @see org.springframework.cassandra.config.CassandraCqlSessionFactoryBean
+ * @since 1.5.0
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CassandraCqlSessionFactoryBeanUnitTests {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Mock
+	private Cluster mockCluster;
+
+	@Mock
+	private Session mockSession;
+
+	private CassandraCqlSessionFactoryBean factoryBean;
+
+	protected <T> List<T> asList(T... array) {
+		return new ArrayList<T>(Arrays.asList(array));
+	}
+
+	protected void assertNonNullEmptyCollection(Collection<?> collection) {
+		assertThat(collection, is(notNullValue()));
+		assertThat(collection.isEmpty(), is(true));
+	}
+
+	@Before
+	public void setup() {
+		factoryBean = spy(new CassandraCqlSessionFactoryBean());
+	}
+
+	@Test
+	public void cassandraCqlSessionFactoryBeanIsSingleton() {
+		assertThat(factoryBean.isSingleton(), is(true));
+	}
+
+	@Test
+	public void objectTypeWhenSessionHasNotBeenInitializedIsSessionClass() {
+		assertThat(factoryBean.getObject(), is(nullValue()));
+		assertEquals(Session.class, factoryBean.<Session>getObjectType());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void afterPropertiesSetInitializesSessionWithKeyspaceAndExecutesStartupScripts() throws Exception {
+		List<String> expectedStartupScripts = asList("/path/to/schema.cql", "/path/to/data.cql");
+
+		CqlOperations mockCqlOperations = mock(CqlOperations.class);
+
+		doReturn(mockSession).when(factoryBean).connect(eq("TestKeyspace"));
+		doReturn(mockCqlOperations).when(factoryBean).newCqlOperations(eq(mockSession));
+
+		factoryBean.setKeyspaceName("TestKeyspace");
+		factoryBean.setStartupScripts(expectedStartupScripts);
+
+		assertThat(factoryBean.getKeyspaceName(), is(equalTo("TestKeyspace")));
+		assertThat(factoryBean.getStartupScripts(), is(equalTo(expectedStartupScripts)));
+
+		factoryBean.afterPropertiesSet();
+
+		assertEquals(mockSession.getClass(), factoryBean.getObjectType());
+		assertThat(factoryBean.getObject(), is(equalTo(mockSession)));
+		assertThat(factoryBean.getSession(), is(equalTo(mockSession)));
+
+		InOrder inOrder = inOrder(factoryBean);
+
+		inOrder.verify(factoryBean, times(1)).connect(eq("TestKeyspace"));
+		inOrder.verify(factoryBean, times(1)).executeScripts(eq(expectedStartupScripts));
+		inOrder.verify(factoryBean, times(1)).newCqlOperations(eq(mockSession));
+		verify(mockCqlOperations, times(1)).execute(eq(expectedStartupScripts.get(0)));
+		verify(mockCqlOperations, times(1)).execute(eq(expectedStartupScripts.get(1)));
+	}
+
+	@Test
+	public void connectToSystemKeyspace() {
+		when(mockCluster.connect()).thenReturn(mockSession);
+
+		factoryBean.setCluster(mockCluster);
+
+		assertThat(factoryBean.connect(null), is(equalTo(mockSession)));
+
+		verify(mockCluster, times(1)).connect();
+		verify(mockCluster, never()).connect(anyString());
+	}
+
+	@Test
+	public void connectToTargetKeyspace() {
+		when(mockCluster.connect(eq("TestKeyspace"))).thenReturn(mockSession);
+
+		factoryBean.setCluster(mockCluster);
+
+		assertThat(factoryBean.connect("TestKeyspace"), is(equalTo(mockSession)));
+
+		verify(mockCluster, never()).connect();
+		verify(mockCluster, times(1)).connect(eq("TestKeyspace"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void destroySessionAndExecutesShutdownScripts() throws Exception {
+		List<String> expectedShutdownScripts = asList("/path/to/shutdown.cql");
+
+		CqlOperations mockCqlOperations = mock(CqlOperations.class);
+
+		doReturn(mockSession).when(factoryBean).getSession();
+		doReturn(mockCqlOperations).when(factoryBean).newCqlOperations(eq(mockSession));
+
+		factoryBean.setShutdownScripts(expectedShutdownScripts);
+		factoryBean.destroy();
+
+		InOrder inOrder = inOrder(factoryBean, mockSession);
+
+		inOrder.verify(factoryBean, times(1)).executeScripts(eq(expectedShutdownScripts));
+		verify(mockCqlOperations, times(1)).execute(eq(expectedShutdownScripts.get(0)));
+		inOrder.verify(mockSession, times(1)).close();
+	}
+
+	@Test
+	public void isConnectedWithNullSessionIsFalse() {
+		assertThat(factoryBean.getObject(), is(nullValue()));
+		assertThat(factoryBean.isConnected(), is(false));
+	}
+
+	@Test
+	public void isConnectedWithClosedSessionIsFalse() {
+		doReturn(mockSession).when(factoryBean).getObject();
+		when(mockSession.isClosed()).thenReturn(true);
+		assertThat(factoryBean.isConnected(), is(false));
+		verify(mockSession, times(1)).isClosed();
+	}
+
+	@Test
+	public void isConnectedWithOpenSessionIsTrue() {
+		doReturn(mockSession).when(factoryBean).getObject();
+		when(mockSession.isClosed()).thenReturn(false);
+		assertThat(factoryBean.isConnected(), is(true));
+		verify(mockSession, times(1)).isClosed();
+	}
+
+	@Test
+	public void setAndGetCluster() {
+		factoryBean.setCluster(mockCluster);
+		assertThat(factoryBean.getCluster(), is(equalTo(mockCluster)));
+	}
+
+	@Test
+	public void setClusterToNullThrowsIllegalArgumentException() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectCause(is(nullValue(Throwable.class)));
+		exception.expectMessage("Cluster must not be null");
+
+		factoryBean.setCluster(null);
+	}
+
+	@Test
+	public void getClusterWhenUninitializedThrowsIllegalStateException() {
+		exception.expect(IllegalStateException.class);
+		exception.expectCause(is(nullValue(Throwable.class)));
+		exception.expectMessage("Cluster was not properly initialized");
+
+		factoryBean.getCluster();
+	}
+
+	@Test
+	public void setAndGetKeyspaceName() {
+		assertThat(factoryBean.getKeyspaceName(), is(nullValue()));
+
+		factoryBean.setKeyspaceName("TEST");
+
+		assertThat(factoryBean.getKeyspaceName(), is(equalTo("TEST")));
+
+		factoryBean.setKeyspaceName(null);
+
+		assertThat(factoryBean.getKeyspaceName(), is(nullValue()));
+	}
+
+	@Test
+	public void getSessionWhenUninitializedThrowsIllegalStateException() {
+		exception.expect(IllegalStateException.class);
+		exception.expectCause(is(nullValue(Throwable.class)));
+		exception.expectMessage(is(equalTo("Session was not properly initialized")));
+
+		assertThat(factoryBean.getObject(), is(nullValue()));
+
+		factoryBean.getSession();
+	}
+
+	@Test
+	public void setAndGetStartupScripts() {
+		assertNonNullEmptyCollection(factoryBean.getStartupScripts());
+
+		List<String> expectedStartupScripts = asList("/path/to/schema.cql", "/path/to/data.cql");
+
+		factoryBean.setStartupScripts(expectedStartupScripts);
+
+		List<String> actualStartupScripts = factoryBean.getStartupScripts();
+
+		assertThat(actualStartupScripts, is(not(sameInstance(expectedStartupScripts))));
+		assertThat(actualStartupScripts, is(equalTo(expectedStartupScripts)));
+
+		factoryBean.setStartupScripts(null);
+
+		assertNonNullEmptyCollection(factoryBean.getStartupScripts());
+	}
+
+	@Test
+	public void startupScriptsAreImmutable() {
+		List<String> startupScripts = asList("/path/to/startup.cql");
+
+		factoryBean.setStartupScripts(startupScripts);
+
+		List<String> actualStartupScripts = factoryBean.getStartupScripts();
+
+		assertThat(actualStartupScripts, is(notNullValue()));
+		assertThat(actualStartupScripts, is(not(sameInstance(startupScripts))));
+		assertThat(actualStartupScripts, is(equalTo(startupScripts)));
+
+		startupScripts.add("/path/to/another.cql");
+
+		actualStartupScripts = factoryBean.getStartupScripts();
+
+		assertThat(actualStartupScripts, is(not(equalTo(startupScripts))));
+		assertThat(actualStartupScripts.size(), is(equalTo(1)));
+		assertThat(actualStartupScripts.get(0), is(equalTo(startupScripts.get(0))));
+
+		try {
+			exception.expect(UnsupportedOperationException.class);
+			actualStartupScripts.add("/path/to/yetAnother.cql");
+		}
+		finally {
+			assertThat(actualStartupScripts.size(), is(equalTo(1)));
+		}
+	}
+
+	@Test
+	public void setAndGetShutdownScripts() {
+		assertNonNullEmptyCollection(factoryBean.getShutdownScripts());
+
+		List<String> expectedShutdownScripts = asList("/path/to/backup.cql", "/path/to/dropTables.cql");
+
+		factoryBean.setShutdownScripts(expectedShutdownScripts);
+
+		List<String> actualShutdownScripts = factoryBean.getShutdownScripts();
+
+		assertThat(actualShutdownScripts, is(not(sameInstance(expectedShutdownScripts))));
+		assertThat(actualShutdownScripts, is(equalTo(expectedShutdownScripts)));
+
+		factoryBean.setShutdownScripts(null);
+
+		assertNonNullEmptyCollection(factoryBean.getShutdownScripts());
+	}
+
+	@Test
+	public void shutdownScriptsAreImmutable() {
+		List<String> shutdownScripts = asList("/path/to/shutdown.cql");
+
+		factoryBean.setShutdownScripts(shutdownScripts);
+
+		List<String> actualShutdownScripts = factoryBean.getShutdownScripts();
+
+		assertThat(actualShutdownScripts, is(notNullValue()));
+		assertThat(actualShutdownScripts, is(not(sameInstance(shutdownScripts))));
+		assertThat(actualShutdownScripts, is(equalTo(shutdownScripts)));
+
+		shutdownScripts.add("/path/to/corruptSession.cql");
+
+		actualShutdownScripts = factoryBean.getShutdownScripts();
+
+		assertThat(actualShutdownScripts, is(not(sameInstance(shutdownScripts))));
+		assertThat(actualShutdownScripts, is(not(equalTo(shutdownScripts))));
+		assertThat(actualShutdownScripts.size(), is(equalTo(1)));
+
+		try {
+			exception.expect(UnsupportedOperationException.class);
+			actualShutdownScripts.add("/path/to/blowUpCluster.cql");
+		}
+		finally {
+			assertThat(actualShutdownScripts.size(), is(equalTo(1)));
+		}
+	}
+
+}

--- a/spring-cql/src/test/java/org/springframework/cassandra/config/CassandraCqlSessionFactoryBeanUnitTests.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/config/CassandraCqlSessionFactoryBeanUnitTests.java
@@ -16,24 +16,11 @@
 
 package org.springframework.cassandra.config;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,14 +45,8 @@ import com.datastax.driver.core.Session;
  * and functionality of the {@link CassandraCqlSessionFactoryBean} class.
  *
  * @author John Blum
- * @see org.junit.Rule
- * @see org.junit.Test
- * @see org.junit.rules.ExpectedException
- * @see org.junit.runner.RunWith
- * @see org.mockito.Mock
- * @see org.mockito.Mockito
- * @see org.mockito.runners.MockitoJUnitRunner
  * @see org.springframework.cassandra.config.CassandraCqlSessionFactoryBean
+ * @see <a href="https://jira.spring.io/browse/DATACASS-219>DATACASS-219</a>
  * @since 1.5.0
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -293,8 +274,7 @@ public class CassandraCqlSessionFactoryBeanUnitTests {
 		try {
 			exception.expect(UnsupportedOperationException.class);
 			actualStartupScripts.add("/path/to/yetAnother.cql");
-		}
-		finally {
+		} finally {
 			assertThat(actualStartupScripts.size(), is(equalTo(1)));
 		}
 	}
@@ -340,10 +320,8 @@ public class CassandraCqlSessionFactoryBeanUnitTests {
 		try {
 			exception.expect(UnsupportedOperationException.class);
 			actualShutdownScripts.add("/path/to/blowUpCluster.cql");
-		}
-		finally {
+		} finally {
 			assertThat(actualShutdownScripts.size(), is(equalTo(1)));
 		}
 	}
-
 }

--- a/spring-cql/src/test/java/org/springframework/cassandra/core/util/CollectionUtilsUnitTests.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/core/util/CollectionUtilsUnitTests.java
@@ -1,0 +1,143 @@
+/*
+ *  Copyright 2013-2016 the original author or authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cassandra.core.util;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * The CollectionUtilsUnitTests class is a test suite of test cases testing the contract and functionality
+ * of the {@link CollectionUtils} class.
+ *
+ * @author John Blum
+ * @see org.junit.Test
+ * @see org.springframework.cassandra.core.util.CollectionUtils
+ * @since 1.5.0
+ */
+public class CollectionUtilsUnitTests {
+
+	<T> List<T> asList(T... array) {
+		return Arrays.asList(array);
+	}
+
+	void assertNonNullEmptyArray(Object[] array) {
+		assertThat(array, is(notNullValue()));
+		assertThat(array.length, is(equalTo(0)));
+	}
+
+	void assertNonNullEmptyCollection(Collection<?> collection) {
+		assertThat(collection, is(notNullValue()));
+		assertThat(collection.isEmpty(), is(true));
+	}
+
+	<T> Iterable<T> newIterable(final T... elements) {
+		return new Iterable<T>() {
+			@Override
+			public Iterator<T> iterator() {
+				return new Iterator<T>() {
+					int index = 0;
+
+					@Override
+					public boolean hasNext() {
+						return (index < elements.length);
+					}
+
+					@Override
+					public T next() {
+						return elements[index++];
+					}
+				};
+			}
+		};
+	}
+
+	@Test
+	public void toArrayWithIterable() {
+		Object[] array = CollectionUtils.toArray(newIterable(1, 2, 3));
+
+		assertThat(array, is(notNullValue()));
+		assertThat(array.length, is(equalTo(3)));
+
+		for (int index = 0; index < array.length; index++) {
+			Object valueAtIndex = (index + 1);
+			assertThat(array[index], is(equalTo(valueAtIndex)));
+		}
+	}
+
+	@Test
+	public void toArrayWithEmptyIterable() {
+		assertNonNullEmptyArray(CollectionUtils.toArray(newIterable()));
+	}
+
+	@Test
+	public void toArrayWithNull() {
+		assertNonNullEmptyArray(CollectionUtils.toArray(null));
+	}
+
+	@Test
+	public void toListWithArray() {
+		List<String> list = CollectionUtils.toList("test", "testing", "tested");
+
+		assertThat(list, is(notNullValue()));
+		assertThat(list.size(), is(equalTo(3)));
+		assertThat(list.containsAll(asList("test", "testing", "tested")), is(true));
+	}
+
+	@Test
+	public void toListWithEmptyArray() {
+		assertNonNullEmptyCollection(CollectionUtils.toList());
+	}
+
+	@Test
+	public void toListWithNullArray() {
+		assertNonNullEmptyCollection(CollectionUtils.toList((Object[]) null));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void toListWithIterable() {
+		List<Integer> list = CollectionUtils.toList(newIterable(1, 2, 3));
+
+		assertThat(list, is(notNullValue()));
+		assertThat(list.size(), is(equalTo(3)));
+		assertThat(list.containsAll(asList(1, 2, 3)), is(true));
+	}
+
+	@Test
+	public void toListWithList() {
+		List<Integer> expected = asList(1, 2, 3);
+		List<Integer> actual = CollectionUtils.toList(expected);
+
+		assertThat(actual, is(sameInstance(expected)));
+	}
+
+	@Test
+	public void toListWithNullIterable() {
+		assertNonNullEmptyCollection(CollectionUtils.toList((Iterable<?>) null));
+	}
+
+}

--- a/spring-cql/src/test/java/org/springframework/cassandra/core/util/CollectionUtilsUnitTests.java
+++ b/spring-cql/src/test/java/org/springframework/cassandra/core/util/CollectionUtilsUnitTests.java
@@ -16,11 +16,8 @@
 
 package org.springframework.cassandra.core.util;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -34,7 +31,6 @@ import org.junit.Test;
  * of the {@link CollectionUtils} class.
  *
  * @author John Blum
- * @see org.junit.Test
  * @see org.springframework.cassandra.core.util.CollectionUtils
  * @since 1.5.0
  */

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-
-	<artifactId>spring-data-cassandra</artifactId>
-
-	<name>Spring Data Cassandra - Core</name>
-	<description>Cassandra Support for Spring Data</description>
 
 	<parent>
 		<groupId>org.springframework.data</groupId>
@@ -15,6 +11,12 @@
 		<version>1.5.0.BUILD-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
+	<artifactId>spring-data-cassandra</artifactId>
+
+	<name>Spring Data Cassandra Core</name>
+	<description>Cassandra support for Spring Data</description>
+	<url>https://github.com/spring-projects/spring-data-cassandra/tree/master/spring-data-cassandra</url>
 
 	<properties>
 		<validation>1.0.0.GA</validation>
@@ -146,4 +148,5 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
 </project>

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraClusterFactoryBean.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraClusterFactoryBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.data.cassandra.config;
 
 import org.springframework.cassandra.config.CassandraCqlClusterFactoryBean;
@@ -20,7 +21,9 @@ import org.springframework.cassandra.config.CassandraCqlClusterFactoryBean;
 /**
  * Spring Data Cassandra extension of CassandraCqlClusterFactoryBean. This class exists only in the name of symmetry,
  * based on the other CassandraData*FactoryBean classes.
- * 
+ *
  * @author Matthew T. Adams
  */
-public class CassandraClusterFactoryBean extends CassandraCqlClusterFactoryBean {}
+public class CassandraClusterFactoryBean extends CassandraCqlClusterFactoryBean {
+
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBean.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBean.java
@@ -16,7 +16,7 @@
 
 package org.springframework.data.cassandra.config;
 
-import static org.springframework.cassandra.core.cql.CqlIdentifier.cqlId;
+import static org.springframework.cassandra.core.cql.CqlIdentifier.*;
 
 import java.util.Collection;
 
@@ -59,7 +59,7 @@ public class CassandraSessionFactoryBean extends CassandraCqlSessionFactoryBean 
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
 
-		Assert.state(converter != null, "Converter must not be null");
+		Assert.state(converter != null, "Converter was not properly initialized");
 
 		admin = newCassandraAdminOperations(getObject(), converter);
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/SchemaAction.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/SchemaAction.java
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.data.cassandra.config;
 
 /**
  * Enum identifying any schema actions to take at startup.
  * 
  * @author Matthew T. Adams
+ * @author John Blum
  */
 public enum SchemaAction {
 
@@ -33,6 +35,11 @@ public enum SchemaAction {
 	CREATE,
 
 	/**
+	 * Create each table as necessary. Avoid table creation if the table already exists.
+	 */
+	CREATE_IF_NOT_EXISTS,
+
+	/**
 	 * Create each table as necessary, dropping the table first if it exists.
 	 */
 	RECREATE,
@@ -44,11 +51,6 @@ public enum SchemaAction {
 
 	// TODO:
 	// /**
-	// * Validate that each required table and column exists. Fail if any required table or column does not exists.
-	// */
-	// VALIDATE,
-	//
-	// /**
 	// * Alter or create each table and column as necessary, leaving unused tables and columns untouched.
 	// */
 	// UPDATE,
@@ -56,5 +58,11 @@ public enum SchemaAction {
 	// /**
 	// * Alter or create each table and column as necessary, removing unused tables and columns.
 	// */
-	// UPDATE_DROP_UNUNSED;
+	// UPDATE_DROP_UNUNSED,
+	//
+	// /**
+	// * Validate that each required table and column exists. Fail if any required table or column does not exists.
+	// */
+	// VALIDATE
+
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraNamespaceHandler.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraNamespaceHandler.java
@@ -29,14 +29,12 @@ public class CassandraNamespaceHandler extends NamespaceHandlerSupport {
 
 	@Override
 	public void init() {
-
-		registerBeanDefinitionParser("repositories", new RepositoryBeanDefinitionParser(
-				new CassandraRepositoryConfigurationExtension()));
-
 		registerBeanDefinitionParser("cluster", new CassandraClusterParser());
 		registerBeanDefinitionParser("session", new CassandraSessionParser());
 		registerBeanDefinitionParser("template", new CassandraTemplateParser());
 		registerBeanDefinitionParser("converter", new CassandraMappingConverterParser());
 		registerBeanDefinitionParser("mapping", new CassandraMappingContextParser());
+		registerBeanDefinitionParser("repositories", new RepositoryBeanDefinitionParser(
+			new CassandraRepositoryConfigurationExtension()));
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraNamespaceHandler.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraNamespaceHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.data.cassandra.config.xml;
 
 import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
@@ -21,7 +22,7 @@ import org.springframework.data.repository.config.RepositoryBeanDefinitionParser
 
 /**
  * Namespace handler for spring-data-cassandra.
- * 
+ *
  * @author Alex Shvid
  * @author Matthew T. Adams
  */

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -108,16 +108,17 @@ public class CassandraTemplate extends CqlTemplate implements CassandraOperation
 	}
 
 	/**
-	 * Set the {@link CassandraConverter}.
+	 * Set the {@link CassandraConverter} used by this template to perform conversions.
 	 *
-	 * @param cassandraConverter must not be {@literal null}.
+	 * @param cassandraConverter Converter used to perform conversion of Cassandra data types to entity types.
+	 * Must not be {@literal null}.
 	 */
 	public void setConverter(CassandraConverter cassandraConverter) {
 
-		Assert.notNull(cassandraConverter, "CassandraConverter must not be null!");
+		Assert.notNull(cassandraConverter, "CassandraConverter must not be null");
 
 		this.cassandraConverter = cassandraConverter;
-		mappingContext = cassandraConverter.getMappingContext();
+		this.mappingContext = cassandraConverter.getMappingContext();
 	}
 
 	/* (non-Javadoc)

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraMappingContext.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraMappingContext.java
@@ -153,7 +153,7 @@ public class BasicCassandraMappingContext extends
 
 	@Override
 	public boolean usesTable(TableMetadata table) {
-		return entitySetsByTableName.containsKey(table.getName());
+		return entitySetsByTableName.containsKey(cqlId(table.getName()));
 	}
 
 	@Override

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBeanUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBeanUnitTests.java
@@ -16,28 +16,14 @@
 
 package org.springframework.data.cassandra.config;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
-import static org.springframework.data.cassandra.config.CassandraSessionFactoryBean.DEFAULT_CREATE_IF_NOT_EXISTS;
-import static org.springframework.data.cassandra.config.CassandraSessionFactoryBean.DEFAULT_DROP_TABLES;
-import static org.springframework.data.cassandra.config.CassandraSessionFactoryBean.DEFAULT_DROP_UNUSED_TABLES;
+import static org.mockito.Mockito.*;
+import static org.springframework.data.cassandra.config.CassandraSessionFactoryBean.*;
 
 import java.util.Collections;
 import java.util.Map;
@@ -68,14 +54,8 @@ import com.datastax.driver.core.TableMetadata;
  * of the {@link CassandraSessionFactoryBean} class.
  *
  * @author John Blum
- * @see org.junit.Rule
- * @see org.junit.Test
- * @see org.junit.rules.ExpectedException
- * @see org.junit.runner.RunWith
- * @see org.mockito.Mock
- * @see org.mockito.Mockito
- * @see org.mockito.runners.MockitoJUnitRunner
  * @see org.springframework.data.cassandra.config.CassandraSessionFactoryBean
+ * @see <a href="https://jira.spring.io/browse/DATACASS-219>DATACASS-219</a>
  * @since 1.5.0
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -136,7 +116,7 @@ public class CassandraSessionFactoryBeanUnitTests {
 	public void afterPropertiesSetThrowsIllegalStateExceptionWhenConverterIsNull() throws Exception {
 		exception.expect(IllegalStateException.class);
 		exception.expectCause(is(nullValue(Throwable.class)));
-		exception.expectMessage("Converter must not be null");
+		exception.expectMessage("Converter was not properly initialized");
 
 		factoryBean.setCluster(mockCluster);
 		factoryBean.afterPropertiesSet();

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBeanUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBeanUnitTests.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2013-2016 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.cassandra.config;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.data.cassandra.config.CassandraSessionFactoryBean.DEFAULT_CREATE_IF_NOT_EXISTS;
+import static org.springframework.data.cassandra.config.CassandraSessionFactoryBean.DEFAULT_DROP_TABLES;
+import static org.springframework.data.cassandra.config.CassandraSessionFactoryBean.DEFAULT_DROP_UNUSED_TABLES;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.springframework.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.convert.CassandraConverter;
+import org.springframework.data.cassandra.core.CassandraAdminOperations;
+import org.springframework.data.cassandra.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.mapping.CassandraPersistentEntity;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TableMetadata;
+
+/**
+ * The CassandraSessionFactoryBeanUnitTests class is a test suite of test cases testing the contract and functionality
+ * of the {@link CassandraSessionFactoryBean} class.
+ *
+ * @author John Blum
+ * @see org.junit.Rule
+ * @see org.junit.Test
+ * @see org.junit.rules.ExpectedException
+ * @see org.junit.runner.RunWith
+ * @see org.mockito.Mock
+ * @see org.mockito.Mockito
+ * @see org.mockito.runners.MockitoJUnitRunner
+ * @see org.springframework.data.cassandra.config.CassandraSessionFactoryBean
+ * @since 1.5.0
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CassandraSessionFactoryBeanUnitTests {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Mock
+	private CassandraConverter mockConverter;
+
+	@Mock
+	private Cluster mockCluster;
+
+	@Mock
+	private Session mockSession;
+
+	private CassandraSessionFactoryBean factoryBean;
+
+	@Before
+	public void setup() {
+		when(mockCluster.connect()).thenReturn(mockSession);
+		when(mockSession.getCluster()).thenReturn(mockCluster);
+
+		factoryBean = spy(new CassandraSessionFactoryBean());
+		factoryBean.setCluster(mockCluster);
+	}
+
+	protected CqlIdentifier newCqlIdentifier(String id) {
+		return new CqlIdentifier(id, false);
+	}
+
+	@Test
+	public void afterPropertiesSetPerformsSchemaAction() throws Exception {
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+				assertThat(factoryBean.getSchemaAction(), is(equalTo(SchemaAction.RECREATE)));
+				return null;
+			}
+		}).when(factoryBean).performSchemaAction();
+
+		factoryBean.setConverter(mockConverter);
+		factoryBean.setSchemaAction(SchemaAction.RECREATE);
+
+		assertThat(factoryBean.getConverter(), is(equalTo(mockConverter)));
+		assertThat(factoryBean.getSchemaAction(), is(equalTo(SchemaAction.RECREATE)));
+
+		factoryBean.afterPropertiesSet();
+
+		assertThat(factoryBean.getCassandraAdminOperations(), is(notNullValue(CassandraAdminOperations.class)));
+		assertThat(factoryBean.getObject(), is(equalTo(mockSession)));
+
+		verify(factoryBean, times(1)).performSchemaAction();
+	}
+
+	@Test
+	public void afterPropertiesSetThrowsIllegalStateExceptionWhenConverterIsNull() throws Exception {
+		exception.expect(IllegalStateException.class);
+		exception.expectCause(is(nullValue(Throwable.class)));
+		exception.expectMessage("Converter must not be null");
+
+		factoryBean.setCluster(mockCluster);
+		factoryBean.afterPropertiesSet();
+	}
+
+	protected void performSchemaActionCallsCreateTableWithArgumentsMatchingTheSchemaAction(SchemaAction schemaAction,
+			final boolean dropTables, final boolean dropUnused, final boolean ifNotExists) {
+
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+				assertThat(invocationOnMock.getArgumentAt(0, Boolean.class), is(equalTo(dropTables)));
+				assertThat(invocationOnMock.getArgumentAt(1, Boolean.class), is(equalTo(dropUnused)));
+				assertThat(invocationOnMock.getArgumentAt(2, Boolean.class), is(equalTo(ifNotExists)));
+				return null;
+			}
+		}).when(factoryBean).createTables(anyBoolean(), anyBoolean(), anyBoolean());
+
+		factoryBean.setSchemaAction(schemaAction);
+
+		assertThat(factoryBean.getSchemaAction(), is(equalTo(schemaAction)));
+
+		factoryBean.performSchemaAction();
+
+		verify(factoryBean, times(1)).createTables(eq(dropTables), eq(dropUnused), eq(ifNotExists));
+	}
+
+	@Test
+	public void performsSchemaActionCreatesTablesWithDefaults() {
+		performSchemaActionCallsCreateTableWithArgumentsMatchingTheSchemaAction(SchemaAction.CREATE,
+			DEFAULT_DROP_TABLES, DEFAULT_DROP_UNUSED_TABLES, DEFAULT_CREATE_IF_NOT_EXISTS);
+	}
+
+	@Test
+	public void performsSchemaActionCreatesTablesIfNotExists() {
+		performSchemaActionCallsCreateTableWithArgumentsMatchingTheSchemaAction(SchemaAction.CREATE_IF_NOT_EXISTS,
+			DEFAULT_DROP_TABLES, DEFAULT_DROP_UNUSED_TABLES, true);
+	}
+
+	@Test
+	public void performsSchemaActionRecreatesTables() {
+		performSchemaActionCallsCreateTableWithArgumentsMatchingTheSchemaAction(SchemaAction.RECREATE, true,
+			DEFAULT_DROP_UNUSED_TABLES, DEFAULT_CREATE_IF_NOT_EXISTS);
+	}
+
+	@Test
+	public void performsSchemaActionRecreatesAndDropsUnusedTables() {
+		performSchemaActionCallsCreateTableWithArgumentsMatchingTheSchemaAction(SchemaAction.RECREATE_DROP_UNUSED,
+			true, true, DEFAULT_CREATE_IF_NOT_EXISTS);
+	}
+
+	@Test
+	public void performsSchemaActionDoesNotCallCreateTablesWhenSchemaActionIsNone() {
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+				fail("'createTables(..)' should not have been called");
+				return null;
+			}
+		}).when(factoryBean).createTables(anyBoolean(), anyBoolean(), anyBoolean());
+
+		factoryBean.setSchemaAction(SchemaAction.NONE);
+
+		assertThat(factoryBean.getSchemaAction(), is(equalTo(SchemaAction.NONE)));
+
+		factoryBean.performSchemaAction();
+
+		verify(factoryBean, never()).createTables(anyBoolean(), anyBoolean(), anyBoolean());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void createsTableForEntity() throws Exception {
+		Metadata mockMetadata = mock(Metadata.class);
+		KeyspaceMetadata mockKeyspaceMetadata = mock(KeyspaceMetadata.class);
+		CassandraMappingContext mockMappingContext = mock(CassandraMappingContext.class);
+		CassandraPersistentEntity<Person> mockPersistentEntity = mock(CassandraPersistentEntity.class);
+		CassandraAdminOperations mockCassandraAdminOperations = mock(CassandraAdminOperations.class);
+
+		doReturn(mockCassandraAdminOperations).when(factoryBean).getCassandraAdminOperations();
+		doReturn(mockSession).when(factoryBean).getObject();
+		when(mockCluster.getMetadata()).thenReturn(mockMetadata);
+		when(mockMetadata.getKeyspace(eq("TestKeyspace"))).thenReturn(mockKeyspaceMetadata);
+		when(mockKeyspaceMetadata.getTables()).thenReturn(Collections.<TableMetadata>emptyList());
+		when(mockConverter.getMappingContext()).thenReturn(mockMappingContext);
+		when(mockMappingContext.getNonPrimaryKeyEntities()).thenReturn(
+			Collections.<CassandraPersistentEntity<?>>singletonList(mockPersistentEntity));
+		when(mockPersistentEntity.getTableName()).thenReturn(newCqlIdentifier("TestTable"));
+		when(mockPersistentEntity.getType()).thenReturn(Person.class);
+
+		factoryBean.setConverter(mockConverter);
+		factoryBean.setKeyspaceName("TestKeyspace");
+
+		assertThat(factoryBean.getConverter(), is(equalTo(mockConverter)));
+
+		factoryBean.createTables(true, false, false);
+
+		verify(mockSession, times(1)).getCluster();
+		verify(mockCluster, times(1)).getMetadata();
+		verify(mockMetadata, times(1)).getKeyspace(eq("TestKeyspace"));
+		verify(mockKeyspaceMetadata, times(1)).getTables();
+		verify(mockConverter, times(1)).getMappingContext();
+		verify(mockMappingContext, times(1)).getNonPrimaryKeyEntities();
+		verify(mockPersistentEntity, times(1)).getTableName();
+		verify(mockPersistentEntity, times(1)).getType();
+		verify(mockCassandraAdminOperations, times(1)).createTable(eq(false), eq(newCqlIdentifier("TestTable")),
+			eq(Person.class), isNull(Map.class));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void createTableForEntityIfNotExists() {
+		CassandraMappingContext mockMappingContext = mock(CassandraMappingContext.class);
+		CassandraPersistentEntity<Person> mockPersistentEntity = mock(CassandraPersistentEntity.class);
+		CassandraAdminOperations mockCassandraAdminOperations = mock(CassandraAdminOperations.class);
+
+		doReturn(mockCassandraAdminOperations).when(factoryBean).getCassandraAdminOperations();
+		doReturn(mockSession).when(factoryBean).getObject();
+		when(mockConverter.getMappingContext()).thenReturn(mockMappingContext);
+		when(mockMappingContext.getNonPrimaryKeyEntities()).thenReturn(
+			Collections.<CassandraPersistentEntity<?>>singletonList(mockPersistentEntity));
+		when(mockPersistentEntity.getTableName()).thenReturn(newCqlIdentifier("TestTable"));
+		when(mockPersistentEntity.getType()).thenReturn(Person.class);
+
+		factoryBean.setConverter(mockConverter);
+		factoryBean.setKeyspaceName("TestKeyspace");
+
+		assertThat(factoryBean.getConverter(), is(equalTo(mockConverter)));
+
+		factoryBean.createTables(false, false, true);
+
+		verify(mockSession, never()).getCluster();
+		verify(mockCluster, never()).getMetadata();
+		verify(mockConverter, times(1)).getMappingContext();
+		verify(mockMappingContext, times(1)).getNonPrimaryKeyEntities();
+		verify(mockPersistentEntity, times(1)).getTableName();
+		verify(mockPersistentEntity, times(1)).getType();
+		verify(mockCassandraAdminOperations, times(1)).createTable(eq(true), eq(newCqlIdentifier("TestTable")),
+			eq(Person.class), isNull(Map.class));
+	}
+
+	@Test
+	public void createTableThrowsIllegalStateExceptionWhenKeyspaceNotFound() {
+		Metadata mockMetadata = mock(Metadata.class);
+
+		doReturn(mockSession).when(factoryBean).getObject();
+		when(mockCluster.getMetadata()).thenReturn(mockMetadata);
+		when(mockMetadata.getKeyspace(anyString())).thenReturn(null);
+
+		exception.expect(IllegalStateException.class);
+		exception.expectCause(is(nullValue(Throwable.class)));
+		exception.expectMessage("keyspace [TestKeyspace] does not exist");
+
+		factoryBean.setKeyspaceName("TestKeyspace");
+		factoryBean.createTables(true, false, true);
+
+		verify(mockSession, times(1)).getCluster();
+		verify(mockCluster, times(1)).getMetadata();
+		verify(mockMetadata, times(1)).getKeyspace(eq("TestKeyspace"));
+		verify(mockMetadata, times(1)).getKeyspace(eq("testkeyspace"));
+	}
+
+	// TODO: add more createTable tests covering drop tables, etc
+
+	@Test
+	public void setAndGetConverter() {
+		assertThat(factoryBean.getConverter(), is(nullValue()));
+		factoryBean.setConverter(mockConverter);
+		assertThat(factoryBean.getConverter(), is(equalTo(mockConverter)));
+		verifyZeroInteractions(mockConverter);
+	}
+
+	@Test
+	public void setConverterToNull() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectCause(is(nullValue(Throwable.class)));
+		exception.expectMessage("CassandraConverter must not be null");
+
+		factoryBean.setConverter(null);
+	}
+
+	@Test
+	public void setAndGetSchemaAction() {
+		assertThat(factoryBean.getSchemaAction(), is(equalTo(SchemaAction.NONE)));
+		factoryBean.setSchemaAction(SchemaAction.CREATE);
+		assertThat(factoryBean.getSchemaAction(), is(equalTo(SchemaAction.CREATE)));
+		factoryBean.setSchemaAction(SchemaAction.NONE);
+		assertThat(factoryBean.getSchemaAction(), is(equalTo(SchemaAction.NONE)));
+	}
+
+	@Test
+	public void setSchemaActionToNullThrowsIllegalArgumentException() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectCause(is(nullValue(Throwable.class)));
+		exception.expectMessage("SchemaAction must not be null");
+
+		factoryBean.setSchemaAction(null);
+	}
+
+	static class Person {
+	}
+
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/config/SchemaActionIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/config/SchemaActionIntegrationTests.java
@@ -1,0 +1,286 @@
+/*
+ *  Copyright 2013-2016 the original author or authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.data.cassandra.test.integration.config;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.cassandra.config.CassandraCqlClusterFactoryBean;
+import org.springframework.cassandra.core.SessionCallback;
+import org.springframework.cassandra.test.integration.AbstractEmbeddedCassandraIntegrationTest;
+import org.springframework.cassandra.test.integration.KeyspaceRule;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.cassandra.config.SchemaAction;
+import org.springframework.data.cassandra.config.java.AbstractCassandraConfiguration;
+import org.springframework.data.cassandra.test.integration.repository.querymethods.declared.Person;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.exceptions.AlreadyExistsException;
+
+/**
+ * The SchemaActionIntegrationTests class is a test suite of test cases testing the contract and behavior
+ * of various {@link SchemaAction}s on startup of a Spring configured, Cassandra application client.
+ *
+ * @author John Blum
+ * @see org.junit.Test
+ * @see org.junit.Rule
+ * @see org.junit.rules.ExpectedException
+ * @see org.springframework.cassandra.test.integration.AbstractEmbeddedCassandraIntegrationTest
+ * @see org.springframework.cassandra.test.integration.KeyspaceRule
+ * @see org.springframework.data.cassandra.config.CassandraSessionFactoryBean
+ * @see org.springframework.data.cassandra.config.SchemaAction
+ * @see org.springframework.data.cassandra.config.java.AbstractCassandraConfiguration
+ * @since 1.0.0
+ */
+public class SchemaActionIntegrationTests extends AbstractEmbeddedCassandraIntegrationTest {
+
+	protected static final String KEYSPACE_NAME = SchemaActionIntegrationTests.class.getSimpleName().toLowerCase();
+
+	protected static final String PERSON_TABLE_DEFINITION_CQL =
+		String.format("CREATE TABLE %s.person (id int, firstName text, lastName text, PRIMARY KEY(id));",
+			KEYSPACE_NAME);
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Rule
+	public KeyspaceRule KEYSPACE_RULE = new KeyspaceRule(cassandraEnvironment, KEYSPACE_NAME);
+
+	static <T> T[] asArray(T... array) {
+		return array;
+	}
+
+	protected ConfigurableApplicationContext newApplicationContext(Class<?>... annotatedClasses) {
+		AnnotationConfigApplicationContext applicationContext =
+			new AnnotationConfigApplicationContext(annotatedClasses);
+
+		applicationContext.registerShutdownHook();
+
+		return applicationContext;
+	}
+
+	protected <T> T doInSessionWithConfiguration(Class<?> annotatedClass, SessionCallback<T> sessionCallback) {
+		ConfigurableApplicationContext applicationContext = null;
+
+		try {
+			applicationContext = newApplicationContext(annotatedClass);
+			return sessionCallback.doInSession(applicationContext.getBean(Session.class));
+		}
+		finally {
+			close(applicationContext);
+		}
+	}
+
+	protected void close(ConfigurableApplicationContext applicationContext) {
+		if (applicationContext != null) {
+			applicationContext.close();
+		}
+	}
+
+	protected void assertHasTableWithColumns(Session session, String tableName, String... columns) {
+		Metadata clusterMetadata = session.getCluster().getMetadata();
+		KeyspaceMetadata keyspaceMetadata = clusterMetadata.getKeyspace(KEYSPACE_NAME);
+
+		assertThat(String.format("Keyspace [%s] does not exist!", KEYSPACE_NAME), keyspaceMetadata, is(notNullValue()));
+
+		TableMetadata tableMetadata = keyspaceMetadata.getTable(tableName);
+
+		assertThat(String.format("Table [%s] does not exist!", tableName), tableMetadata, is(notNullValue()));
+
+		assertThat(tableMetadata.getColumns().size(), is(equalTo(columns.length)));
+
+		for (String columnName : columns) {
+			assertThat(String.format("Column [%s] dos not exist!", columnName),
+				tableMetadata.getColumn(columnName), is(notNullValue()));
+		}
+	}
+
+	@Test
+	public void createWithNoExistingTableCreatesTableFromEntity() {
+		doInSessionWithConfiguration(CreateWithNoExistingTableConfiguration.class,
+			new SessionCallback<Void>() {
+				@Override public Void doInSession(Session session) throws DataAccessException {
+					assertHasTableWithColumns(session, "person", "firstName", "lastName", "nickname",
+						"birthDate", "numberOfChildren", "cool");
+					return null;
+				}
+			}
+		);
+	}
+
+	@Test
+	public void createWithExistingTableThrowsErrorWhenCreatingTableFromEntity() {
+		exception.expect(BeanCreationException.class);
+		exception.expectCause(isA(AlreadyExistsException.class));
+		exception.expectMessage(containsString(String.format("Table %s.person already exists", KEYSPACE_NAME)));
+
+		doInSessionWithConfiguration(CreateWithExistingTableConfiguration.class,
+			new SessionCallback<Object>() {
+				@Override public Object doInSession(Session s) throws DataAccessException {
+					fail(String.format("%s should have failed!",
+						CreateWithExistingTableConfiguration.class.getSimpleName()));
+					return null;
+				}
+			}
+		);
+	}
+
+	@Test
+	public void createIfNotExistsWithNoExistingTableCreatesTableFromEntity() {
+		doInSessionWithConfiguration(CreateIfNotExistsWithNoExistingTableConfiguration.class,
+			new SessionCallback<Void>() {
+				@Override public Void doInSession(Session session) throws DataAccessException {
+					assertHasTableWithColumns(session, "person", "firstName", "lastName", "nickname",
+						"birthDate", "numberOfChildren", "cool");
+					return null;
+				}
+			}
+		);
+	}
+
+	@Test
+	public void createIfNotExistsWithExistingTableUsesExistingTable() {
+		doInSessionWithConfiguration(CreateIfNotExistsWithExistingTableConfiguration.class,
+			new SessionCallback<Void>() {
+				@Override public Void doInSession(Session session) throws DataAccessException {
+					assertHasTableWithColumns(session, "person", "id", "firstName", "lastName");
+					return null;
+				}
+			}
+		);
+	}
+
+	@Test
+	public void recreateTableFromEntityDropsExistingTable() {
+		doInSessionWithConfiguration(RecreateSchemaActionWithExistingTableConfiguration.class,
+			new SessionCallback<Void>() {
+				@Override public Void doInSession(Session session) throws DataAccessException {
+					assertHasTableWithColumns(session, "person", "firstName", "lastName", "nickname",
+						"birthDate", "numberOfChildren", "cool");
+					return null;
+				}
+			}
+		);
+	}
+
+	@Configuration
+	static class CreateWithNoExistingTableConfiguration extends CassandraConfiguration {
+
+		@Override
+		public SchemaAction getSchemaAction() {
+			return SchemaAction.CREATE;
+		}
+	}
+
+	@Configuration
+	static class CreateWithExistingTableConfiguration extends CassandraConfiguration {
+
+		@Override
+		public SchemaAction getSchemaAction() {
+			return SchemaAction.CREATE;
+		}
+
+		@Override
+		protected List<String> getStartupScripts() {
+			return Collections.singletonList(PERSON_TABLE_DEFINITION_CQL);
+		}
+	}
+
+	@Configuration
+	static class CreateIfNotExistsWithNoExistingTableConfiguration extends CassandraConfiguration {
+
+		@Override
+		public SchemaAction getSchemaAction() {
+			return SchemaAction.CREATE_IF_NOT_EXISTS;
+		}
+	}
+
+	@Configuration
+	static class CreateIfNotExistsWithExistingTableConfiguration extends CassandraConfiguration {
+
+		@Override
+		public SchemaAction getSchemaAction() {
+			return SchemaAction.CREATE_IF_NOT_EXISTS;
+		}
+
+		@Override
+		protected List<String> getStartupScripts() {
+			return Collections.singletonList(PERSON_TABLE_DEFINITION_CQL);
+		}
+	}
+
+	@Configuration
+	static class RecreateSchemaActionWithExistingTableConfiguration extends CassandraConfiguration {
+
+		@Override
+		public SchemaAction getSchemaAction() {
+			return SchemaAction.RECREATE;
+		}
+
+		@Override
+		protected List<String> getStartupScripts() {
+			return Collections.singletonList(PERSON_TABLE_DEFINITION_CQL);
+		}
+	}
+
+	@Configuration
+	static abstract class CassandraConfiguration extends AbstractCassandraConfiguration {
+
+		@Bean
+		@Override
+		public CassandraCqlClusterFactoryBean cluster() {
+			return new CassandraCqlClusterFactoryBean() {
+				@Override public void afterPropertiesSet() throws Exception {
+					// avoid Cassandra Cluster creation; use embedded
+				}
+				@Override public Cluster getObject() {
+					return cassandraEnvironment.getCluster();
+				}
+			};
+		}
+
+		@Override
+		public String[] getEntityBasePackages() {
+			return asArray(Person.class.getPackage().getName());
+		}
+
+		@Override
+		protected String getKeyspaceName() {
+			return KEYSPACE_NAME;
+		}
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/config/SchemaActionIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/config/SchemaActionIntegrationTests.java
@@ -16,13 +16,8 @@
 
 package org.springframework.data.cassandra.test.integration.config;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isA;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 import java.util.Collections;
 import java.util.List;
@@ -56,15 +51,12 @@ import com.datastax.driver.core.exceptions.AlreadyExistsException;
  * of various {@link SchemaAction}s on startup of a Spring configured, Cassandra application client.
  *
  * @author John Blum
- * @see org.junit.Test
- * @see org.junit.Rule
- * @see org.junit.rules.ExpectedException
  * @see org.springframework.cassandra.test.integration.AbstractEmbeddedCassandraIntegrationTest
  * @see org.springframework.cassandra.test.integration.KeyspaceRule
  * @see org.springframework.data.cassandra.config.CassandraSessionFactoryBean
  * @see org.springframework.data.cassandra.config.SchemaAction
- * @see org.springframework.data.cassandra.config.java.AbstractCassandraConfiguration
- * @since 1.0.0
+ * @see <a href="https://jira.spring.io/browse/DATACASS-219>DATACASS-219</a>
+ * @since 1.5.0
  */
 public class SchemaActionIntegrationTests extends AbstractEmbeddedCassandraIntegrationTest {
 
@@ -99,8 +91,7 @@ public class SchemaActionIntegrationTests extends AbstractEmbeddedCassandraInteg
 		try {
 			applicationContext = newApplicationContext(annotatedClass);
 			return sessionCallback.doInSession(applicationContext.getBean(Session.class));
-		}
-		finally {
+		} finally {
 			close(applicationContext);
 		}
 	}
@@ -267,6 +258,7 @@ public class SchemaActionIntegrationTests extends AbstractEmbeddedCassandraInteg
 				@Override public void afterPropertiesSet() throws Exception {
 					// avoid Cassandra Cluster creation; use embedded
 				}
+
 				@Override public Cluster getObject() {
 					return cassandraEnvironment.getCluster();
 				}

--- a/spring-data-cassandra/src/test/resources/config/spring-data-cassandra-basic.xml
+++ b/spring-data-cassandra/src/test/resources/config/spring-data-cassandra-basic.xml
@@ -1,37 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2016 the original author or authors.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cass="http://www.springframework.org/schema/data/cassandra"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="
-		http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+       xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+		http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+">
 
 	<bean name="randomKeyspaceName" class="java.lang.String">
-		<constructor-arg value="#{'' + T(org.springframework.cassandra.support.RandomKeySpaceName).create()}"/>
+		<constructor-arg value="#{T(org.springframework.cassandra.support.RandomKeySpaceName).create()}"/>
 	</bean>
 
-	<context:property-placeholder
-		location="classpath:/config/cassandra-connection.properties" />
+	<context:property-placeholder location="classpath:/config/cassandra-connection.properties"/>
 
 	<cass:converter mapping-ref="cassandraMapping"/>
 
-	<cass:template />
+	<cass:template/>
 
 </beans>


### PR DESCRIPTION
Fixes [DATACASS-219](https://jira.spring.io/browse/DATACASS-219).

Note, I also fixed the issue with `SchemaAction.RECREATE`.