### PR TITLE
DATACASS-290 - Support multiple Keyspaces using XML configuration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>1.5.0.BUILD-SNAPSHOT</version>
+	<version>1.5.0.DATACASS-290-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-290-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-cql/src/main/java/org/springframework/cassandra/config/CassandraCqlTemplateFactoryBean.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/CassandraCqlTemplateFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package org.springframework.cassandra.config;
 
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.cassandra.core.CqlOperations;
 import org.springframework.cassandra.core.CqlTemplate;
+import org.springframework.util.Assert;
 
 import com.datastax.driver.core.Session;
 
@@ -26,38 +26,63 @@ import com.datastax.driver.core.Session;
  * Factory for configuring a {@link CqlTemplate}.
  * 
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
-public class CassandraCqlTemplateFactoryBean implements FactoryBean<CqlOperations>, InitializingBean {
+public class CassandraCqlTemplateFactoryBean implements FactoryBean<CqlTemplate>, InitializingBean {
 
 	private CqlTemplate template;
 	private Session session;
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.FactoryBean#getObject()
+	 */
 	@Override
-	public CqlOperations getObject() {
+	public CqlTemplate getObject() {
 		return template;
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.FactoryBean#getObjectType()
+	 */
 	@Override
-	public Class<? extends CqlOperations> getObjectType() {
-		return CqlOperations.class;
+	public Class<CqlTemplate> getObjectType() {
+		return CqlTemplate.class;
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.FactoryBean#isSingleton()
+	 */
 	@Override
 	public boolean isSingleton() {
 		return true;
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
 
-		if (session == null) {
-			throw new IllegalStateException("session is required");
-		}
+		Assert.notNull(session, "Session must not be null");
 
 		this.template = new CqlTemplate(session);
 	}
 
+	/**
+	 * Sets the Cassandra {@link Session} to use. The {@link CqlTemplate} will use the logged keyspace of the underlying
+	 * {@link Session}. Don't change the keyspace using CQL but use multiple {@link Session} and
+	 * {@link CqlTemplate} beans.
+	 * 
+	 * @param session must not be {@literal null}.
+	 */
 	public void setSession(Session session) {
+
+		Assert.notNull(session, "Session must not be null");
+
 		this.session = session;
 	}
 }

--- a/spring-cql/src/main/java/org/springframework/cassandra/config/xml/CassandraCqlClusterParser.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/xml/CassandraCqlClusterParser.java
@@ -52,6 +52,9 @@ import com.datastax.driver.core.SocketOptions;
  */
 public class CassandraCqlClusterParser extends AbstractBeanDefinitionParser {
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractBeanDefinitionParser#resolveId(org.w3c.dom.Element, org.springframework.beans.factory.support.AbstractBeanDefinition, org.springframework.beans.factory.xml.ParserContext)
+	 */
 	@Override
 	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
 			throws BeanDefinitionStoreException {
@@ -61,11 +64,13 @@ public class CassandraCqlClusterParser extends AbstractBeanDefinitionParser {
 		return (StringUtils.hasText(id) ? id : DefaultCqlBeanNames.CLUSTER);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractBeanDefinitionParser#parseInternal(org.w3c.dom.Element, org.springframework.beans.factory.xml.ParserContext)
+	 */
 	@Override
 	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
 
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-			CassandraCqlClusterFactoryBean.class);
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(CassandraCqlClusterFactoryBean.class);
 
 		builder.setLazyInit(parserContext.isDefaultLazyInit());
 		builder.getRawBeanDefinition().setDestroyMethodName("destroy");
@@ -131,11 +136,11 @@ public class CassandraCqlClusterParser extends AbstractBeanDefinitionParser {
 		List<String> startupScripts = new ArrayList<String>();
 		List<String> shutdownScripts = new ArrayList<String>();
 
-		BeanDefinitionBuilder poolingOptionsBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-			PoolingOptionsFactoryBean.class);
+		BeanDefinitionBuilder poolingOptionsBuilder = BeanDefinitionBuilder
+				.genericBeanDefinition(PoolingOptionsFactoryBean.class);
 
-		addOptionalPropertyReference(poolingOptionsBuilder, "initializationExecutor",
-			element, "initialization-executor-ref");
+		addOptionalPropertyReference(poolingOptionsBuilder, "initializationExecutor", element,
+				"initialization-executor-ref");
 
 		addOptionalPropertyValue(poolingOptionsBuilder, "heartbeatIntervalSeconds", element, "heartbeat-interval-seconds");
 		addOptionalPropertyValue(poolingOptionsBuilder, "idleTimeoutSeconds", element, "idle-timeout-seconds");
@@ -148,8 +153,8 @@ public class CassandraCqlClusterParser extends AbstractBeanDefinitionParser {
 			String name = subElement.getLocalName();
 
 			if ("keyspace".equals(name)) {
-				keyspaceActionSpecificationBeanDefinitions.add(
-					newKeyspaceActionSpecificationBeanDefinition(subElement, parserContext));
+				keyspaceActionSpecificationBeanDefinitions
+						.add(newKeyspaceActionSpecificationBeanDefinition(subElement, parserContext));
 			} else if ("local-pooling-options".equals(name)) {
 				parseLocalPoolingOptions(subElement, poolingOptionsBuilder);
 			} else if ("remote-pooling-options".equals(name)) {
@@ -163,11 +168,10 @@ public class CassandraCqlClusterParser extends AbstractBeanDefinitionParser {
 			}
 		}
 
-		builder.addPropertyValue("keyspaceSpecifications", newKeyspaceSetFlattenerBeanDefinition(
-			element, parserContext, keyspaceActionSpecificationBeanDefinitions));
+		builder.addPropertyValue("keyspaceSpecifications",
+				newKeyspaceSetFlattenerBeanDefinition(element, parserContext, keyspaceActionSpecificationBeanDefinitions));
 
-		builder.addPropertyValue("poolingOptions", getSourceBeanDefinition(
-			poolingOptionsBuilder, parserContext, element));
+		builder.addPropertyValue("poolingOptions", getSourceBeanDefinition(poolingOptionsBuilder, parserContext, element));
 
 		builder.addPropertyValue("startupScripts", startupScripts);
 		builder.addPropertyValue("shutdownScripts", shutdownScripts);
@@ -182,15 +186,14 @@ public class CassandraCqlClusterParser extends AbstractBeanDefinitionParser {
 	 */
 	BeanDefinition newKeyspaceActionSpecificationBeanDefinition(Element element, ParserContext parserContext) {
 
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-			KeyspaceActionSpecificationFactoryBean.class);
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder
+				.genericBeanDefinition(KeyspaceActionSpecificationFactoryBean.class);
 
 		// add required replication defaults
-		addRequiredPropertyValue(builder, "replicationStrategy",
-			KeyspaceAttributes.DEFAULT_REPLICATION_STRATEGY.name());
+		addRequiredPropertyValue(builder, "replicationStrategy", KeyspaceAttributes.DEFAULT_REPLICATION_STRATEGY.name());
 
 		addRequiredPropertyValue(builder, "replicationFactor",
-			String.valueOf(KeyspaceAttributes.DEFAULT_REPLICATION_FACTOR));
+				String.valueOf(KeyspaceAttributes.DEFAULT_REPLICATION_FACTOR));
 
 		addRequiredPropertyValue(builder, "name", element, "name");
 		addOptionalPropertyValue(builder, "durableWrites", element, "durable-writes", "false");
@@ -214,10 +217,10 @@ public class CassandraCqlClusterParser extends AbstractBeanDefinitionParser {
 
 		if (element != null) {
 			addOptionalPropertyValue(builder, "replicationStrategy", element, "class",
-				KeyspaceAttributes.DEFAULT_REPLICATION_STRATEGY.name());
+					KeyspaceAttributes.DEFAULT_REPLICATION_STRATEGY.name());
 
 			addOptionalPropertyValue(builder, "replicationFactor", element, "replication-factor",
-				String.valueOf(KeyspaceAttributes.DEFAULT_REPLICATION_FACTOR));
+					String.valueOf(KeyspaceAttributes.DEFAULT_REPLICATION_FACTOR));
 
 			// DataCenters only apply to NetworkTopologyStrategy
 			for (Element dataCenter : DomUtils.getChildElementsByTagName(element, "data-center")) {
@@ -241,8 +244,8 @@ public class CassandraCqlClusterParser extends AbstractBeanDefinitionParser {
 	Object newKeyspaceSetFlattenerBeanDefinition(Element element, ParserContext parserContext,
 			ManagedSet<BeanDefinition> keyspaceActionSpecificationBeanDefinitions) {
 
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-			MultiLevelSetFlattenerFactoryBean.class);
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder
+				.genericBeanDefinition(MultiLevelSetFlattenerFactoryBean.class);
 
 		builder.addPropertyValue("multiLevelSet", keyspaceActionSpecificationBeanDefinitions);
 

--- a/spring-cql/src/main/java/org/springframework/cassandra/config/xml/CassandraCqlSessionParser.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/xml/CassandraCqlSessionParser.java
@@ -15,9 +15,7 @@
  */
 package org.springframework.cassandra.config.xml;
 
-import static org.springframework.cassandra.config.xml.ParsingUtils.addOptionalPropertyReference;
-import static org.springframework.cassandra.config.xml.ParsingUtils.addRequiredPropertyReference;
-import static org.springframework.cassandra.config.xml.ParsingUtils.addRequiredPropertyValue;
+import static org.springframework.cassandra.config.xml.ParsingUtils.*;
 
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -39,11 +37,17 @@ import org.w3c.dom.NamedNodeMap;
  */
 public class CassandraCqlSessionParser extends AbstractSingleBeanDefinitionParser {
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser#getBeanClass(org.w3c.dom.Element)
+	 */
 	@Override
 	protected Class<?> getBeanClass(Element element) {
 		return CassandraCqlSessionFactoryBean.class;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractBeanDefinitionParser#resolveId(org.w3c.dom.Element, org.springframework.beans.factory.support.AbstractBeanDefinition, org.springframework.beans.factory.xml.ParserContext)
+	 */
 	@Override
 	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
 			throws BeanDefinitionStoreException {
@@ -67,10 +71,13 @@ public class CassandraCqlSessionParser extends AbstractSingleBeanDefinitionParse
 	 */
 	protected void parseUnhandledSessionElementAttribute(Attr attribute, ParserContext parserContext,
 			BeanDefinitionBuilder builder) {
-		throw new IllegalStateException(String.format("encountered unhandled session element attribute [%s]",
-				attribute.getName()));
+		throw new IllegalStateException(
+				String.format("encountered unhandled session element attribute [%s]", attribute.getName()));
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser#doParse(org.w3c.dom.Element, org.springframework.beans.factory.xml.ParserContext, org.springframework.beans.factory.support.BeanDefinitionBuilder)
+	 */
 	@Override
 	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
 
@@ -108,7 +115,8 @@ public class CassandraCqlSessionParser extends AbstractSingleBeanDefinitionParse
 		}
 	}
 
-	protected void parseSessionChildElements(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+	protected void parseSessionChildElements(Element element, ParserContext parserContext,
+			BeanDefinitionBuilder builder) {
 
 		for (Element child : DomUtils.getChildElements(element)) {
 

--- a/spring-cql/src/main/java/org/springframework/cassandra/config/xml/CassandraCqlTemplateParser.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/xml/CassandraCqlTemplateParser.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.cassandra.config.xml;
 
-import static org.springframework.cassandra.config.xml.ParsingUtils.addOptionalPropertyReference;
+import static org.springframework.cassandra.config.xml.ParsingUtils.*;
 
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -34,11 +34,17 @@ import org.w3c.dom.Element;
  */
 public class CassandraCqlTemplateParser extends AbstractSingleBeanDefinitionParser {
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser#getBeanClass(org.w3c.dom.Element)
+	 */
 	@Override
 	protected Class<?> getBeanClass(Element element) {
 		return CassandraCqlTemplateFactoryBean.class;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractBeanDefinitionParser#resolveId(org.w3c.dom.Element, org.springframework.beans.factory.support.AbstractBeanDefinition, org.springframework.beans.factory.xml.ParserContext)
+	 */
 	@Override
 	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
 			throws BeanDefinitionStoreException {
@@ -47,6 +53,9 @@ public class CassandraCqlTemplateParser extends AbstractSingleBeanDefinitionPars
 		return StringUtils.hasText(id) ? id : DefaultCqlBeanNames.TEMPLATE;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser#doParse(org.w3c.dom.Element, org.springframework.beans.factory.xml.ParserContext, org.springframework.beans.factory.support.BeanDefinitionBuilder)
+	 */
 	@Override
 	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
 		addOptionalPropertyReference(builder, "session", element, "session-ref", DefaultCqlBeanNames.SESSION);

--- a/spring-cql/src/main/java/org/springframework/cassandra/config/xml/CassandraNamespaceHandler.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/xml/CassandraNamespaceHandler.java
@@ -25,6 +25,9 @@ import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
  */
 public class CassandraNamespaceHandler extends NamespaceHandlerSupport {
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.NamespaceHandler#init()
+	 */
 	@Override
 	public void init() {
 

--- a/spring-cql/src/main/java/org/springframework/cassandra/config/xml/DefaultCqlBeanNames.java
+++ b/spring-cql/src/main/java/org/springframework/cassandra/config/xml/DefaultCqlBeanNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ package org.springframework.cassandra.config.xml;
  */
 public interface DefaultCqlBeanNames {
 
-	public static final String CLUSTER = "cassandraCluster";
-	public static final String SESSION = "cassandraSession";
-	public static final String TEMPLATE = "cqlTemplate";
+	String CLUSTER = "cassandraCluster";
+	String SESSION = "cassandraSession";
+	String TEMPLATE = "cqlTemplate";
 }

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-290-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-290-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/BeanDefinitionUtils.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/BeanDefinitionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2016 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,15 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.util.StringUtils;
 
+/**
+ * Utilities to lookup {@link BeanDefinition bean definitions} for a {@link ListableBeanFactory} and to conditionally
+ * register {@link BeanDefinition bean definitions}.
+ *
+ * @author Matthew Adams
+ * @author Mark Paluch
+ * @deprecated Will be removed with the next major release.
+ */
+@Deprecated
 public class BeanDefinitionUtils {
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/BeanDefinitionUtils.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/BeanDefinitionUtils.java
@@ -152,7 +152,7 @@ public class BeanDefinitionUtils {
 				try {
 					beanDefinition = registry.getBeanDefinition(name);
 				} catch (NoSuchBeanDefinitionException x) {
-					if (FactoryBean.class.isAssignableFrom(type)) { // try unmangled BeanFactory-prefixed name
+					if (FactoryBean.class.isAssignableFrom(type)) { // try unmanged BeanFactory-prefixed name
 						name = name.substring(BeanFactory.FACTORY_BEAN_PREFIX.length());
 					} else {
 						throw x;

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2016 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,34 +15,38 @@
  */
 package org.springframework.data.cassandra.config;
 
-import static org.springframework.data.cassandra.config.BeanDefinitionUtils.getBeanDefinitionsOfType;
+import static org.springframework.data.cassandra.config.BeanDefinitionUtils.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.data.cassandra.convert.CassandraConverter;
 import org.springframework.data.cassandra.convert.MappingCassandraConverter;
 import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.data.cassandra.core.CassandraTemplate;
-import org.springframework.data.cassandra.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.mapping.BasicCassandraMappingContext;
+import org.springframework.data.cassandra.mapping.CassandraMappingContext;
 import org.springframework.util.StringUtils;
 
 import com.datastax.driver.core.Session;
 
 /**
- * {@link BeanDefinitionRegistryPostProcessor} that does its best to register any missing Spring Data Cassandra beans
- * that can be defaulted. Specifically, it attempts to create default bean definitions for the following required
- * interface types via their default implementation types:
+ * {@link BeanFactoryPostProcessor} that does its best to register any missing Spring Data Cassandra beans that can be
+ * defaulted. Specifically, it attempts to create default bean definitions for the following required interface types
+ * via their default implementation types:
  * <ul>
  * <li>{@link CassandraOperations} via {@link CassandraTemplate}</li>
  * <li>{@link CassandraMappingContext} via {@link BasicCassandraMappingContext}</li>
- * <li> {@link CassandraConverter} via {@link MappingCassandraConverter}</li>
+ * <li>{@link CassandraConverter} via {@link MappingCassandraConverter}</li>
  * </ul>
  * <p/>
  * If there are multiple definitions for any type that another type depends on, an {@link IllegalStateException} is
@@ -57,59 +61,53 @@ import com.datastax.driver.core.Session;
  * It requires that a single {@link Session} or {@link CassandraSessionFactoryBean} definition be present. As described
  * above, multiple {@link Session} definitions, multiple {@link CassandraSessionFactoryBean} definitions, or both a
  * {@link Session} and {@link CassandraSessionFactoryBean} will cause an {@link IllegalStateException} to be thrown.
- * 
+ *
  * @author Matthew T. Adams
+ * @author Mark Paluch
+ * @deprecated Will be removed with the next major release. Spring Data Cassandra is not the best place to apply
+ *             configuration defaults.
  */
-public class CassandraMappingBeanFactoryPostProcessor implements BeanDefinitionRegistryPostProcessor {
-
-	/**
-	 * Does nothing.
-	 */
-	@Override
-	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {}
+@Deprecated
+public class CassandraMappingBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
 
 	/**
 	 * Ensures that {@link BeanDefinition}s for a {@link CassandraMappingContext} and a {@link CassandraConverter} exist.
 	 */
 	@Override
-	public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+	public void postProcessBeanFactory(ConfigurableListableBeanFactory factory) throws BeansException {
 
-		if (!(registry instanceof ListableBeanFactory)) {
+		if (!(factory instanceof BeanDefinitionRegistry)) {
 			return;
 		}
-		ListableBeanFactory factory = (ListableBeanFactory) registry;
 
-		registerMissingDefaultableBeanDefinitions(registry, factory);
+		registerMissingDefaultableBeanDefinitions((BeanDefinitionRegistry) factory, factory);
 	}
 
-	protected void registerMissingDefaultableBeanDefinitions(BeanDefinitionRegistry registry, ListableBeanFactory factory) {
+	private void registerMissingDefaultableBeanDefinitions(BeanDefinitionRegistry registry, ListableBeanFactory factory) {
 
 		// see if any template definitions exist, which requires a converter, which requires a mapping context
 		BeanDefinitionHolder[] templateBeans = getBeanDefinitionsOfType(registry, factory, CassandraOperations.class, true,
-				false);
+				true);
 
 		if (templateBeans.length >= 1) {
 			return;
 		}
 
 		// need a session & converter for the default template
-
 		// see if an actual Session definition exists
 		String sessionBeanName = findSessionBeanName(registry, factory);
 
 		// see if any converter bean definitions exist, which requires a mapping context
-		BeanDefinitionHolder[] converterBeans = getBeanDefinitionsOfType(registry, factory,
-				MappingCassandraConverter.class, true, false);
+		BeanDefinitionHolder[] converterBeans = getBeanDefinitionsOfType(registry, factory, MappingCassandraConverter.class,
+				true, false);
+
+		if (converterBeans.length > 1) {
+			throw createAmbiguousBeansException(converterBeans.length, CassandraConverter.class, CassandraTemplate.class);
+		}
 
 		if (converterBeans.length == 1) {
-
 			registerDefaultTemplate(registry, sessionBeanName, converterBeans[0].getBeanName());
 			return;
-		} else if (converterBeans.length > 1) {
-			// then throw, because we need to create a default converter, but we wouldn't know which mapping context to use
-			throw new IllegalStateException(String.format(
-					"found %d beans of type [%s] - can't disambiguate for creation of [%s]", converterBeans.length,
-					CassandraConverter.class.getName(), CassandraTemplate.class.getName()));
 		}
 
 		// see if any mapping context bean definitions exist
@@ -118,84 +116,85 @@ public class CassandraMappingBeanFactoryPostProcessor implements BeanDefinitionR
 
 		if (contextBeans.length > 1) {
 			// then throw, because we need to create a default converter, but we wouldn't know which mapping context to use
-			throw new IllegalStateException(String.format(
-					"found %d beans of type [%s] - can't disambiguate for creation of [%s]", contextBeans.length,
-					CassandraMappingContext.class.getName(), MappingCassandraConverter.class.getName()));
+			throw createAmbiguousBeansException(contextBeans.length, MappingCassandraConverter.class,
+					CassandraMappingContext.class);
 		}
 
 		// create the mapping context if necessary
-		BeanDefinitionHolder contextBean = contextBeans.length == 1 ? contextBeans[0] : null;
-		if (contextBean == null) {
-			contextBean = regsiterDefaultContext(registry);
-		}
+		BeanDefinitionHolder contextBean = contextBeans.length == 1 ? contextBeans[0] : registerDefaultContext(registry);
 
 		// create the default converter & template bean definitions
 		BeanDefinitionHolder converter = registerDefaultConverter(registry, contextBean.getBeanName());
 		registerDefaultTemplate(registry, sessionBeanName, converter.getBeanName());
 	}
 
-	public String findSessionBeanName(BeanDefinitionRegistry registry, ListableBeanFactory factory) {
+	private String findSessionBeanName(BeanDefinitionRegistry registry, ListableBeanFactory factory) {
 
 		// first, search for any session and session factory beans
-		BeanDefinitionHolder[] sessionBeans = getBeanDefinitionsOfType(registry, factory, Session.class, true, false);
-		BeanDefinitionHolder[] sessionFactoryBeans = getBeanDefinitionsOfType(registry, factory,
-				CassandraSessionFactoryBean.class, true, false);
+		BeanDefinitionHolder[] sessionBeans = getBeanDefinitionsOfType(registry, factory, Session.class, true, true);
 
-		int sessionCount = sessionBeans.length;
-		int sessionFactoryCount = sessionFactoryBeans.length;
-		int totalCount = sessionCount + sessionFactoryCount;
-
-		if (totalCount == 0 || totalCount > 1) { // can't create default template -- none or multiple
-			throw createSessionException(totalCount, Session.class, CassandraSessionFactoryBean.class);
-		}
-
-		if (sessionCount == 1) {
+		if (sessionBeans.length == 1) { // can't create default template -- none or multiple
 			return sessionBeans[0].getBeanName();
 		}
-		// else it must be the one session factory bean
-		return sessionFactoryBeans[0].getBeanName();
+
+		throw createAmbiguousBeansException(sessionBeans.length, CassandraTemplate.class, Session.class,
+				CassandraSessionFactoryBean.class);
 	}
 
-	protected IllegalStateException createSessionException(int beanDefinitionCount, Class<?>... types) {
+	private IllegalStateException createAmbiguousBeansException(int beanDefinitionCount, Class<?> defaultBeanType,
+			Class<?>... types) {
 
-		return new IllegalStateException(String.format("found %d beans of type%s [%s] - %s for creation of default [%s]",
-				beanDefinitionCount, beanDefinitionCount == 1 ? "" : "s", StringUtils.arrayToCommaDelimitedString(types),
-				beanDefinitionCount == 0 ? "need exactly one" : "can't disambiguate", CassandraTemplate.class.getName()));
+		return new IllegalStateException(
+				String.format("found %d beans of type%s [%s] - %s for creation of default [%s]", beanDefinitionCount,
+						beanDefinitionCount == 1 ? "" : "s", StringUtils.collectionToCommaDelimitedString(getNames(types)),
+						beanDefinitionCount == 0 ? "need exactly one" : "can't disambiguate", defaultBeanType.getName()));
 	}
 
-	protected BeanDefinitionHolder regsiterDefaultContext(BeanDefinitionRegistry registry) {
+	private BeanDefinitionHolder registerDefaultContext(BeanDefinitionRegistry registry) {
 
-		BeanDefinitionHolder contextBean = new BeanDefinitionHolder(BeanDefinitionBuilder.genericBeanDefinition(
-				BasicCassandraMappingContext.class).getBeanDefinition(), DefaultBeanNames.CONTEXT);
+		BeanDefinitionHolder contextBean = new BeanDefinitionHolder(
+				BeanDefinitionBuilder.genericBeanDefinition(BasicCassandraMappingContext.class).getBeanDefinition(),
+				DefaultBeanNames.CONTEXT);
 
 		registry.registerBeanDefinition(contextBean.getBeanName(), contextBean.getBeanDefinition());
 
 		return contextBean;
 	}
 
-	public BeanDefinitionHolder registerDefaultConverter(BeanDefinitionRegistry registry, String contextBeanName) {
+	private BeanDefinitionHolder registerDefaultConverter(BeanDefinitionRegistry registry, String contextBeanName) {
 
-		BeanDefinitionBuilder converterBeanDefinitionBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-				MappingCassandraConverter.class).addConstructorArgReference(contextBeanName);
-		BeanDefinitionHolder beanDefinition = new BeanDefinitionHolder(converterBeanDefinitionBuilder.getBeanDefinition(),
-				DefaultBeanNames.CONVERTER);
+		BeanDefinition beanDefinition = BeanDefinitionBuilder //
+				.genericBeanDefinition(MappingCassandraConverter.class) //
+				.addConstructorArgReference(contextBeanName).getBeanDefinition();
 
-		registry.registerBeanDefinition(beanDefinition.getBeanName(), beanDefinition.getBeanDefinition());
+		BeanDefinitionHolder converter = new BeanDefinitionHolder(beanDefinition, DefaultBeanNames.CONVERTER);
+		registry.registerBeanDefinition(converter.getBeanName(), converter.getBeanDefinition());
 
-		return beanDefinition;
+		return converter;
 	}
 
-	public BeanDefinitionHolder registerDefaultTemplate(BeanDefinitionRegistry registry, String sessionBeanName,
+	private BeanDefinitionHolder registerDefaultTemplate(BeanDefinitionRegistry registry, String sessionBeanName,
 			String converterBeanName) {
 
-		BeanDefinitionBuilder templateBeanDefinitionBuilder = BeanDefinitionBuilder
-				.genericBeanDefinition(CassandraTemplate.class).addConstructorArgReference(sessionBeanName)
-				.addConstructorArgReference(converterBeanName);
-		BeanDefinition beanDefinition = templateBeanDefinitionBuilder.getBeanDefinition();
+		BeanDefinition beanDefinition = BeanDefinitionBuilder.genericBeanDefinition(CassandraTemplate.class) //
+				.addConstructorArgReference(sessionBeanName) //
+				.addConstructorArgReference(converterBeanName) //
+				.getBeanDefinition();
 
 		BeanDefinitionHolder template = new BeanDefinitionHolder(beanDefinition, DefaultBeanNames.TEMPLATE);
 		registry.registerBeanDefinition(template.getBeanName(), template.getBeanDefinition());
 
 		return template;
+	}
+
+	private Collection<String> getNames(Class<?>[] types) {
+
+		List<String> names = new ArrayList<String>();
+
+		for (Class<?> type : types) {
+			names.add(type.getName());
+		}
+
+		return names;
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBean.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBean.java
@@ -42,7 +42,9 @@ public class CassandraSessionFactoryBean extends CassandraCqlSessionFactoryBean 
 	protected static final boolean DEFAULT_DROP_UNUSED_TABLES = false;
 
 	private CassandraAdminOperations admin;
+
 	private CassandraConverter converter;
+
 	private SchemaAction schemaAction = SchemaAction.NONE;
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraTemplateFactoryBean.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraTemplateFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2017 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,45 +18,84 @@ package org.springframework.data.cassandra.config;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.data.cassandra.convert.CassandraConverter;
-import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.data.cassandra.core.CassandraTemplate;
 import org.springframework.util.Assert;
 
 import com.datastax.driver.core.Session;
 
-public class CassandraTemplateFactoryBean implements FactoryBean<CassandraOperations>, InitializingBean {
+/**
+ * Factory for configuring a {@link CassandraTemplate}.
+ *
+ * @author Matthew T. Adams
+ * @author Mark Paluch
+ */
+public class CassandraTemplateFactoryBean implements FactoryBean<CassandraTemplate>, InitializingBean {
 
 	protected Session session;
+
 	protected CassandraConverter converter;
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(session);
-		Assert.notNull(converter);
+
+		Assert.notNull(session, "Session must not be null");
+		Assert.notNull(converter, "Converter must not be null");
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.FactoryBean#getObject()
+	 */
 	@Override
-	public CassandraOperations getObject() throws Exception {
+	public CassandraTemplate getObject() throws Exception {
 		return new CassandraTemplate(session, converter);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.FactoryBean#getObjectType()
+	 */
 	@Override
-	public Class<?> getObjectType() {
-		return CassandraOperations.class;
+	public Class<CassandraTemplate> getObjectType() {
+		return CassandraTemplate.class;
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.FactoryBean#isSingleton()
+	 */
 	@Override
 	public boolean isSingleton() {
 		return true;
 	}
 
+	/**
+	 * Sets the Cassandra {@link Session} to use. The {@link CassandraTemplate} will use the logged keyspace of the
+	 * underlying {@link Session}. Don't change the keyspace using CQL but use multiple {@link Session} and
+	 * {@link CassandraTemplate} beans.
+	 * 
+	 * @param session must not be {@literal null}.
+	 */
 	public void setSession(Session session) {
-		Assert.notNull(session);
+
+		Assert.notNull(session, "Session must not be null");
+
 		this.session = session;
 	}
 
+	/**
+	 * Set the {@link CassandraConverter} to use.
+	 * 
+	 * @param converter must not be {@literal null}.
+	 */
 	public void setConverter(CassandraConverter converter) {
-		Assert.notNull(converter);
+
+		Assert.notNull(converter, "Converter must not be null");
+
 		this.converter = converter;
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/DefaultBeanNames.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/DefaultBeanNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2017 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@ package org.springframework.data.cassandra.config;
 
 import org.springframework.cassandra.config.xml.DefaultCqlBeanNames;
 
+/**
+ * @author Matthew T. Adams
+ * @author Mark Paluch
+ */
 public interface DefaultBeanNames extends DefaultCqlBeanNames {
 
-	public static final String DATA_TEMPLATE = "cassandraTemplate";
-	public static final String CONVERTER = "cassandraConverter";
-	public static final String CONTEXT = "cassandraMapping";
-	public static final String USER_TYPE_RESOLVER = "userTypeResolver";
+	String DATA_TEMPLATE = "cassandraTemplate";
+	String CONVERTER = "cassandraConverter";
+	String CONTEXT = "cassandraMapping";
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraClusterParser.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraClusterParser.java
@@ -21,12 +21,16 @@ import org.springframework.cassandra.config.xml.CassandraCqlClusterParser;
 import org.w3c.dom.Element;
 
 /**
- * Spring Data Cassandra XML namespace parser for the &lt;cluster&gt; element.
+ * Spring Data Cassandra XML namespace parser for the {@code cassandra:cluster} element.
  * 
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
 public class CassandraClusterParser extends CassandraCqlClusterParser {
 
+	/* (non-Javadoc)
+	 * @see org.springframework.cassandra.config.xml.CassandraCqlClusterParser#parseInternal(org.w3c.dom.Element, org.springframework.beans.factory.xml.ParserContext)
+	 */
 	@Override
 	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraMappingContextParser.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraMappingContextParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors
+ * Copyright 2013-2017 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,17 +41,24 @@ import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
 
 /**
- * Spring Data Cassandra XML namespace parser for the &lt;mapping&gt; element.
+ * Spring Data Cassandra XML namespace parser for the {@code cassandra:mapping} element.
  *
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
 public class CassandraMappingContextParser extends AbstractSingleBeanDefinitionParser {
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser#getBeanClass(org.w3c.dom.Element)
+	 */
 	@Override
 	protected Class<?> getBeanClass(Element element) {
 		return BasicCassandraMappingContext.class;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractBeanDefinitionParser#resolveId(org.w3c.dom.Element, org.springframework.beans.factory.support.AbstractBeanDefinition, org.springframework.beans.factory.xml.ParserContext)
+	 */
 	@Override
 	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
 			throws BeanDefinitionStoreException {
@@ -61,6 +68,9 @@ public class CassandraMappingContextParser extends AbstractSingleBeanDefinitionP
 		return (StringUtils.hasText(id) ? id : DefaultBeanNames.CONTEXT);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser#doParse(org.w3c.dom.Element, org.springframework.beans.factory.xml.ParserContext, org.springframework.beans.factory.support.BeanDefinitionBuilder)
+	 */
 	@Override
 	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
 
@@ -75,14 +85,13 @@ public class CassandraMappingContextParser extends AbstractSingleBeanDefinitionP
 
 		if (StringUtils.hasText(packages)) {
 			try {
-				Set<Class<?>> entityClasses = CassandraEntityClassScanner.scan(
-					StringUtils.commaDelimitedListToStringArray(packages));
+				Set<Class<?>> entityClasses = CassandraEntityClassScanner
+						.scan(StringUtils.commaDelimitedListToStringArray(packages));
 
 				builder.addPropertyValue("initialEntitySet", entityClasses);
 			} catch (Exception x) {
 				throw new IllegalArgumentException(
-						String.format("encountered exception while scanning for entity classes in package(s) [%s]",
-							packages), x);
+						String.format("encountered exception while scanning for entity classes in package(s) [%s]", packages), x);
 			}
 		}
 
@@ -105,7 +114,7 @@ public class CassandraMappingContextParser extends AbstractSingleBeanDefinitionP
 			builder.addPropertyReference("userTypeResolver", userTypeResolverRef);
 		}
 
-		if (!userTypeResolvers.isEmpty()){
+		if (!userTypeResolvers.isEmpty()) {
 			BeanDefinition userTypeResolver = parseUserTypeResolver(userTypeResolvers.get(0));
 			builder.addPropertyValue("userTypeResolver", userTypeResolver);
 		}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraMappingConverterParser.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraMappingConverterParser.java
@@ -26,17 +26,24 @@ import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
 /**
- * Spring Data Cassandra XML namespace parser for the &lt;converter&gt; element.
+ * Spring Data Cassandra XML namespace parser for the {@code cassandra:converter} element.
  * 
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
 public class CassandraMappingConverterParser extends AbstractSingleBeanDefinitionParser {
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser#getBeanClass(org.w3c.dom.Element)
+	 */
 	@Override
 	protected Class<?> getBeanClass(Element element) {
 		return MappingCassandraConverter.class;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractBeanDefinitionParser#resolveId(org.w3c.dom.Element, org.springframework.beans.factory.support.AbstractBeanDefinition, org.springframework.beans.factory.xml.ParserContext)
+	 */
 	@Override
 	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
 			throws BeanDefinitionStoreException {
@@ -45,6 +52,9 @@ public class CassandraMappingConverterParser extends AbstractSingleBeanDefinitio
 		return StringUtils.hasText(id) ? id : DefaultBeanNames.CONVERTER;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser#doParse(org.w3c.dom.Element, org.springframework.beans.factory.xml.ParserContext, org.springframework.beans.factory.support.BeanDefinitionBuilder)
+	 */
 	@Override
 	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraNamespaceHandler.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraNamespaceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2017 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.cassandra.config.xml;
 
 import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
@@ -25,17 +24,22 @@ import org.springframework.data.repository.config.RepositoryBeanDefinitionParser
  *
  * @author Alex Shvid
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
 public class CassandraNamespaceHandler extends NamespaceHandlerSupport {
 
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.xml.NamespaceHandler#init()
+	 */
 	@Override
 	public void init() {
+
 		registerBeanDefinitionParser("cluster", new CassandraClusterParser());
 		registerBeanDefinitionParser("session", new CassandraSessionParser());
 		registerBeanDefinitionParser("template", new CassandraTemplateParser());
 		registerBeanDefinitionParser("converter", new CassandraMappingConverterParser());
 		registerBeanDefinitionParser("mapping", new CassandraMappingContextParser());
-		registerBeanDefinitionParser("repositories", new RepositoryBeanDefinitionParser(
-			new CassandraRepositoryConfigurationExtension()));
+		registerBeanDefinitionParser("repositories",
+				new RepositoryBeanDefinitionParser(new CassandraRepositoryConfigurationExtension()));
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraSessionParser.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraSessionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2017 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package org.springframework.data.cassandra.config.xml;
 
-import static org.springframework.cassandra.config.xml.ParsingUtils.addOptionalPropertyReference;
-import static org.springframework.cassandra.config.xml.ParsingUtils.addOptionalPropertyValue;
-import static org.springframework.cassandra.config.xml.ParsingUtils.addRequiredPropertyReference;
-import static org.springframework.cassandra.config.xml.ParsingUtils.addRequiredPropertyValue;
+import static org.springframework.cassandra.config.xml.ParsingUtils.*;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
@@ -30,17 +27,24 @@ import org.w3c.dom.Attr;
 import org.w3c.dom.Element;
 
 /**
- * Spring Data Cassandra XML namespace parser for the &lt;session&gt; element.
+ * Spring Data Cassandra XML namespace parser for the {@code cassandra:session} element.
  * 
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
 public class CassandraSessionParser extends CassandraCqlSessionParser {
 
+	/* (non-Javadoc)
+	 * @see org.springframework.cassandra.config.xml.CassandraCqlSessionParser#getBeanClass(org.w3c.dom.Element)
+	 */
 	@Override
 	protected Class<?> getBeanClass(Element element) {
 		return CassandraSessionFactoryBean.class;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.cassandra.config.xml.CassandraCqlSessionParser#doParse(org.w3c.dom.Element, org.springframework.beans.factory.xml.ParserContext, org.springframework.beans.factory.support.BeanDefinitionBuilder)
+	 */
 	@Override
 	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
 
@@ -49,6 +53,9 @@ public class CassandraSessionParser extends CassandraCqlSessionParser {
 		CassandraMappingXmlBeanFactoryPostProcessorRegistrar.ensureRegistration(element, parserContext);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.cassandra.config.xml.CassandraCqlSessionParser#parseUnhandledSessionElementAttribute(org.w3c.dom.Attr, org.springframework.beans.factory.xml.ParserContext, org.springframework.beans.factory.support.BeanDefinitionBuilder)
+	 */
 	@Override
 	protected void parseUnhandledSessionElementAttribute(Attr attribute, ParserContext parserContext,
 			BeanDefinitionBuilder builder) {
@@ -64,6 +71,9 @@ public class CassandraSessionParser extends CassandraCqlSessionParser {
 		}
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.cassandra.config.xml.CassandraCqlSessionParser#setDefaultProperties(org.springframework.beans.factory.support.BeanDefinitionBuilder)
+	 */
 	@Override
 	protected void setDefaultProperties(BeanDefinitionBuilder builder) {
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraTemplateParser.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/xml/CassandraTemplateParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2017 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,31 +20,44 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.cassandra.config.xml.CassandraCqlTemplateParser;
-import org.springframework.data.cassandra.config.DefaultBeanNames;
 import org.springframework.data.cassandra.config.CassandraTemplateFactoryBean;
+import org.springframework.data.cassandra.config.DefaultBeanNames;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
 /**
- * Spring Data Cassandra XML namespace parser for the &lt;template&gt; element.
+ * Spring Data Cassandra XML namespace parser for the {@code cassandra:template} element.
  * 
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
 public class CassandraTemplateParser extends CassandraCqlTemplateParser {
 
+	/* (non-Javadoc)
+	 * @see org.springframework.cassandra.config.xml.CassandraCqlTemplateParser#getBeanClass(org.w3c.dom.Element)
+	 */
 	@Override
 	protected Class<?> getBeanClass(Element element) {
 		return CassandraTemplateFactoryBean.class;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.cassandra.config.xml.CassandraCqlTemplateParser#resolveId(org.w3c.dom.Element, org.springframework.beans.factory.support.AbstractBeanDefinition, org.springframework.beans.factory.xml.ParserContext)
+	 */
 	@Override
 	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
 			throws BeanDefinitionStoreException {
 
+		// TODO: super.resolveId resolves always to a non-empty id because its fallback is DefaultCqlBeanNames.TEMPLATE.
+		// This also means that CassandraTemplate is exposed as bean named cqlTemplate. This should change with 2.0
+		// because 2.0 breaks up inheritance.
 		String id = super.resolveId(element, definition, parserContext);
 		return StringUtils.hasText(id) ? id : DefaultBeanNames.DATA_TEMPLATE;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.cassandra.config.xml.CassandraCqlTemplateParser#doParse(org.w3c.dom.Element, org.springframework.beans.factory.xml.ParserContext, org.springframework.beans.factory.support.BeanDefinitionBuilder)
+	 */
 	@Override
 	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/CassandraRepositoriesRegistrar.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/CassandraRepositoriesRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors
+ * Copyright 2013-2017 the original author or authors
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,11 +29,17 @@ import org.springframework.data.repository.config.RepositoryConfigurationExtensi
  */
 public class CassandraRepositoriesRegistrar extends RepositoryBeanDefinitionRegistrarSupport {
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryBeanDefinitionRegistrarSupport#getAnnotation()
+	 */
 	@Override
 	protected Class<? extends Annotation> getAnnotation() {
 		return EnableCassandraRepositories.class;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryBeanDefinitionRegistrarSupport#getExtension()
+	 */
 	@Override
 	protected RepositoryConfigurationExtension getExtension() {
 		return new CassandraRepositoryConfigurationExtension();

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/CassandraRepositoryConfigurationExtension.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/config/CassandraRepositoryConfigurationExtension.java
@@ -20,9 +20,9 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.cassandra.config.xml.DefaultCqlBeanNames;
 import org.springframework.cassandra.config.xml.ParsingUtils;
 import org.springframework.core.annotation.AnnotationAttributes;
-import org.springframework.data.cassandra.config.DefaultBeanNames;
 import org.springframework.data.cassandra.mapping.Table;
 import org.springframework.data.cassandra.repository.CassandraRepository;
 import org.springframework.data.cassandra.repository.support.CassandraRepositoryFactoryBean;
@@ -44,25 +44,38 @@ public class CassandraRepositoryConfigurationExtension extends RepositoryConfigu
 
 	private static final String CASSANDRA_TEMPLATE_REF = "cassandra-template-ref";
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#getModulePrefix()
+	 */
 	@Override
 	protected String getModulePrefix() {
 		return "cassandra";
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtension#getRepositoryFactoryClassName()
+	 */
 	@Override
 	public String getRepositoryFactoryClassName() {
 		return CassandraRepositoryFactoryBean.class.getName();
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#postProcess(org.springframework.beans.factory.support.BeanDefinitionBuilder, org.springframework.data.repository.config.XmlRepositoryConfigurationSource)
+	 */
 	@Override
 	public void postProcess(BeanDefinitionBuilder builder, XmlRepositoryConfigurationSource config) {
 
 		Element element = config.getElement();
 
+		// TODO: XML-based configuration uses a different bean name than Java config
 		ParsingUtils.addOptionalPropertyReference(builder, "cassandraTemplate", element, CASSANDRA_TEMPLATE_REF,
-				DefaultBeanNames.TEMPLATE);
+				DefaultCqlBeanNames.TEMPLATE);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#postProcess(org.springframework.beans.factory.support.BeanDefinitionBuilder, org.springframework.data.repository.config.AnnotationRepositoryConfigurationSource)
+	 */
 	@Override
 	public void postProcess(BeanDefinitionBuilder builder, AnnotationRepositoryConfigurationSource config) {
 

--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.5.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.5.xsd
@@ -818,7 +818,7 @@ The reference to a UserTypeResolver. UserTypeResolver is required when working w
 		<xsd:attribute name="cassandra-template-ref" type="cassandraTemplateRef">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The reference to a CassandraTemplate. Will default to 'cassandraTemplate'.
+The reference to a CassandraTemplate. Will default to 'cqlTemplate'.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.5.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.5.xsd
@@ -775,6 +775,13 @@ Defines a CassandraMappingContext for holding rich entity mapping information.
 				<xsd:element name="entity" type="entityType" minOccurs="0" maxOccurs="unbounded" />
 				<xsd:element name="user-type-resolver" type="userTypeResolverType" minOccurs="0" maxOccurs="1" />
 			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:ID" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	The name of the mapping context; default is "cassandraMapping".
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="entity-base-packages" type="xsd:string" use="optional">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessorTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessorTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.config;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.context.support.GenericXmlApplicationContext;
+import org.springframework.data.cassandra.convert.CassandraConverter;
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.mapping.CassandraMappingContext;
+
+import com.datastax.driver.core.Session;
+
+/**
+ * Unit tests for {@link CassandraMappingBeanFactoryPostProcessor}.
+ * 
+ * @author Mark Paluch
+ */
+public class CassandraMappingBeanFactoryPostProcessorTests {
+
+	@Rule public final ExpectedException expectedException = ExpectedException.none();
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void clusterRegistrationTriggersDefaultBeanRegistration() {
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "cluster-and-mock-session.xml");
+		context.refresh();
+
+		assertThat(context.getBeanNamesForType(CassandraOperations.class), hasItemInArray("cqlTemplate"));
+		assertThat(context.getBeanNamesForType(CassandraMappingContext.class), hasItemInArray("cassandraMapping"));
+		assertThat(context.getBeanNamesForType(CassandraConverter.class), hasItemInArray("cassandraConverter"));
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void MappingAndConverterRegistrationTriggersDefaultBeanRegistration() {
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "mock-session-mapping-converter.xml");
+		context.refresh();
+
+		assertThat(context.getBeanNamesForType(CassandraOperations.class), hasItemInArray("cqlTemplate"));
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void converterRegistrationFailsDueToMissingCassandraMapping() {
+
+		expectedException.expect(BeanCreationException.class);
+		expectedException.expectMessage(containsString("No bean named 'cassandraMapping'"));
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "mock-session-converter.xml");
+		context.refresh();
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void defaultBeanRegistrationShouldFailWithMultipleSessions() {
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage(allOf(containsString("found 2 beans of type"), containsString("Session")));
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-sessions.xml");
+		context.refresh();
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void defaultBeanRegistrationShouldFailWithMultipleSessionFactories() {
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage(allOf(containsString("found 2 beans of type"), containsString("Session")));
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-session-factories.xml");
+		context.refresh();
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void defaultBeanRegistrationShouldFailWithMultipleMappingContexts() {
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException
+				.expectMessage(allOf(containsString("found 2 beans of type"), containsString("CassandraMappingContext")));
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-mapping-contexts.xml");
+		context.refresh();
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void defaultBeanRegistrationShouldFailWithMultipleConvertersContexts() {
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException
+				.expectMessage(allOf(containsString("found 2 beans of type"), containsString("CassandraConverter")));
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-converters.xml");
+		context.refresh();
+	}
+
+	/**
+	 * @see DATACASS-290
+	 */
+	@Test
+	public void shouldAllowTwoKeyspaces() {
+
+		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
+		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "two-keyspaces-namespace.xml");
+		context.refresh();
+
+		assertThat(context.getBeanNamesForType(CassandraOperations.class), arrayContaining("c-1", "c-2"));
+		assertThat(context.getBeanNamesForType(CassandraMappingContext.class), arrayContaining("mapping-1", "mapping-2"));
+		assertThat(context.getBeanNamesForType(CassandraConverter.class), arrayContaining("converter-1", "converter-2"));
+	}
+
+	@SuppressWarnings("unused")
+	private static class MockSessionFactory extends AbstractFactoryBean<Session> {
+
+		@Override
+		public Class<?> getObjectType() {
+			return Session.class;
+		}
+
+		@Override
+		protected Session createInstance() {
+			return mock(Session.class);
+		}
+	}
+}

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/cluster-and-mock-session.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/cluster-and-mock-session.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-converter.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-converter.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<cass:converter />
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-mapping-converter.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-mapping-converter.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<cass:mapping/>
+	<cass:converter/>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-converters.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-converters.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+
+	<cass:mapping/>
+	<cass:converter/>
+
+	<bean class="org.springframework.data.cassandra.convert.MappingCassandraConverter">
+		<constructor-arg index="0" ref="cassandraMapping"/>
+	</bean>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-mapping-contexts.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-mapping-contexts.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<cass:mapping/>
+	<bean class="org.springframework.data.cassandra.mapping.BasicCassandraMappingContext"/>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-session-factories.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-session-factories.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+	<cass:session id="session-1" keyspace-name="system"/>
+	<cass:session id="session-2" keyspace-name="system"/>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-sessions.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-sessions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+	<bean id="mockSession1" class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<bean id="mockSession2" class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+
+</beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/two-keyspaces-namespace.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/two-keyspaces-namespace.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<cass:cluster/>
+
+	<bean id="keyspace-1"
+		  class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<bean id="keyspace-2"
+		  class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+
+	<cass:mapping id="mapping-1"/>
+	<cass:mapping id="mapping-2"/>
+
+	<cass:converter id="converter-1" mapping-ref="mapping-1"/>
+	<cass:converter id="converter-2" mapping-ref="mapping-2"/>
+
+	<cass:template id="c-1" cassandra-converter-ref="converter-1" session-ref="keyspace-1"/>
+	<cass:template id="c-2" cassandra-converter-ref="converter-2" session-ref="keyspace-2"/>
+
+</beans>


### PR DESCRIPTION
We now support multiple Cassandra keyspaces by allowing multiple definitions of Sessions, Mapping Contexts, Converters and `CassandraTemplate`s.

Added support for id attribute for converter and mapping context elements and adopt `CassandraMappingBeanFactoryPostProcessor` to scan with eager initialization for existing infrastructure components. 

We are lenient about the source (factory bean or concrete bean definition) for infrastructure beans (Session, Converter, Mapping Context, Template) and register only the necessary beans. This change fixes also the default `CassandraTemplate` name to `cassandraTemplate` (was: `cqlTemplate`) to reflect the documentation state.

Sample XML configuration:

``` xml
<beans … >

  <cass:cluster/>

  <cass:session id="keyspace-1" keyspace-name="keyspace-1" cassandra-converter-ref="converter-1"/>
  <cass:session id="keyspace-2" keyspace-name="keyspace-2" cassandra-converter-ref="converter-2"/>

  <cass:mapping id="mapping-1"/>
  <cass:mapping id="mapping-2"/>

  <cass:converter id="converter-1" mapping-ref="mapping-1"/>
  <cass:converter id="converter-2" mapping-ref="mapping-2"/>

  <cass:template id="c-1" cassandra-converter-ref="converter-1" session-ref="keyspace-1"/>
  <cass:template id="c-2" cassandra-converter-ref="converter-2" session-ref="keyspace-2"/>

</beans>
```

---

Related ticket: [DATACASS-290](https://jira.spring.io/browse/DATACASS-290)
