### PR TITLE
DATACASS-7 - Support query derivation in Cassandra repositories.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>1.5.0.BUILD-SNAPSHOT</version>
+	<version>1.5.0.DATACASS-7-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Cassandra</name>

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-7-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-7-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-7-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/AbstractCassandraConverter.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/AbstractCassandraConverter.java
@@ -63,6 +63,14 @@ public abstract class AbstractCassandraConverter implements CassandraConverter, 
 	}
 
 	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.convert.CassandraConverter#getCustomConversions()
+	 */
+	@Override
+	public CustomConversions getCustomConversions() {
+		return conversions;
+	}
+
+	/* (non-Javadoc)
 	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
 	 */
 	@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/CassandraConverter.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/CassandraConverter.java
@@ -46,7 +46,7 @@ public interface CassandraConverter
 	 * <li>A the composite primary key for {@link org.springframework.data.cassandra.mapping.PrimaryKey} using a
 	 * {@link org.springframework.data.cassandra.mapping.PrimaryKeyClass}</li>
 	 * </ul>
-	 * 
+	 *
 	 * @param object must not be {@literal null}.
 	 * @param entity must not be {@literal null}.
 	 * @return
@@ -55,10 +55,17 @@ public interface CassandraConverter
 
 	/**
 	 * Converts and writes a {@code source} object into a {@code sink} using the given {@link CassandraPersistentEntity}.
-	 * 
+	 *
 	 * @param source the source, may be {@literal null}.
 	 * @param sink must not be {@literal null}.
 	 * @param entity must not be {@literal null}.
 	 */
 	void write(Object source, Object sink, CassandraPersistentEntity<?> entity);
+
+	/**
+	 * Returns the {@link CustomConversions} registered in the {@link CassandraConverter}.
+	 * 
+	 * @return the {@link CustomConversions}.
+	 */
+	CustomConversions getCustomConversions();
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraPersistentEntityMetadataVerifier.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraPersistentEntityMetadataVerifier.java
@@ -42,6 +42,10 @@ public class BasicCassandraPersistentEntityMetadataVerifier implements Cassandra
 	@Override
 	public void verify(CassandraPersistentEntity<?> entity) throws MappingException {
 
+		if(entity.getType().isInterface()){
+			return;
+		}
+
 		VerifierMappingExceptions exceptions = new VerifierMappingExceptions(entity,
 				String.format("Mapping Exceptions from BasicCassandraPersistentEntityMetadataVerifier for %s", entity.getName()));
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraPersistentProperty.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraPersistentProperty.java
@@ -51,6 +51,7 @@ import com.datastax.driver.core.DataType;
  * @author Alex Shvid
  * @author Matthew T. Adams
  * @author Antoine Toulme
+ * @author Mark Paluch
  */
 public class BasicCassandraPersistentProperty extends AnnotationBasedPersistentProperty<CassandraPersistentProperty>
 		implements CassandraPersistentProperty, ApplicationContextAware {
@@ -129,7 +130,7 @@ public class BasicCassandraPersistentProperty extends AnnotationBasedPersistentP
 		List<CqlIdentifier> columnNames = getColumnNames();
 
 		if (columnNames.size() != 1) {
-			throw new IllegalStateException("property does not have a single column mapping");
+			throw new IllegalStateException(String.format("Property [%s] has no single column mapping", getName()));
 		}
 
 		return columnNames.get(0);

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParameterAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParameterAccessor.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.cassandra.repository.query;
 
+import org.springframework.data.cassandra.mapping.CassandraType;
 import org.springframework.data.repository.query.ParameterAccessor;
 
 import com.datastax.driver.core.DataType;
@@ -32,7 +33,7 @@ public interface CassandraParameterAccessor extends ParameterAccessor {
 	 * Returns the Cassandra {@link DataType} for the declared parameter if the type is a
 	 * {@link org.springframework.data.cassandra.mapping.CassandraSimpleTypeHolder simple type}. Parameter types may be
 	 * specified using {@link org.springframework.data.cassandra.mapping.CassandraType}.
-	 * 
+	 *
 	 * @param index the parameter index
 	 * @return the Cassandra {@link DataType} or {@literal null} if the parameter type cannot be determined from
 	 *         {@link org.springframework.data.cassandra.mapping.CassandraSimpleTypeHolder}
@@ -40,6 +41,16 @@ public interface CassandraParameterAccessor extends ParameterAccessor {
 	 * @see org.springframework.data.cassandra.mapping.CassandraType
 	 */
 	DataType getDataType(int index);
+
+	/**
+	 * Returns the {@link CassandraType} for the declared method parameter.
+	 *
+	 * @param index the parameter index
+	 * @return the Cassandra {@link CassandraType} or {@literal null}.
+	 * @see org.springframework.data.cassandra.mapping.CassandraSimpleTypeHolder
+	 * @see org.springframework.data.cassandra.mapping.CassandraType
+	 */
+	CassandraType findCassandraType(int index);
 
 	/**
 	 * The actual parameter type (after unwrapping).

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParameters.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParameters.java
@@ -71,7 +71,7 @@ public class CassandraParameters extends Parameters<CassandraParameters, Cassand
 	 */
 	class CassandraParameter extends Parameter {
 
-		private final DataType dataType;
+		private final CassandraType cassandraType;
 
 		protected CassandraParameter(MethodParameter parameter) {
 
@@ -87,22 +87,19 @@ public class CassandraParameters extends Parameters<CassandraParameters, Cassand
 									CassandraType.class.getSimpleName()));
 				}
 
-				this.dataType = CassandraSimpleTypeHolder.getDataTypeFor(cassandraType.type());
+				this.cassandraType = cassandraType;
 			} else {
-				this.dataType = CassandraSimpleTypeHolder.getDataTypeFor(getType());
+				this.cassandraType = null;
 			}
 		}
 
 		/**
-		 * Returns the Cassandra {@link DataType} for the declared parameter if the type is a
-		 * {@link org.springframework.data.cassandra.mapping.CassandraSimpleTypeHolder simple type}. Parameter types may be
-		 * specified using {@link org.springframework.data.cassandra.mapping.CassandraType}.
+		 * Returns the {@link CassandraType} for the declared parameter if specified using {@link org.springframework.data.cassandra.mapping.CassandraType}.
 		 * 
-		 * @return the Cassandra {@link DataType} or {@literal null} if the parameter type cannot be determined from
-		 *         {@link org.springframework.data.cassandra.mapping.CassandraSimpleTypeHolder}
+		 * @return the {@link CassandraType} or {@literal null}.
 		 */
-		public DataType getCassandraType() {
-			return dataType;
+		public CassandraType getCassandraType() {
+			return cassandraType;
 		}
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParametersParameterAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParametersParameterAccessor.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.cassandra.repository.query;
 
+import org.springframework.data.cassandra.mapping.CassandraSimpleTypeHolder;
+import org.springframework.data.cassandra.mapping.CassandraType;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
 
@@ -39,17 +41,26 @@ public class CassandraParametersParameterAccessor extends ParametersParameterAcc
 		super(method.getParameters(), values);
 	}
 
-	/**
-	 * Returns the Cassandra {@link DataType} for the declared parameter if the type is a
-	 * {@link org.springframework.data.cassandra.mapping.CassandraSimpleTypeHolder simple type}. Parameter types may be
-	 * specified using {@link org.springframework.data.cassandra.mapping.CassandraType}.
-	 *
-	 * @param index parameter index
-	 * @return the Cassandra {@link DataType} or {@literal null} if the parameter type cannot be determined from
-	 *         {@link org.springframework.data.cassandra.mapping.CassandraSimpleTypeHolder}
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#findCassandraType(int)
 	 */
-	public DataType getDataType(int index) {
+	public CassandraType findCassandraType(int index) {
 		return getParameters().getParameter(index).getCassandraType();
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#getDataType(int)
+	 */
+	@Override
+	public DataType getDataType(int index) {
+
+		CassandraType cassandraType = findCassandraType(index);
+
+		if (cassandraType != null) {
+			return CassandraSimpleTypeHolder.getDataTypeFor(cassandraType.type());
+		}
+
+		return CassandraSimpleTypeHolder.getDataTypeFor(getParameterType(index));
 	}
 
 	/* (non-Javadoc)

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,9 @@ import org.springframework.data.repository.query.parser.PartTree;
 
 /**
  * {@link RepositoryQuery} implementation for Cassandra.
+ * 
+ * @author Matthew Adams
+ * @author Mark Paluch
  */
 public class PartTreeCassandraQuery extends AbstractCassandraQuery {
 
@@ -34,13 +37,14 @@ public class PartTreeCassandraQuery extends AbstractCassandraQuery {
 	 * Creates a new {@link PartTreeCassandraQuery} from the given {@link QueryMethod} and {@link CassandraTemplate}.
 	 * 
 	 * @param method must not be {@literal null}.
-	 * @param template must not be {@literal null}.
+	 * @param operations must not be {@literal null}.
 	 */
-	public PartTreeCassandraQuery(CassandraQueryMethod method, CassandraOperations cassandraOperations) {
+	public PartTreeCassandraQuery(CassandraQueryMethod method, CassandraOperations operations) {
 
-		super(method, cassandraOperations);
+		super(method, operations);
+
 		this.tree = new PartTree(method.getName(), method.getEntityInformation().getJavaType());
-		this.context = cassandraOperations.getConverter().getMappingContext();
+		this.context = operations.getConverter().getMappingContext();
 	}
 
 	/**
@@ -52,10 +56,15 @@ public class PartTreeCassandraQuery extends AbstractCassandraQuery {
 		return tree;
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.AbstractCassandraQuery#createQuery(org.springframework.data.cassandra.repository.query.CassandraParameterAccessor, boolean)
+	 */
 	@Override
 	protected String createQuery(CassandraParameterAccessor accessor) {
 
-		CassandraQueryCreator creator = new CassandraQueryCreator(tree, accessor, context);
-		return creator.createQuery().getQueryString();
+		CassandraQueryCreator creator = new CassandraQueryCreator(tree, accessor, context,
+				getQueryMethod().getEntityInformation());
+		return creator.createQuery().toString();
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/SimpleCassandraEntityMetadata.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/SimpleCassandraEntityMetadata.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.query;
+
+import org.springframework.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.mapping.CassandraPersistentEntity;
+import org.springframework.util.Assert;
+
+/**
+ * Implementation of {@link CassandraEntityMetadata} based on the type and {@link CassandraPersistentEntity}.
+ * 
+ * @author Mark Paluch
+ * @since 1.5
+ */
+class SimpleCassandraEntityMetadata<T> implements CassandraEntityMetadata<T> {
+
+	private final Class<T> type;
+	private final CassandraPersistentEntity<?> tableEntity;
+
+	/**
+	 * Creates a new {@link SimpleCassandraEntityMetadata} using the given type and {@link CassandraPersistentEntity} to
+	 * use for table lookups.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @param tableEntity must not be {@literal null} or empty.
+	 */
+	public SimpleCassandraEntityMetadata(Class<T> type, CassandraPersistentEntity<?> tableEntity) {
+
+		Assert.notNull(type, "Type must not be null!");
+		Assert.notNull(tableEntity, "Collection entity must not be null or empty!");
+
+		this.type = type;
+		this.tableEntity = tableEntity;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.CassandraEntityMetadata#getTableName()
+	 */
+	@Override
+	public CqlIdentifier getTableName() {
+		return tableEntity.getTableName();
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.repository.core.EntityMetadata#getJavaType()
+	 */
+	@Override
+	public Class<T> getJavaType() {
+		return type;
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/CassandraParametersUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/CassandraParametersUnitTests.java
@@ -44,12 +44,12 @@ public class CassandraParametersUnitTests {
 	 * @see DATACASS-296
 	 */
 	@Test
-	public void shouldReturnDataTypeForSimpleType() throws Exception {
+	public void shouldUnknownDataTypeForSimpleType() throws Exception {
 
 		Method method = PersonRepository.class.getMethod("findByFirstname", String.class);
 		CassandraParameters cassandraParameters = new CassandraParameters(method);
 
-		assertThat(cassandraParameters.getParameter(0).getCassandraType(), is(DataType.varchar()));
+		assertThat(cassandraParameters.getParameter(0).getCassandraType(), is(nullValue()));
 	}
 
 	/**
@@ -61,7 +61,8 @@ public class CassandraParametersUnitTests {
 		Method method = PersonRepository.class.getMethod("findByFirstTime", String.class);
 		CassandraParameters cassandraParameters = new CassandraParameters(method);
 
-		assertThat(cassandraParameters.getParameter(0).getCassandraType(), is(DataType.time()));
+		assertThat(cassandraParameters.getParameter(0).getCassandraType(), is(notNullValue()));
+		assertThat(cassandraParameters.getParameter(0).getCassandraType().type(), is(Name.TIME));
 	}
 
 	/**
@@ -85,7 +86,8 @@ public class CassandraParametersUnitTests {
 		Method method = PersonRepository.class.getMethod("findByAnnotatedObject", Object.class);
 		CassandraParameters cassandraParameters = new CassandraParameters(method);
 
-		assertThat(cassandraParameters.getParameter(0).getCassandraType(), is(DataType.time()));
+		assertThat(cassandraParameters.getParameter(0).getCassandraType(), is(notNullValue()));
+		assertThat(cassandraParameters.getParameter(0).getCassandraType().type(), is(Name.TIME));
 	}
 
 	interface PersonRepository {

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/CassandraQueryCreatorUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/CassandraQueryCreatorUnitTests.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.query;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.cassandra.repository.query.StubParameterAccessor.*;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.cassandra.core.PrimaryKeyType;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.convert.CassandraConverter;
+import org.springframework.data.cassandra.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.domain.Person;
+import org.springframework.data.cassandra.mapping.BasicCassandraMappingContext;
+import org.springframework.data.cassandra.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.mapping.Column;
+import org.springframework.data.cassandra.mapping.PrimaryKey;
+import org.springframework.data.cassandra.mapping.PrimaryKeyClass;
+import org.springframework.data.cassandra.mapping.PrimaryKeyColumn;
+import org.springframework.data.cassandra.mapping.Table;
+import org.springframework.data.repository.core.EntityMetadata;
+import org.springframework.data.repository.query.parser.PartTree;
+
+/**
+ * Unit tests for {@link CassandraQueryCreator}.
+ * 
+ * @author Mark Paluch
+ * @soundtrack Odyssey - Everybody Move 9Club Mix
+ */
+public class CassandraQueryCreatorUnitTests {
+
+	CassandraMappingContext context;
+	CassandraConverter converter;
+
+	@Rule public ExpectedException expection = ExpectedException.none();
+
+	@Before
+	public void setUp() throws SecurityException, NoSuchMethodException {
+
+		context = new BasicCassandraMappingContext();
+		converter = new MappingCassandraConverter(context);
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsQueryCorrectly() {
+
+		String query = createQuery("findByFirstname", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname='Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsQueryWithSortCorrectly() {
+
+		String query = createQuery("findByFirstnameOrderByLastname", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname='Walter' ORDER BY lastname ASC;")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsAndQueryCorrectly() {
+
+		String query = createQuery("findByFirstnameAndLastname", Person.class, "Walter", "White");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname='Walter' AND lastname='White';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test(expected = InvalidDataAccessApiUsageException.class)
+	public void rejectsNegatingQueryQuery() {
+		createQuery("findByFirstnameNot", Person.class, "Walter");
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test(expected = InvalidDataAccessApiUsageException.class)
+	public void rejectsOrQuery() {
+		createQuery("findByFirstnameOrLastname", Person.class, "Walter", "White");
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsGreaterThanQueryCorrectly() {
+
+		String query = createQuery("findByFirstnameGreaterThan", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname>'Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsGreaterThanEqualQueryCorrectly() {
+
+		String query = createQuery("findByFirstnameGreaterThanEqual", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname>='Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsLessThanQueryCorrectly() {
+
+		String query = createQuery("findByFirstnameLessThan", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname<'Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsLessThanEqualQueryCorrectly() {
+
+		String query = createQuery("findByFirstnameLessThanEqual", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname<='Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsInQueryCorrectly() {
+
+		String query = createQuery("findByFirstnameIn", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname IN ('Walter');")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsInQueryWithListCorrectly() {
+
+		String query = createQuery("findByFirstnameIn", Person.class, Arrays.asList("Walter", "Gus"));
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname IN ('Walter','Gus');")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsInQueryWithArrayCorrectly() {
+
+		String query = createQuery("findByFirstnameInAndLastname", Person.class, new String[] { "Walter", "Gus" }, "Fring");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname IN ('Walter','Gus') AND lastname='Fring';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsLikeQueryCorrectly() {
+
+		assertThat(createQuery("findByFirstnameLike", Person.class, "Wal%ter"),
+				is(equalTo("SELECT * FROM person WHERE firstname LIKE 'Wal%ter';")));
+		assertThat(createQuery("findByFirstnameLike", Person.class, "Walter"),
+				is(equalTo("SELECT * FROM person WHERE firstname LIKE 'Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsStartsWithQueryCorrectly() {
+
+		String query = createQuery("findByFirstnameStartsWith", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname LIKE 'Walter%';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsEndsWithQueryCorrectly() {
+
+		String query = createQuery("findByFirstnameEndsWith", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname LIKE '%Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsContainsQueryOnSimplePropertyCorrectly() {
+
+		String query = createQuery("findByFirstnameContains", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname LIKE '%Walter%';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsContainsQueryOnSetPropertyCorrectly() {
+
+		String query = createQuery("findByMysetContains", TypeWithSet.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM typewithset WHERE myset CONTAINS 'Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsContainsQueryOnListPropertyCorrectly() {
+
+		String query = createQuery("findByMylistContains", TypeWithList.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM typewithlist WHERE mylist CONTAINS 'Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsContainsQueryOnMapPropertyCorrectly() {
+
+		String query = createQuery("findByMymapContains", TypeWithMap.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM typewithmap WHERE mymap CONTAINS 'Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsIsTrueQueryCorrectly() {
+
+		String query = createQuery("findByFirstnameIsTrue", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname=true;")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsIsFalseQueryCorrectly() {
+
+		String query = createQuery("findByFirstnameIsFalse", Person.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname=false;")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsQueryUsingQuotingCorrectly() {
+
+		String query = createQuery("findByIdAndSet", QuotedType.class, "Walter", "White");
+
+		assertThat(query, is(equalTo("SELECT * FROM \"myTable\" WHERE \"my_id\"='Walter' AND \"set\"='White';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsFindByPrimaryKeyPartCorrectly() {
+
+		String query = createQuery("findByKeyFirstname", TypeWithCompositeId.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM typewithcompositeid WHERE firstname='Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsFindByPrimaryKeyPartWithSortCorrectly() {
+
+		String query = createQuery("findByKeyFirstnameOrderByKeyLastnameAsc", TypeWithCompositeId.class, "Walter");
+
+		assertThat(query, is(equalTo("SELECT * FROM typewithcompositeid WHERE firstname='Walter' ORDER BY lastname ASC;")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsFindByPrimaryKeyPartOfPrimaryKeyClassCorrectly() {
+
+		String query = createQuery("findByFirstname", Key.class, "Walter");
+
+		// ⊙_ʘ rly? ヾ( •́д•̀ ;)ﾉ
+		assertThat(query, is(equalTo("SELECT * FROM key WHERE firstname='Walter';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test(expected = IllegalStateException.class)
+	public void createsFindByPrimaryKey2PartCorrectly() {
+		createQuery("findByKey", TypeWithCompositeId.class, new Key());
+	}
+
+	private String createQuery(String source, Class<?> entityClass, Object... values) {
+
+		PartTree tree = new PartTree(source, entityClass);
+		CassandraQueryCreator creator = new CassandraQueryCreator(tree, getAccessor(converter, values), context,
+				getEntityInformation(entityClass));
+		return creator.createQuery().toString();
+	}
+
+	private <T> EntityMetadata<T> getEntityInformation(final Class<T> entityClass) {
+		return new EntityMetadata<T>() {
+			@Override
+			public Class<T> getJavaType() {
+				return entityClass;
+			}
+		};
+	}
+
+	@Table
+	private static class TypeWithSet {
+
+		@Id String id;
+		Set<String> myset;
+	}
+
+	@Table
+	private static class TypeWithList {
+
+		@Id String id;
+		List<String> mylist;
+	}
+
+	@Table
+	private static class TypeWithMap {
+
+		@Id String id;
+		Map<String, String> mymap;
+	}
+
+	@Table(value = "myTable", forceQuote = true)
+	private static class QuotedType {
+
+		@PrimaryKey(value = "my_id", forceQuote = true) String id;
+
+		@Column(value = "set") Set<String> set;
+	}
+
+	@PrimaryKeyClass
+	private static class Key implements Serializable {
+
+		@PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED, ordinal = 1) String firstname;
+
+		@PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED, ordinal = 1) String lastname;
+	}
+
+	@Table
+	private static class TypeWithCompositeId {
+
+		@PrimaryKey Key key;
+
+		String city;
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/CassandraQueryMethodUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/CassandraQueryMethodUnitTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.query;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.cassandra.domain.Person;
+import org.springframework.data.cassandra.mapping.BasicCassandraMappingContext;
+import org.springframework.data.cassandra.mapping.CassandraMappingContext;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
+
+/**
+ * Unit tests for {@link CassandraQueryMethod}.
+ * 
+ * @author Mark Paluch
+ */
+public class CassandraQueryMethodUnitTests {
+
+	CassandraMappingContext context;
+
+	@Before
+	public void setUp() {
+		context = new BasicCassandraMappingContext();
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void detectsCollectionFromRepoTypeIfReturnTypeNotAssignable() throws Exception {
+
+		CassandraQueryMethod queryMethod = queryMethod(SampleRepository.class, "method");
+		CassandraEntityMetadata<?> metadata = queryMethod.getEntityInformation();
+
+		assertThat(metadata.getJavaType(), is(typeCompatibleWith(Person.class)));
+		assertThat(metadata.getTableName().toCql(), is("person"));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void rejectsNullMappingContext() throws Exception {
+
+		Method method = SampleRepository.class.getMethod("method");
+
+		new CassandraQueryMethod(method, new DefaultRepositoryMetadata(SampleRepository.class),
+				new SpelAwareProxyProjectionFactory(), null);
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void considersMethodAsCollectionQuery() throws Exception {
+
+		CassandraQueryMethod queryMethod = queryMethod(SampleRepository.class, "method");
+
+		assertThat(queryMethod.isCollectionQuery(), is(true));
+	}
+
+	private CassandraQueryMethod queryMethod(Class<?> repository, String name, Class<?>... parameters) throws Exception {
+
+		Method method = repository.getMethod(name, parameters);
+		ProjectionFactory factory = new SpelAwareProxyProjectionFactory();
+		return new CassandraQueryMethod(method, new DefaultRepositoryMetadata(repository), factory, context);
+	}
+
+	interface SampleRepository extends Repository<Person, Long> {
+
+		List<Person> method();
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQueryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQueryUnitTests.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.query;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.cassandra.convert.CassandraConverter;
+import org.springframework.data.cassandra.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.domain.Person;
+import org.springframework.data.cassandra.mapping.BasicCassandraMappingContext;
+import org.springframework.data.cassandra.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.data.cassandra.repository.Query;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
+
+/**
+ * Unit tests for {@link PartTreeCassandraQuery}.
+ * 
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PartTreeCassandraQueryUnitTests {
+
+	public @Rule ExpectedException exception = ExpectedException.none();
+
+	@Mock CassandraOperations cassandraOperationsMock;
+
+	CassandraMappingContext mappingContext;
+	CassandraConverter converter;
+
+	@Before
+	public void setUp() {
+
+		mappingContext = new BasicCassandraMappingContext();
+		converter = new MappingCassandraConverter(mappingContext);
+		when(cassandraOperationsMock.getConverter()).thenReturn(converter);
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldDeriveSimpleQuery() {
+
+		String query = deriveQueryFromMethod("findByLastname", "foo");
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE lastname='foo';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldDeriveSimpleQueryWithoutNames() {
+
+		String query = deriveQueryFromMethod("findPersonBy");
+
+		assertThat(query, is(equalTo("SELECT * FROM person;")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldDeriveAndQuery() {
+
+		String query = deriveQueryFromMethod("findByFirstnameAndLastname", "foo", "bar" );
+
+		assertThat(query, is(equalTo("SELECT * FROM person WHERE firstname='foo' AND lastname='bar';")));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void usesDynamicProjection() {
+
+		String query = deriveQueryFromMethod("findDynamicallyProjectedBy", PersonProjection.class);
+
+		assertThat(query, is(equalTo("SELECT * FROM person;")));
+	}
+
+
+	private String deriveQueryFromMethod(String method, Object... args) {
+
+		Class<?>[] types = new Class<?>[args.length];
+
+		for (int i = 0; i < args.length; i++) {
+			types[i] = args[i].getClass();
+		}
+
+		PartTreeCassandraQuery partTreeQuery = createQueryForMethod(method, types);
+
+		CassandraParameterAccessor accessor = new CassandraParametersParameterAccessor(partTreeQuery.getQueryMethod(), args);
+		return partTreeQuery.createQuery(new ConvertingParameterAccessor(cassandraOperationsMock.getConverter(), accessor));
+	}
+
+	private PartTreeCassandraQuery createQueryForMethod(String methodName, Class<?>... paramTypes) {
+
+		try {
+
+			Method method = Repo.class.getMethod(methodName, paramTypes);
+			ProjectionFactory factory = new SpelAwareProxyProjectionFactory();
+			CassandraQueryMethod queryMethod = new CassandraQueryMethod(method, new DefaultRepositoryMetadata(Repo.class), factory,
+					mappingContext);
+
+			return new PartTreeCassandraQuery(queryMethod, cassandraOperationsMock);
+		} catch (NoSuchMethodException e) {
+			throw new IllegalArgumentException(e.getMessage(), e);
+		} catch (SecurityException e) {
+			throw new IllegalArgumentException(e.getMessage(), e);
+		}
+	}
+
+	@SuppressWarnings("unused")
+	interface Repo extends CassandraRepository<Person> {
+
+		@Query()
+		Person findByLastname(String lastname);
+
+		Person findByFirstnameAndLastname(String firstname, String lastname);
+
+		Person findPersonByFirstnameAndLastname(String firstname, String lastname);
+
+		Person findByAge(Integer age);
+
+		Person findPersonBy();
+
+		PersonProjection findPersonProjectedBy();
+
+		<T> T findDynamicallyProjectedBy(Class<T> type);
+
+	}
+
+	interface PersonProjection {
+
+		String getFirstname();
+
+		String getLastname();
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/StubParameterAccessor.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/StubParameterAccessor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.query;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import org.springframework.data.cassandra.convert.CassandraConverter;
+import org.springframework.data.cassandra.mapping.CassandraType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Range;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.repository.query.ParameterAccessor;
+
+import com.datastax.driver.core.CodecRegistry;
+import com.datastax.driver.core.DataType;
+
+/**
+ * Simple {@link ParameterAccessor} that returns the given parameters unfiltered.
+ * 
+ * @author Mark Paluch
+ */
+class StubParameterAccessor implements CassandraParameterAccessor {
+
+	private final Object[] values;
+
+	/**
+	 * Creates a new {@link ConvertingParameterAccessor} backed by a {@link StubParameterAccessor} simply returning the
+	 * given parameters converted but unfiltered.
+	 *
+	 * @param converter
+	 * @param parameters
+	 * @return
+	 */
+	public static ConvertingParameterAccessor getAccessor(CassandraConverter converter, Object... parameters) {
+		return new ConvertingParameterAccessor(converter, new StubParameterAccessor(parameters));
+	}
+
+	@SuppressWarnings("unchecked")
+	public StubParameterAccessor(Object... values) {
+		this.values = values;
+	}
+
+	@Override
+	public DataType getDataType(int index) {
+		return CodecRegistry.DEFAULT_INSTANCE.codecFor(values[index]).getCqlType();
+	}
+
+	@Override
+	public Class<?> getParameterType(int index) {
+		return values[index].getClass();
+	}
+
+	@Override
+	public Pageable getPageable() {
+		return null;
+	}
+
+	@Override
+	public Sort getSort() {
+		return null;
+	}
+
+	@Override
+	public Class<?> getDynamicProjection() {
+		return null;
+	}
+
+	@Override
+	public Object getBindableValue(int index) {
+		return values[index];
+	}
+
+	@Override
+	public boolean hasBindableNullValue() {
+		return false;
+	}
+
+	@Override
+	public Iterator<Object> iterator() {
+		return Arrays.asList(values).iterator();
+	}
+
+	@Override
+	public CassandraType findCassandraType(int index) {
+		return null;
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/CassandraRepositoryFactoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/CassandraRepositoryFactoryUnitTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.support;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.Serializable;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.cassandra.convert.CassandraConverter;
+import org.springframework.data.cassandra.core.CassandraTemplate;
+import org.springframework.data.cassandra.domain.Person;
+import org.springframework.data.cassandra.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.mapping.CassandraPersistentEntity;
+import org.springframework.data.cassandra.repository.query.CassandraEntityInformation;
+import org.springframework.data.repository.Repository;
+
+/**
+ * Unit tests for {@link CassandraRepositoryFactory}.
+ * 
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class CassandraRepositoryFactoryUnitTests {
+
+	@Mock CassandraTemplate template;
+	@Mock CassandraConverter converter;
+	@Mock CassandraMappingContext mappingContext;
+	@Mock CassandraPersistentEntity entity;
+
+	@Before
+	public void setUp() {
+
+		when(template.getConverter()).thenReturn(converter);
+		when(converter.getMappingContext()).thenReturn(mappingContext);
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void usesMappingCassandraEntityInformationIfMappingContextSet() {
+
+		when(mappingContext.getPersistentEntity(Person.class)).thenReturn(entity);
+		when(entity.getType()).thenReturn(Person.class);
+
+		CassandraRepositoryFactory factory = new CassandraRepositoryFactory(template);
+		CassandraEntityInformation<Person, Serializable> entityInformation = factory.getEntityInformation(Person.class);
+		assertTrue(entityInformation instanceof MappingCassandraEntityInformation);
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void createsRepositoryWithIdTypeLong() {
+
+		when(mappingContext.getPersistentEntity(Person.class)).thenReturn(entity);
+		when(entity.getType()).thenReturn(Person.class);
+
+		CassandraRepositoryFactory factory = new CassandraRepositoryFactory(template);
+		MyPersonRepository repository = factory.getRepository(MyPersonRepository.class);
+		assertThat(repository, is(notNullValue()));
+	}
+
+	interface MyPersonRepository extends Repository<Person, Long> {
+
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/core/AsynchronousCassandraTemplateIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/core/AsynchronousCassandraTemplateIntegrationTests.java
@@ -246,7 +246,7 @@ public class AsynchronousCassandraTemplateIntegrationTests extends AbstractSprin
 	@AllArgsConstructor
 	@NoArgsConstructor
 	@SuppressWarnings("unused")
-	public static class Person {
+	static class Person {
 
 		@PrimaryKeyColumn(ordinal = 0, type = PrimaryKeyType.PARTITIONED) String id;
 		@Column String firstname;

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/core/CassandraOperationsIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/core/CassandraOperationsIntegrationTests.java
@@ -734,7 +734,11 @@ public class CassandraOperationsIntegrationTests extends AbstractSpringDataEmbed
 	 * @see <a href="https://jira.spring.io/browse/DATACASS-182">DATACASS-182</a>
 	 */
 	@Test
-	public void stream() {
+	public void stream() throws InterruptedException {
+
+		while(template.select("SELECT * FROM book", Book.class).size() != 0){
+			Thread.sleep(10);
+		}
 
 		template.insert(getBookList(20));
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/conversion/Address.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/conversion/Address.java
@@ -13,21 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.cassandra.domain;
+package org.springframework.data.cassandra.test.integration.repository.querymethods.conversion;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.cassandra.mapping.Table;
-
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Mark Paluch
  */
-@Table
 @Data
-public class Person {
+@AllArgsConstructor
+@NoArgsConstructor
+class Address {
 
-	@Id String id;
-	String firstname;
-	String lastname;
+	String city;
+	String country;
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/conversion/Contact.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/conversion/Contact.java
@@ -13,21 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.cassandra.domain;
+package org.springframework.data.cassandra.test.integration.repository.querymethods.conversion;
+
+import java.util.List;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.cassandra.mapping.Table;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Mark Paluch
  */
 @Table
 @Data
-public class Person {
+@NoArgsConstructor
+class Contact {
 
 	@Id String id;
-	String firstname;
-	String lastname;
+
+	Address address;
+	List<Address> addresses;
+
+	public Contact(String id) {
+		this.id = id;
+	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/conversion/ParameterConversionIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/conversion/ParameterConversionIntegrationTests.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.test.integration.repository.querymethods.conversion;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.cassandra.config.SchemaAction;
+import org.springframework.data.cassandra.convert.CustomConversions;
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.data.cassandra.repository.config.EnableCassandraRepositories;
+import org.springframework.data.cassandra.test.integration.repository.querymethods.declared.base.PersonRepository;
+import org.springframework.data.cassandra.test.integration.support.AbstractSpringDataEmbeddedCassandraIntegrationTest;
+import org.springframework.data.cassandra.test.integration.support.IntegrationTestConfig;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.StringUtils;
+
+/**
+ * Integration tests for query derivation through {@link PersonRepository}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class ParameterConversionIntegrationTests extends AbstractSpringDataEmbeddedCassandraIntegrationTest {
+
+	@Configuration
+	@EnableCassandraRepositories(considerNestedRepositories = true)
+	public static class Config extends IntegrationTestConfig {
+
+		@Override
+		public String[] getEntityBasePackages() {
+			return new String[] { Contact.class.getPackage().getName() };
+		}
+
+		@Override
+		public SchemaAction getSchemaAction() {
+			return SchemaAction.RECREATE_DROP_UNUSED;
+		}
+
+		@Override
+		public CustomConversions customConversions() {
+			return new CustomConversions(Arrays.asList(AddressReadConverter.INSTANCE, AddressWriteConverter.INSTANCE));
+		}
+	}
+
+	@Autowired CassandraOperations template;
+	@Autowired ContactRepository contactRepository;
+
+	Contact walter, flynn;
+
+	@Before
+	public void before() {
+
+		deleteAllEntities();
+
+		template.execute("CREATE INDEX IF NOT EXISTS contact_address ON contact (address);");
+		template.execute("CREATE INDEX IF NOT EXISTS contact_addresses ON contact (addresses);");
+
+		walter = new Contact("Walter");
+		walter.setAddress(new Address("Albuquerque", "USA"));
+		walter.setAddresses(Arrays.asList(new Address("Albuquerque", "USA"), new Address("New Hampshire", "USA"),
+				new Address("Grocery Store", "Mexico")));
+
+		flynn = new Contact("Flynn");
+		flynn.setAddress(new Address("Albuquerque", "USA"));
+		flynn.setAddresses(Collections.singletonList(new Address("Albuquerque", "USA")));
+
+		walter = contactRepository.save(walter);
+		flynn = contactRepository.save(flynn);
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldFindByConvertedParameter()  {
+
+		List<Contact> contacts = contactRepository.findByAddress(walter.getAddress());
+
+		assertThat(contacts, hasItems(walter, flynn));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldFindByStringParameter()  {
+
+		String parameter = AddressWriteConverter.INSTANCE.convert(walter.getAddress());
+		List<Contact> contacts = contactRepository.findByAddress(parameter);
+
+		assertThat(contacts, hasItems(walter, flynn));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void findByAddressesIn()  {
+
+		assertThat(contactRepository.findByAddressesContains(flynn.address), containsInAnyOrder(flynn, walter));
+		assertThat(contactRepository.findByAddressesContains(walter.addresses.get(1)), contains(walter));
+	}
+
+	interface ContactRepository extends CassandraRepository<Contact> {
+
+		List<Contact> findByAddress(Address address);
+
+		List<Contact> findByAddress(String address);
+
+		List<Contact> findByAddressesContains(Address address);
+	}
+
+	/**
+	 * @author Mark Paluch
+	 */
+	static enum AddressReadConverter implements Converter<String, Address> {
+
+		INSTANCE;
+
+		public Address convert(String source) {
+
+			if (StringUtils.hasText(source)) {
+				try {
+					return new ObjectMapper().readValue(source, Address.class);
+				} catch (IOException e) {
+					throw new IllegalStateException(e);
+				}
+			}
+
+			return null;
+		}
+	}
+
+	/**
+	 * @author Mark Paluch
+	 */
+	static enum AddressWriteConverter implements Converter<Address, String> {
+		INSTANCE;
+
+		public String convert(Address source) {
+
+			try {
+				return new ObjectMapper().writeValueAsString(source);
+			} catch (IOException e) {
+				throw new IllegalStateException(e);
+			}
+		}
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/declared/Person.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/declared/Person.java
@@ -20,17 +20,18 @@ import java.time.ZoneId;
 import java.util.Date;
 
 import org.springframework.cassandra.core.PrimaryKeyType;
-import org.springframework.data.cassandra.mapping.Indexed;
 import org.springframework.data.cassandra.mapping.PrimaryKeyColumn;
 import org.springframework.data.cassandra.mapping.Table;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Sample domain class.
  */
 @Table
 @Data
+@NoArgsConstructor
 public class Person {
 
 	@PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED, ordinal = 0) private String lastname;
@@ -44,4 +45,10 @@ public class Person {
 
 	private LocalDate createdDate;
 	private ZoneId zoneId;
+
+	public Person(String firstname, String lastname) {
+
+		this.firstname = firstname;
+		this.lastname = lastname;
+	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/derived/PersonRepository.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/derived/PersonRepository.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.test.integration.repository.querymethods.derived;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.data.cassandra.repository.Query;
+import org.springframework.data.cassandra.test.integration.repository.querymethods.declared.Person;
+import org.springframework.data.domain.Sort;
+
+/**
+ * @author Mark Paluch
+ */
+interface PersonRepository extends CassandraRepository<Person> {
+
+	List<Person> findByLastname(String lastname);
+
+	List<Person> findByLastname(String lastname, Sort sort);
+
+	List<Person> findByLastnameOrderByFirstnameAsc(String lastname);
+
+	Person findByFirstnameAndLastname(String firstname, String lastname);
+
+	Person findByCreatedDate(LocalDate createdDate);
+
+	Person findByNicknameStartsWith(String prefix);
+
+	Person findByNicknameContains(String contains);
+
+	Person findByNumberOfChildren(NumberOfChildren numberOfChildren);
+
+	Collection<PersonProjection> findPersonProjectedBy();
+
+	@Query("select * from person where firstname = ?0 and lastname = 'White'")
+	List<Person> findByFirstname(String firstname);
+
+	enum NumberOfChildren {
+		ZERO, ONE, TWO,
+	}
+
+	interface PersonProjection {
+
+		String getFirstname();
+
+		String getLastname();
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/derived/QueryDerivationIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/derived/QueryDerivationIntegrationTests.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.test.integration.repository.querymethods.derived;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.SpringVersion;
+import org.springframework.data.cassandra.config.SchemaAction;
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.repository.config.EnableCassandraRepositories;
+import org.springframework.data.cassandra.test.integration.repository.querymethods.declared.Person;
+import org.springframework.data.cassandra.test.integration.repository.querymethods.derived.PersonRepository.NumberOfChildren;
+import org.springframework.data.cassandra.test.integration.repository.querymethods.derived.PersonRepository.PersonProjection;
+import org.springframework.data.cassandra.test.integration.support.AbstractSpringDataEmbeddedCassandraIntegrationTest;
+import org.springframework.data.cassandra.test.integration.support.CassandraVersion;
+import org.springframework.data.cassandra.test.integration.support.IntegrationTestConfig;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.util.Version;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Integration tests for query derivation through {@link PersonRepository}.
+ * 
+ * @author Mark Paluch
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class QueryDerivationIntegrationTests extends AbstractSpringDataEmbeddedCassandraIntegrationTest {
+
+	@Configuration
+	@EnableCassandraRepositories
+	public static class Config extends IntegrationTestConfig {
+
+		@Override
+		public String[] getEntityBasePackages() {
+			return new String[] { Person.class.getPackage().getName() };
+		}
+
+		@Override
+		public SchemaAction getSchemaAction() {
+			return SchemaAction.RECREATE_DROP_UNUSED;
+		}
+
+	}
+
+	@Autowired CassandraOperations template;
+	@Autowired PersonRepository personRepository;
+
+	Person walter, skyler, flynn;
+
+	@Before
+	public void before() {
+
+		deleteAllEntities();
+
+		Person person = new Person("Walter", "White");
+		person.setNumberOfChildren(2);
+
+		walter = personRepository.save(person);
+		skyler = personRepository.save(new Person("Skyler", "White"));
+		flynn = personRepository.save(new Person("Flynn (Walter Jr.)", "White"));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldFindByLastname() {
+
+		List<Person> result = personRepository.findByLastname("White");
+
+		assertThat(result, hasItems(walter, skyler, flynn));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldFindByLastnameAndDynamicSort() {
+
+		List<Person> result = personRepository.findByLastname("White", new Sort("firstname"));
+
+		assertThat(result, contains(flynn, skyler, walter));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldFindByLastnameWithOrdering() {
+
+		List<Person> result = personRepository.findByLastnameOrderByFirstnameAsc("White");
+
+		assertThat(result, contains(flynn, skyler, walter));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldFindByFirstnameAndLastname() {
+
+		Person result = personRepository.findByFirstnameAndLastname("Walter", "White");
+
+		assertThat(result, is(walter));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void executesCollectionQueryWithProjectionCorrectly() {
+
+		Collection<PersonProjection> collection = personRepository.findPersonProjectedBy();
+
+		assertThat(collection, hasSize(3));
+
+		for (PersonProjection personProjection : collection) {
+			assertThat(personProjection.getLastname(), is(equalTo("White")));
+		}
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldFindByNumberOfChildren() throws Exception {
+
+		assumeThat(SpringVersion.getVersion(), startsWith("4.3"));
+
+		template.execute("CREATE INDEX IF NOT EXISTS person_number_of_children ON person (numberofchildren);");
+		// Give Cassandra some time to build the index
+		Thread.sleep(500);
+
+		Person result = personRepository.findByNumberOfChildren(NumberOfChildren.TWO);
+
+		assertThat(result, is(walter));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldFindByLocalDate() throws InterruptedException {
+
+		template.execute("CREATE INDEX IF NOT EXISTS person_created_date ON person (createddate);");
+		// Give Cassandra some time to build the index
+		Thread.sleep(500);
+
+		walter.setCreatedDate(LocalDate.now());
+		personRepository.save(walter);
+
+		Person result = personRepository.findByCreatedDate(walter.getCreatedDate());
+
+		assertThat(result, is(walter));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldUseQueryOverride() {
+
+		Person otherWalter = new Person("Walter", "Black");
+		personRepository.save(otherWalter);
+
+		List<Person> result = personRepository.findByFirstname("Walter");
+
+		assertThat(result, hasSize(1));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldUseStartsWithQuery() throws InterruptedException {
+
+		Version version = CassandraVersion.get(template.getSession());
+		assumeTrue(version.isGreaterThanOrEqualTo(Version.parse("3.4")));
+
+		template.execute(
+				"CREATE CUSTOM INDEX IF NOT EXISTS fn_starts_with ON person (nickname) USING 'org.apache.cassandra.index.sasi.SASIIndex';");
+		// Give Cassandra some time to build the index
+		Thread.sleep(500);
+
+		walter.setNickname("Heisenberg");
+		personRepository.save(walter);
+
+		assertThat(personRepository.findByNicknameStartsWith("Heis"), is(walter));
+	}
+
+	/**
+	 * @see DATACASS-7
+	 */
+	@Test
+	public void shouldUseContainsQuery() throws InterruptedException {
+
+		Version version = CassandraVersion.get(template.getSession());
+		assumeTrue(version.isGreaterThanOrEqualTo(Version.parse("3.4")));
+
+		template.execute(
+				"CREATE CUSTOM INDEX IF NOT EXISTS fn_contains ON person (nickname) USING 'org.apache.cassandra.index.sasi.SASIIndex'\n"
+						+ "WITH OPTIONS = { 'mode': 'CONTAINS' };");
+		// Give Cassandra some time to build the index
+		Thread.sleep(500);
+
+		walter.setNickname("Heisenberg");
+		personRepository.save(walter);
+
+		assertThat(personRepository.findByNicknameContains("eisenber"), is(walter));
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/support/AbstractSpringDataEmbeddedCassandraIntegrationTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/support/AbstractSpringDataEmbeddedCassandraIntegrationTest.java
@@ -39,6 +39,11 @@ public abstract class AbstractSpringDataEmbeddedCassandraIntegrationTest
 	 */
 	public void deleteAllEntities() {
 		for (CassandraPersistentEntity<?> entity : template.getConverter().getMappingContext().getPersistentEntities()) {
+
+			if(entity.getType().isInterface()){
+				continue;
+			}
+
 			template.truncate(entity.getTableName());
 		}
 	}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/support/CassandraVersion.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/support/CassandraVersion.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.test.integration.support;
+
+import lombok.experimental.UtilityClass;
+
+import org.springframework.data.util.Version;
+import org.springframework.util.Assert;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+
+/**
+ * Utility to retrieve the Cassandra release version.
+ * 
+ * @author Mark Paluch
+ */
+@UtilityClass
+public class CassandraVersion {
+
+	/**
+	 * Retrieve the Cassandra release version.
+	 * 
+	 * @param session must not be {@literal null}.
+	 * @return the release {@link Version}.
+	 */
+	public static Version get(Session session) {
+
+		Assert.notNull(session, "Session must not be null");
+
+		ResultSet resultSet = session.execute("SELECT release_version FROM system.local;");
+		Row row = resultSet.one();
+		return Version.parse(row.getString(0));
+	}
+}

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/test/integration/repository/simple/UserRepositoryXmlConfigIntegrationTests-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/test/integration/repository/simple/UserRepositoryXmlConfigIntegrationTests-context.xml
@@ -1,34 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2016 the original author or authors.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cass="http://www.springframework.org/schema/data/cassandra"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:util="http://www.springframework.org/schema/util"
 	xsi:schemaLocation="
 		http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd
 		">
 
 	<import resource="classpath:/config/spring-data-cassandra-basic.xml" />
 
 	<cass:mapping
-		entity-base-packages="org.springframework.data.cassandra.test.integration.repository">
+		entity-base-packages="org.springframework.data.cassandra.test.integration.repository.simple">
 		<cass:entity
 			class="org.springframework.data.cassandra.test.integration.repository.simple.User">
 			<cass:table name="users" />


### PR DESCRIPTION
We now support query derivation in Cassandra repositories. Repositories may declare query methods and queries are created based on the repository declaration.

```java
interface PersonRepository extends CassandraRepository<Person> {

	List<Person> findByLastname(@CassandraType(type = Name.VARCHAR) String lastname);
	List<Person> findByLastname(String lastname, Sort sort);
	List<Person> findByLastnameOrderByFirstnameAsc(String lastname);
	Collection<PersonProjection> findPersonProjectedBy();

	interface PersonProjection {

		String getFirstname();
	}
}

@Table
@Data
public class Person {
	@PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED, ordinal = 0) 
	private String lastname;

	@PrimaryKeyColumn(type = PrimaryKeyType.CLUSTERED, ordinal = 1) 
	private String firstname;
}
```

Query derivation supports a basic set of where predicates:
* `=` (Equals/Simple property)
* `>=` (Greater or equal)
* `>` (Greater)
* `<` (Less)
* `<=` (Less or equal)
* `IN`, `LIKE` (Like, Starting with, Ending with), `CONTAINING` (SASI Index)
* `= true` (Is true)
* `= false` (Is false)

Derived queries work with primary-key and non-primary key columns. Non-primary key columns require a secondary index otherwise these fields can't be queried.

----

Related ticket: [DATACASS-7](https://jira.spring.io/browse/DATACASS-7)