### PR TITLE
DATACASS-357 - IN query converts collection arguments to singular value.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>1.5.0.BUILD-SNAPSHOT</version>
+	<version>1.5.0.DATACASS-357-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-357-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-357-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-357-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/CassandraConverter.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/CassandraConverter.java
@@ -19,6 +19,7 @@ import org.springframework.data.cassandra.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.mapping.CassandraPersistentEntity;
 import org.springframework.data.cassandra.mapping.CassandraPersistentProperty;
 import org.springframework.data.convert.EntityConverter;
+import org.springframework.data.util.TypeInformation;
 
 /**
  * Central Cassandra specific converter interface from Object to Row.
@@ -61,6 +62,16 @@ public interface CassandraConverter
 	 * @param entity must not be {@literal null}.
 	 */
 	void write(Object source, Object sink, CassandraPersistentEntity<?> entity);
+
+	/**
+	 * Converts the given object into one Cassandra will be able to store natively in a column.
+	 *
+	 * @param obj can be {@literal null}.
+	 * @param typeInformation must not be {@literal null}.
+	 * @return
+	 * @since 1.5
+	 */
+	Object convertToCassandraColumn(Object obj, TypeInformation<?> typeInformation);
 
 	/**
 	 * Returns the {@link CustomConversions} registered in the {@link CassandraConverter}.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/CustomConversions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/convert/CustomConversions.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.cassandra.convert;
 
 import java.util.ArrayList;
@@ -135,9 +134,7 @@ public class CustomConversions {
 	 * @return
 	 */
 	public boolean isSimpleType(Class<?> type) {
-
-		// Enums have no native Cassandra support
-		return (!type.isEnum() && simpleTypeHolder.isSimpleType(type));
+		return simpleTypeHolder.isSimpleType(type);
 	}
 
 	/**

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/convert/MappingCassandraConverterUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/convert/MappingCassandraConverterUnitTests.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.cassandra.convert;
 
 import static org.assertj.core.api.Assertions.*;
@@ -68,7 +67,6 @@ import org.springframework.data.cassandra.mapping.Table;
 import org.springframework.data.util.Version;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.datastax.driver.core.ColumnDefinitions;
 import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.DataType.Name;
 import com.datastax.driver.core.LocalDate;
@@ -96,8 +94,6 @@ public class MappingCassandraConverterUnitTests {
 	private static final Version VERSION_4_3 = Version.parse("4.3");
 
 	@Rule public final ExpectedException expectedException = ExpectedException.none();
-
-	@Mock private ColumnDefinitions columnDefinitionsMock;
 
 	@Mock private Row rowMock;
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/ConvertingParameterAccessorUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/ConvertingParameterAccessorUnitTests.java
@@ -33,6 +33,8 @@ import org.springframework.data.cassandra.mapping.BasicCassandraMappingContext;
 import org.springframework.data.cassandra.mapping.CassandraPersistentProperty;
 import org.springframework.data.cassandra.mapping.CassandraType;
 import org.springframework.data.cassandra.repository.query.ConvertingParameterAccessor.PotentiallyConvertingIterator;
+import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.data.util.TypeInformation;
 
 import com.datastax.driver.core.DataType;
 
@@ -45,16 +47,15 @@ import com.datastax.driver.core.DataType;
 @RunWith(MockitoJUnitRunner.class)
 public class ConvertingParameterAccessorUnitTests {
 
-	@Mock private CassandraParameterAccessor mockParameterAccessor;
-
-	@Mock private CassandraPersistentProperty mockProperty;
+	@Mock CassandraParameterAccessor mockParameterAccessor;
+	@Mock CassandraPersistentProperty mockProperty;
 
 	ConvertingParameterAccessor convertingParameterAccessor;
-
 	MappingCassandraConverter converter;
 
 	@Before
 	public void setUp() {
+
 		this.converter = new MappingCassandraConverter(new BasicCassandraMappingContext());
 		this.converter.afterPropertiesSet();
 		this.convertingParameterAccessor = new ConvertingParameterAccessor(converter, mockParameterAccessor);
@@ -77,6 +78,7 @@ public class ConvertingParameterAccessorUnitTests {
 	@Test
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void shouldReturnNativeBindableValue() {
+
 		when(mockParameterAccessor.getBindableValue(0)).thenReturn("hello");
 		when(mockParameterAccessor.getDataType(0)).thenReturn(DataType.varchar());
 		when(mockParameterAccessor.getParameterType(0)).thenReturn((Class) String.class);
@@ -95,6 +97,7 @@ public class ConvertingParameterAccessorUnitTests {
 	@Test
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void shouldReturnConvertedBindableValue() {
+
 		LocalDate localDate = LocalDate.of(2010, 7, 4);
 
 		when(mockParameterAccessor.getBindableValue(0)).thenReturn(localDate);
@@ -110,6 +113,7 @@ public class ConvertingParameterAccessorUnitTests {
 	 */
 	@Test
 	public void shouldReturnDataTypeProvidedByDelegate() {
+
 		when(mockParameterAccessor.getDataType(0)).thenReturn(DataType.varchar());
 
 		assertThat(convertingParameterAccessor.getDataType(0)).isEqualTo(DataType.varchar());
@@ -122,15 +126,12 @@ public class ConvertingParameterAccessorUnitTests {
 	@Test
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void shouldConvertCollections() {
+
 		LocalDate localDate = LocalDate.of(2010, 7, 4);
 
 		when(mockParameterAccessor.iterator())
 				.thenReturn((Iterator) Collections.singletonList(Collections.singletonList(localDate)).iterator());
-		when(mockParameterAccessor.getDataType(0)).thenReturn(DataType.list(DataType.date()));
-		when(mockParameterAccessor.getParameterType(0)).thenReturn((Class) List.class);
-		when(mockProperty.getType()).thenReturn((Class) List.class);
-		when(mockProperty.getActualType()).thenReturn((Class) LocalDate.class);
-		when(mockProperty.isCollectionLike()).thenReturn(true);
+		when(mockProperty.getTypeInformation()).thenReturn((TypeInformation) ClassTypeInformation.LIST);
 
 		PotentiallyConvertingIterator iterator = (PotentiallyConvertingIterator) convertingParameterAccessor.iterator();
 		Object converted = iterator.nextConverted(mockProperty);
@@ -148,6 +149,7 @@ public class ConvertingParameterAccessorUnitTests {
 	@Test
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void shouldProvideTypeBasedOnValue() {
+
 		when(mockParameterAccessor.getDataType(0)).thenReturn(null);
 		when(mockParameterAccessor.getParameterType(0)).thenReturn((Class) LocalDate.class);
 
@@ -160,10 +162,10 @@ public class ConvertingParameterAccessorUnitTests {
 	@Test
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void shouldProvideTypeBasedOnPropertyType() {
+
 		when(mockProperty.getDataType()).thenReturn(DataType.varchar());
 		when(mockProperty.findAnnotation(CassandraType.class)).thenReturn(mock(CassandraType.class));
 		when(mockParameterAccessor.getParameterType(0)).thenReturn((Class) String.class);
-		when(mockParameterAccessor.getDataType(0)).thenReturn(null);
 
 		assertThat(convertingParameterAccessor.getDataType(0, mockProperty)).isEqualTo(DataType.varchar());
 	}


### PR DESCRIPTION
Previously, query method parameter conversion was handled separately. This was duplicate code and the code additionally converted arguments into property types regardless the further usage. Collection arguments (e.g. for IN query usage) could be converted into the property type (List of String converted into String).

 We now handle collection conversion and single element conversion separately, so collections are no longer converted into the property's type. Collection elements are now inspected individually regarding their type/simple type conversion.

 This change also considers enum types as simple types with a distinct conversion of the enum value into a Cassandra value (numeric, character). The change in enum value handling reduces the scope of the conversion service usage and prevents accidental conversion.

----

Related ticket: [DATACASS-357](https://jira.spring.io/browse/DATACASS-357)