### PR TITLE
DATACASS-156 - CqlOperations' ingest method signatures taking WriteOp…

### DIFF
--- a/spring-cql/src/main/java/org/springframework/cassandra/core/CqlOperations.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/core/CqlOperations.java
@@ -1279,7 +1279,7 @@ public interface CqlOperations {
 	 * @param rowIterator Implementation to provide the Object[] to be bound to the CQL.
 	 * @param options The Query Options Object
 	 */
-	void ingest(String cql, RowIterator rowIterator, WriteOptions options);
+	void ingest(String cql, RowIterator rowIterator, QueryOptions options);
 
 	/**
 	 * This is an operation designed for high performance writes. The CQL is used to create a PreparedStatement once, then
@@ -1305,7 +1305,7 @@ public interface CqlOperations {
 	 * @param rows List of List<?> with data to bind to the CQL.
 	 * @param options The Query Options Object
 	 */
-	void ingest(String cql, List<List<?>> rows, WriteOptions options);
+	void ingest(String cql, List<List<?>> rows, QueryOptions options);
 
 	/**
 	 * This is an operation designed for high performance writes. The CQL is used to create a {@link PreparedStatement}
@@ -1342,7 +1342,7 @@ public interface CqlOperations {
 	 * @param rows The data to bind to the CQL statement
 	 * @param options The Query Options Object
 	 */
-	void ingest(String cql, Object[][] rows, WriteOptions options);
+	void ingest(String cql, Object[][] rows, QueryOptions options);
 
 	/**
 	 * Delete all rows in the table

--- a/spring-cql/src/main/java/org/springframework/cassandra/core/CqlTemplate.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/core/CqlTemplate.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.cassandra.core;
 
-import static org.springframework.cassandra.core.cql.CqlIdentifier.cqlId;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -75,6 +73,8 @@ import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
 import com.datastax.driver.core.querybuilder.Truncate;
 import com.datastax.driver.core.querybuilder.Update;
+
+import static org.springframework.cassandra.core.cql.CqlIdentifier.cqlId;
 
 /**
  * <b>This is the Central class in the Cassandra core package.</b> It simplifies the use of Cassandra and helps to avoid
@@ -934,7 +934,7 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 	}
 
 	@Override
-	public void ingest(String cql, RowIterator rowIterator, WriteOptions options) {
+	public void ingest(String cql, RowIterator rowIterator, QueryOptions options) {
 
 		CachedPreparedStatementCreator cpsc = new CachedPreparedStatementCreator(cql);
 
@@ -953,7 +953,7 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 	}
 
 	@Override
-	public void ingest(String cql, final List<List<?>> rows, WriteOptions options) {
+	public void ingest(String cql, final List<List<?>> rows, QueryOptions options) {
 
 		Assert.notNull(rows);
 		Assert.notEmpty(rows);
@@ -982,7 +982,7 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 	}
 
 	@Override
-	public void ingest(String cql, final Object[][] rows, WriteOptions options) {
+	public void ingest(String cql, final Object[][] rows, QueryOptions options) {
 
 		ingest(cql, new RowIterator() {
 


### PR DESCRIPTION
Submitting a PR as this caused some confusion on our team, we were using ingest setting the TTL on the WriteOptions but wasn't actually doing anything.

As an alternative when using ingest the cql passed in has the TTL in the query.
