### PR TITLE
DATACASS-182 - Add ability to update/store null into fields.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>1.5.0.BUILD-SNAPSHOT</version>
+	<version>1.5.0.DATACASS-182-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Cassandra</name>

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-182-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-182-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-182-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/MappingCassandraConverter.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/MappingCassandraConverter.java
@@ -272,12 +272,10 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 					return;
 				}
 
-				if (value != null) {
-					if (log.isDebugEnabled()) {
-						log.debug("Adding insert.value [{}] - [{}]", prop.getColumnName().toCql(), value);
-					}
-					insert.value(prop.getColumnName().toCql(), value);
+				if (log.isDebugEnabled()) {
+					log.debug("Adding insert.value [{}] - [{}]", prop.getColumnName().toCql(), value);
 				}
+				insert.value(prop.getColumnName().toCql(), value);
 			}
 		});
 	}
@@ -303,12 +301,10 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 					return;
 				}
 
-				if (value != null) {
-					if (prop.isIdProperty() || entity.isCompositePrimaryKey() || prop.isPrimaryKeyColumn()) {
-						update.where(QueryBuilder.eq(prop.getColumnName().toCql(), value));
-					} else {
-						update.with(QueryBuilder.set(prop.getColumnName().toCql(), value));
-					}
+				if (isPrimaryKeyPart(prop)) {
+					update.where(QueryBuilder.eq(prop.getColumnName().toCql(), value));
+				} else {
+					update.with(QueryBuilder.set(prop.getColumnName().toCql(), value));
 				}
 			}
 		});
@@ -443,5 +439,15 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 				? (PersistentPropertyAccessor) source : entity.getPropertyAccessor(source);
 
 		return new ConvertingPropertyAccessor(accessor, conversionService);
+	}
+
+	/**
+	 * Returns whether the property is part of the primary key.
+	 *
+	 * @param property
+	 * @return
+	 */
+	private boolean isPrimaryKeyPart(CassandraPersistentProperty property) {
+		return property.isCompositePrimaryKey() || property.isPrimaryKeyColumn() || property.isIdProperty();
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/SimpleCassandraRepository.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/SimpleCassandraRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2016 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import com.datastax.driver.core.querybuilder.Select;
  * 
  * @author Alex Shvid
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
 public class SimpleCassandraRepository<T, ID extends Serializable> implements TypedIdCassandraRepository<T, ID> {
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/convert/MappingCassandraConverterUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/convert/MappingCassandraConverterUnitTests.java
@@ -103,7 +103,7 @@ public class MappingCassandraConverterUnitTests {
 
 		mappingCassandraConverter.write(withEnumColumns, insert);
 
-		assertThat(getValues(insert), contains((Object) "MINT"));
+		assertThat(getValues(insert), hasItem((Object) "MINT"));
 	}
 
 	/**

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/simple/UserRepositoryIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/simple/UserRepositoryIntegrationTests.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -32,6 +33,7 @@ import com.google.common.collect.Lists;
  * @author Alex Shvid
  * @author Matthew T. Adams
  * @author David Webb
+ * @author Mark Paluch
  */
 public class UserRepositoryIntegrationTests {
 
@@ -150,6 +152,22 @@ public class UserRepositoryIntegrationTests {
 
 	}
 
+	/**
+	 * @see DATACASS-182
+	 */
+	public void save() {
+
+		tom.setPassword(null);
+		tom.setFriends(Collections.<String>emptySet());
+
+		repository.save(tom);
+
+		User loadedTom = repository.findOne(tom.getUsername());
+
+		assertThat(loadedTom.getPassword(), is(nullValue()));
+		assertThat(loadedTom.getFriends(), is(nullValue()));
+	}
+
 	private static void assertEquals(User user1, User user2) {
 		Assert.assertEquals(user1.getUsername(), user2.getUsername());
 		Assert.assertEquals(user1.getFirstName(), user2.getFirstName());
@@ -157,5 +175,4 @@ public class UserRepositoryIntegrationTests {
 		Assert.assertEquals(user1.getPlace(), user2.getPlace());
 		Assert.assertEquals(user1.getPassword(), user2.getPassword());
 	}
-
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/simple/UserRepositoryIntegrationTestsDelegator.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/simple/UserRepositoryIntegrationTestsDelegator.java
@@ -26,6 +26,7 @@ import org.springframework.data.cassandra.test.integration.support.AbstractSprin
  *
  * @author Matthew T. Adams
  * @author David Webb
+ * @author Mark Paluch
  */
 public abstract class UserRepositoryIntegrationTestsDelegator
 		extends AbstractSpringDataEmbeddedCassandraIntegrationTest {
@@ -74,5 +75,13 @@ public abstract class UserRepositoryIntegrationTestsDelegator
 	@Test
 	public void exists() {
 		tests.exists();
+	}
+
+	/**
+	 * @see DATACASS-182
+	 */
+	@Test
+	public void save() {
+		tests.save();
 	}
 }


### PR DESCRIPTION
We now support the removal of columns for properties with `null` values by allowing null values in `Insert` and `Update` statements written by `MappingCassandraConverter`. Objects are stored with all persistent properties. Insert and update perform no longer conditional inserting of non-null values but take all values into account.

----

Related ticket: [DATACASS-182](https://jira.spring.io/browse/DATACASS-182)