### PR TITLE
DATACASS-297 - Add support for streaming queries to select entities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>1.5.0.BUILD-SNAPSHOT</version>
+	<version>1.5.0.DATACASS-297-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Cassandra</name>

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-297-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-297-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-297-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.cassandra.core;
 
+import java.util.Iterator;
 import java.util.List;
 
 import org.springframework.cassandra.core.Cancellable;
@@ -50,6 +51,20 @@ public interface CassandraOperations extends CqlOperations {
 	 * @return the {@link CqlIdentifier}
 	 */
 	CqlIdentifier getTableName(Class<?> entityClass);
+
+	/**
+	 * Executes the given select {@code query} on the entity table of the specified {@code type} backed by a Cassandra
+	 * {@link com.datastax.driver.core.ResultSet}.
+	 * <p>
+	 * Returns a {@link java.util.Iterator} that wraps the a Cassandra {@link com.datastax.driver.core.ResultSet}.
+	 * 
+	 * @param <T> element return type
+	 * @param query must not be empty and not {@literal null}.
+	 * @param type must not be {@literal null}.
+	 * @return
+	 * @since 1.5
+	 */
+	<T> Iterator<T> stream(String query, Class<T> type);
 
 	/**
 	 * Execute query and convert ResultSet to the list of entities.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/AbstractCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/AbstractCassandraQuery.java
@@ -34,6 +34,7 @@ import org.springframework.data.cassandra.repository.query.CassandraQueryExecuti
 import org.springframework.data.cassandra.repository.query.CassandraQueryExecution.ResultProcessingExecution;
 import org.springframework.data.cassandra.repository.query.CassandraQueryExecution.ResultSetQuery;
 import org.springframework.data.cassandra.repository.query.CassandraQueryExecution.SingleEntityExecution;
+import org.springframework.data.cassandra.repository.query.CassandraQueryExecution.StreamExecution;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
@@ -100,13 +101,15 @@ public abstract class AbstractCassandraQuery implements RepositoryQuery {
 	private CassandraQueryExecution getExecution(String query, CassandraParameterAccessor accessor,
 			Converter<Object, Object> resultProcessing) {
 
-		return new ResultProcessingExecution(getExecutionToWrap(accessor), resultProcessing);
+		return new ResultProcessingExecution(getExecutionToWrap(accessor, resultProcessing), resultProcessing);
 	}
 
-	private CassandraQueryExecution getExecutionToWrap(CassandraParameterAccessor accessor) {
+	private CassandraQueryExecution getExecutionToWrap(CassandraParameterAccessor accessor, Converter<Object, Object> resultProcessing) {
 
 		if (method.isResultSetQuery()) {
 			return new ResultSetQuery(template);
+		} else if (method.isStreamQuery()) {
+			return new StreamExecution(template, resultProcessing);
 		} else if (method.isCollectionQuery()) {
 			return new CollectionExecution(template);
 		} else {

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/core/CassandraOperationsIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/core/CassandraOperationsIntegrationTests.java
@@ -15,10 +15,12 @@
  */
 package org.springframework.data.cassandra.test.integration.core;
 
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
@@ -651,8 +653,8 @@ public class CassandraOperationsIntegrationTests extends AbstractSpringDataEmbed
 		log.debug("SingleSelect Book Title -> " + b.getTitle());
 		log.debug("SingleSelect Book Author -> " + b.getAuthor());
 
-		Assert.assertEquals(b.getTitle(), "Spring Data Cassandra Guide");
-		Assert.assertEquals(b.getAuthor(), "Cassandra Guru");
+		assertEquals(b.getTitle(), "Spring Data Cassandra Guide");
+		assertEquals(b.getAuthor(), "Cassandra Guru");
 
 	}
 
@@ -669,11 +671,11 @@ public class CassandraOperationsIntegrationTests extends AbstractSpringDataEmbed
 
 		log.debug("Book Count -> " + bookz.size());
 
-		Assert.assertEquals(bookz.size(), 20);
+		assertEquals(bookz.size(), 20);
 
 		for (Book b : bookz) {
 			Assert.assertTrue(b.isInStock());
-			Assert.assertEquals(BookCondition.NEW, b.getCondition());
+			assertEquals(BookCondition.NEW, b.getCondition());
 		}
 	}
 
@@ -685,7 +687,7 @@ public class CassandraOperationsIntegrationTests extends AbstractSpringDataEmbed
 
 		template.insert(books);
 
-		Assert.assertEquals(count, template.count(Book.class));
+		assertEquals(count, template.count(Book.class));
 	}
 
 
@@ -697,7 +699,25 @@ public class CassandraOperationsIntegrationTests extends AbstractSpringDataEmbed
 
 		template.insert(books);
 
-		Assert.assertEquals(count, template.count(Book.class));
+		assertEquals(count, template.count(Book.class));
 	}
 
+	/**
+	 * @see DATACASS-297
+	 */
+	@Test
+	public void stream() {
+
+		List<Book> books = getBookList(20);
+		template.insert(books);
+
+		Iterator<Book> iterator = template.stream("select * from book", Book.class);
+		List<Book> result = new ArrayList<Book>();
+		while (iterator.hasNext()) {
+			result.add(iterator.next());
+		}
+
+		assertThat(books.size(), is(20));
+		assertThat(books.get(0), is(instanceOf(Book.class)));
+	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/declared/anno/PersonRepositoryWithQueryAnnotations.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/declared/anno/PersonRepositoryWithQueryAnnotations.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.data.cassandra.repository.Query;
 import org.springframework.data.cassandra.test.integration.repository.querymethods.declared.Person;
@@ -73,4 +74,8 @@ public interface PersonRepositoryWithQueryAnnotations extends PersonRepository {
 	@Override
 	@Query("select * from person where lastname = ?0 and firstname = ?1")
 	Optional<Person> findOptionalWithLastnameAndFirstname(String last, String first);
+
+	@Override
+	@Query("select * from person")
+	Stream<Person> findAllPeople();
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/declared/base/PersonRepository.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/declared/base/PersonRepository.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.data.cassandra.repository.CassandraRepository;
 import org.springframework.data.cassandra.test.integration.repository.querymethods.declared.Person;
@@ -28,6 +29,7 @@ import com.datastax.driver.core.ResultSet;
 
 /**
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
 @NoRepositoryBean
 public interface PersonRepository extends CassandraRepository<Person> {
@@ -51,5 +53,7 @@ public interface PersonRepository extends CassandraRepository<Person> {
 	int findSingleNumberOfChildren(String last, String first);
 
 	Optional<Person> findOptionalWithLastnameAndFirstname(String last, String first);
+
+	Stream<Person> findAllPeople();
 
 }

--- a/spring-data-cassandra/src/test/resources/META-INF/PersonRepositoryWithNamedQueries.properties
+++ b/spring-data-cassandra/src/test/resources/META-INF/PersonRepositoryWithNamedQueries.properties
@@ -8,4 +8,5 @@ Person.findSingleBirthdate=select birthdate from person where lastname = ?0 and 
 Person.findSingleCool=select cool from person where lastname = ?0 and firstname = ?1
 Person.findSingleNumberOfChildren=select numberofchildren from person where lastname = ?0 and firstname = ?1
 Person.findOptionalWithLastnameAndFirstname=select * from person where lastname = ?0 and firstname = ?1
+Person.findAllPeople=select * from person
 


### PR DESCRIPTION
We now support java.util.stream.Stream as return type on query methods. Streaming queries wrap the iterator returned by Cassandra's ResultSet. Elements are fetched in batches (see QueryOptions that can be set in CassandraCqlClusterFactoryBean) and processed element by element instead of reading all results. Streaming queries are supported only for select queries.

----

Related ticket: [DATACASS-297](https://jira.spring.io/browse/DATACASS-297)