### PR TITLE
DATACASS-259 - Allow usage of Spring 4.2 @AliasFor for Cassandra annotations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>1.5.0.BUILD-SNAPSHOT</version>
+	<version>1.5.0.DATACASS-259-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-259-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-259-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>1.5.0.BUILD-SNAPSHOT</version>
+		<version>1.5.0.DATACASS-259-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraPersistentEntity.java
@@ -98,13 +98,10 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 
 	protected CqlIdentifier determineTableName() {
 
-		Table tableAnnotation = getType().getAnnotation(Table.class);
+		Table tableAnnotation = findAnnotation(Table.class);
 
-		if (tableAnnotation == null) {
-			return determineDefaultName();
-		}
-
-		return determineName(tableAnnotation.value(), tableAnnotation.forceQuote());
+		return tableAnnotation == null ? determineDefaultName()
+				: determineName(tableAnnotation.value(), tableAnnotation.forceQuote());
 	}
 
 	@Override
@@ -119,7 +116,7 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 
 	@Override
 	public boolean isCompositePrimaryKey() {
-		return getType().isAnnotationPresent(PrimaryKeyClass.class);
+		return findAnnotation(PrimaryKeyClass.class) != null;
 	}
 
 	@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/PrimaryKeyColumn.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/PrimaryKeyColumn.java
@@ -22,12 +22,14 @@ import java.lang.annotation.Target;
 
 import org.springframework.cassandra.core.Ordering;
 import org.springframework.cassandra.core.PrimaryKeyType;
+import org.springframework.core.annotation.AliasFor;
 
 /**
  * Identifies the annotated field of a composite primary key class as a primary key field that is either a partition or
  * cluster key field.
  * 
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
 @Retention(value = RetentionPolicy.RUNTIME)
 @Target(value = { ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
@@ -36,12 +38,19 @@ public @interface PrimaryKeyColumn {
 	/**
 	 * The name of the column in the table.
 	 */
+	@AliasFor(attribute = "name")
+	String value() default "";
+
+	/**
+	 * The name of the column in the table.
+	 */
+	@AliasFor(attribute = "value")
 	String name() default "";
 
 	/**
 	 * The order of this column relative to other primary key columns.
 	 */
-	int ordinal();
+	int ordinal() default Integer.MIN_VALUE;
 
 	/**
 	 * The type of this key column. Default is {@link PrimaryKeyType#CLUSTERED}.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/Query.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/Query.java
@@ -28,9 +28,10 @@ import org.springframework.data.annotation.QueryAnnotation;
  * 
  * @author Alex Shvid
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Documented
 @QueryAnnotation
 public @interface Query {

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/CassandraParametersUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/CassandraParametersUnitTests.java
@@ -17,6 +17,8 @@ package org.springframework.data.cassandra.repository.query;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
 
 import org.junit.Test;
@@ -86,6 +88,18 @@ public class CassandraParametersUnitTests {
 		assertThat(cassandraParameters.getParameter(0).getCassandraType().type()).isEqualTo(Name.TIME);
 	}
 
+	/**
+	 * @see DATACASS-296
+	 */
+	@Test
+	public void shouldReturnTypeForComposedAnnotationType() throws Exception {
+
+		Method method = PersonRepository.class.getMethod("findByComposedAnnotationObject", Object.class);
+		CassandraParameters cassandraParameters = new CassandraParameters(method);
+
+		assertThat(cassandraParameters.getParameter(0).getCassandraType().type()).isEqualTo(Name.BOOLEAN);
+	}
+
 	interface PersonRepository {
 
 		Person findByFirstname(String firstname);
@@ -95,5 +109,12 @@ public class CassandraParametersUnitTests {
 		Person findByObject(Object firstname);
 
 		Person findByAnnotatedObject(@CassandraType(type = Name.TIME) Object firstname);
+
+		Person findByComposedAnnotationObject(@ComposedCassandraTypeAnnotation Object firstname);
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@CassandraType(type = Name.BOOLEAN)
+	@interface ComposedCassandraTypeAnnotation {
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/StringBasedCassandraQueryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/StringBasedCassandraQueryUnitTests.java
@@ -18,6 +18,8 @@ package org.springframework.data.cassandra.repository.query;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -112,6 +114,21 @@ public class StringBasedCassandraQueryUnitTests {
 	public void bindsIndexParameterCorrectly() {
 
 		StringBasedCassandraQuery cassandraQuery = getQueryMethod("findByLastname", String.class);
+		CassandraParametersParameterAccessor accessor = new CassandraParametersParameterAccessor(
+				cassandraQuery.getQueryMethod(), "Matthews");
+
+		String actual = cassandraQuery.createQuery(accessor);
+
+		assertThat(actual).isEqualTo("SELECT * FROM person WHERE lastname = 'Matthews';");
+	}
+
+	/**
+	 * @see DATACASS-259
+	 */
+	@Test
+	public void bindsIndexParameterForComposedQueryAnnotationCorrectly() {
+
+		StringBasedCassandraQuery cassandraQuery = getQueryMethod("findByComposedQueryAnnotation", String.class);
 		CassandraParametersParameterAccessor accessor = new CassandraParametersParameterAccessor(
 				cassandraQuery.getQueryMethod(), "Matthews");
 
@@ -456,5 +473,13 @@ public class StringBasedCassandraQueryUnitTests {
 
 		@Query("SELECT * FROM person WHERE address=?0;")
 		Person findByMainAddress(UDTValue udtValue);
+
+		@ComposedQueryAnnotation
+		Person findByComposedQueryAnnotation(String lastname);
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Query("SELECT * FROM person WHERE lastname = ?0;")
+	@interface ComposedQueryAnnotation {
 	}
 }


### PR DESCRIPTION
We now support `@AliasFor` to build composed annotations with `@Table`, `@UserDefinedType`, `@PrimaryKey`, `@PrimaryKeyClass`, `@PrimaryKeyColumn`, `@Column`, `@Query`, `@CassandraType`.

----

Related ticket: [https://jira.spring.io/browse/DATACASS-259](https://jira.spring.io/browse/DATACASS-259)