### PR TITLE
Fix typo in documentation

### DIFF
--- a/src/main/asciidoc/reference/cassandra.adoc
+++ b/src/main/asciidoc/reference/cassandra.adoc
@@ -175,7 +175,7 @@ After the initial release of Spring Data for Apache Cassandra 1.0.0, we will sta
 [[cassandra-connectors.ext_properties]]
 === Externalize Connection Properties
 
-Create a properties file with the information you need to connect to Cassandra. The contact points are keyspace are the minimal required fields, but port is added here for clarity.
+Create a properties file with the information you need to connect to Cassandra. The contact points and keyspace are the minimal required fields, but port is added here for clarity.
 
 We will call this cassandra.properties
 


### PR DESCRIPTION
I believe this should read `the contact points *and* keyspace`, because as far as I know, it is not possible for a contact points to be a keyspace.

I searched around for a better place to make this change, since this appears to have been generated from some other source (since this typo appears verbatim in an aerospike repository as well), but I couldn't find any such source.