### PR TITLE
DATACASS-359, DATACASS-360 - Do not require @Table annotation and support DTO projections.

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraPersistentEntitySchemaCreator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraPersistentEntitySchemaCreator.java
@@ -152,7 +152,7 @@ public class CassandraPersistentEntitySchemaCreator {
 
 	protected List<CreateTableSpecification> createTableSpecifications(boolean ifNotExists) {
 		Collection<? extends CassandraPersistentEntity<?>> entities = new ArrayList<CassandraPersistentEntity<?>>(
-				mappingContext.getNonPrimaryKeyEntities());
+				mappingContext.getTableEntities());
 
 		List<CreateTableSpecification> specifications = new ArrayList<CreateTableSpecification>();
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraMappingContext.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/BasicCassandraMappingContext.java
@@ -79,9 +79,9 @@ public class BasicCassandraMappingContext
 	protected Map<Class<?>, CassandraPersistentEntity<?>> entitiesByType = new HashMap<Class<?>, CassandraPersistentEntity<?>>();
 	protected Map<CqlIdentifier, Set<CassandraPersistentEntity<?>>> entitySetsByTableName = new HashMap<CqlIdentifier, Set<CassandraPersistentEntity<?>>>();
 
-	protected Set<CassandraPersistentEntity<?>> nonPrimaryKeyEntities = new HashSet<CassandraPersistentEntity<?>>();
 	protected Set<CassandraPersistentEntity<?>> primaryKeyEntities = new HashSet<CassandraPersistentEntity<?>>();
 	protected Set<CassandraPersistentEntity<?>> userDefinedTypes = new HashSet<CassandraPersistentEntity<?>>();
+	protected Set<CassandraPersistentEntity<?>> tableEntities = new HashSet<CassandraPersistentEntity<?>>();
 
 	private CustomConversions customConversions;
 
@@ -128,8 +128,8 @@ public class BasicCassandraMappingContext
 	}
 
 	@Override
-	public Collection<CassandraPersistentEntity<?>> getPersistentEntities() {
-		return getPersistentEntities(false);
+	public Collection<CassandraPersistentEntity<?>> getTableEntities() {
+		return Collections.unmodifiableCollection(tableEntities);
 	}
 
 	@Override
@@ -139,7 +139,7 @@ public class BasicCassandraMappingContext
 
 	@Override
 	public Collection<CassandraPersistentEntity<?>> getNonPrimaryKeyEntities() {
-		return Collections.unmodifiableSet(nonPrimaryKeyEntities);
+		return getTableEntities();
 	}
 
 	@Override
@@ -158,7 +158,7 @@ public class BasicCassandraMappingContext
 			return super.getPersistentEntities();
 		}
 
-		return Collections.unmodifiableSet(nonPrimaryKeyEntities);
+		return getTableEntities();
 	}
 
 	@Override
@@ -207,10 +207,10 @@ public class BasicCassandraMappingContext
 		if (!entity.isUserDefinedType()) {
 			if (entity.isCompositePrimaryKey()) {
 				primaryKeyEntities.add(entity);
-			} else {
-				if (entity.findAnnotation(Persistent.class) != null) {
-					nonPrimaryKeyEntities.add(entity);
-				}
+			}
+
+			if (entity.findAnnotation(Table.class) != null) {
+				tableEntities.add(entity);
 			}
 		}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CassandraMappingContext.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CassandraMappingContext.java
@@ -44,6 +44,13 @@ public interface CassandraMappingContext
 	Collection<CassandraPersistentEntity<?>> getPersistentEntities();
 
 	/**
+	 * Returns only {@link Table} entities.
+	 *
+	 * @since 1.5
+	 */
+	Collection<CassandraPersistentEntity<?>> getTableEntities();
+
+	/**
 	 * Returns all persistent entities or only non-primary-key entities.
 	 * 
 	 * @param includePrimaryKeyTypesAndUdts If {@literal true}, returns all entities, including entities that represent primary
@@ -53,14 +60,18 @@ public interface CassandraMappingContext
 
 	/**
 	 * Returns only those entities representing primary key types.
+	 * @deprecated as of 1.5
 	 */
+	@Deprecated
 	Collection<CassandraPersistentEntity<?>> getPrimaryKeyEntities();
 
 	/**
 	 * Returns only those entities not representing primary key types.
 	 * 
 	 * @see #getPersistentEntities(boolean)
+	 * @deprecated as of 1.5, use {@link #getTableEntities()}.
 	 */
+	@Deprecated
 	Collection<CassandraPersistentEntity<?>> getNonPrimaryKeyEntities();
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CompositeCassandraPersistentEntityMetadataVerifier.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/mapping/CompositeCassandraPersistentEntityMetadataVerifier.java
@@ -17,9 +17,7 @@ package org.springframework.data.cassandra.mapping;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
-import org.springframework.data.annotation.Persistent;
 import org.springframework.data.mapping.model.MappingException;
 import org.springframework.util.Assert;
 
@@ -43,8 +41,8 @@ public class CompositeCassandraPersistentEntityMetadataVerifier implements Cassa
 	 * @see PrimaryKeyClassEntityMetadataVerifier
 	 */
 	public CompositeCassandraPersistentEntityMetadataVerifier() {
-		this(Arrays.asList(new PersistentAnnotationVerifier(), new PrimaryKeyClassEntityMetadataVerifier(),
-			new BasicCassandraPersistentEntityMetadataVerifier()));
+		this(Arrays.asList(new PrimaryKeyClassEntityMetadataVerifier(),
+				new BasicCassandraPersistentEntityMetadataVerifier()));
 	}
 
 	/**
@@ -68,32 +66,6 @@ public class CompositeCassandraPersistentEntityMetadataVerifier implements Cassa
 	public void verify(CassandraPersistentEntity<?> entity) throws MappingException {
 		for (CassandraPersistentEntityMetadataVerifier verifier : verifiers) {
 			verifier.verify(entity);
-		}
-	}
-
-	/**
-	 * {@link CassandraPersistentEntityMetadataVerifier} implementation that requires classes to be annotated with
-	 * {@link Persistent}, {@link Table} or {@link PrimaryKeyClass}.
-	 *
-	 * @author Mark Paluch
-	 */
-	private static class PersistentAnnotationVerifier implements CassandraPersistentEntityMetadataVerifier {
-
-		@Override
-		public void verify(CassandraPersistentEntity<?> entity) throws MappingException {
-
-			if (entity.getType().isInterface()) {
-				return;
-			}
-
-			// Ensure entity is either a @Table/@Persistent, @UserDefinedType or a @PrimaryKey
-			if (entity.findAnnotation(Persistent.class) == null && entity.findAnnotation(UserDefinedType.class) == null) {
-				throw new VerifierMappingExceptions(entity,
-						Collections.singletonList(new MappingException(
-								String.format("Cassandra entities must be annotated with either @%s, @%s, @%s or @%s",
-										Persistent.class.getSimpleName(), Table.class.getSimpleName(),
-										UserDefinedType.class.getSimpleName(), PrimaryKeyClass.class.getSimpleName()))));
-			}
 		}
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraQueryMethod.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraQueryMethod.java
@@ -96,6 +96,7 @@ public class CassandraQueryMethod extends QueryMethod {
 					mappingContext.getPersistentEntity(domainClass));
 
 			} else {
+
 				CassandraPersistentEntity<?> returnedEntity = mappingContext.getPersistentEntity(returnedObjectType);
 				CassandraPersistentEntity<?> managedEntity = mappingContext.getPersistentEntity(domainClass);
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/DtoInstantiatingConverter.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/DtoInstantiatingConverter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.query;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.cassandra.mapping.CassandraPersistentEntity;
+import org.springframework.data.cassandra.mapping.CassandraPersistentProperty;
+import org.springframework.data.convert.EntityInstantiator;
+import org.springframework.data.convert.EntityInstantiators;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.PreferredConstructor;
+import org.springframework.data.mapping.PreferredConstructor.Parameter;
+import org.springframework.data.mapping.SimplePropertyHandler;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mapping.model.ParameterValueProvider;
+import org.springframework.util.Assert;
+
+/**
+ * {@link Converter} to instantiate DTOs from fully equipped domain objects.
+ *
+ * @author Mark Paluch
+ */
+class DtoInstantiatingConverter implements Converter<Object, Object> {
+
+	private final Class<?> targetType;
+	private final MappingContext<? extends PersistentEntity<?, ?>, ? extends PersistentProperty<?>> context;
+	private final EntityInstantiator instantiator;
+
+	/**
+	 * Creates a new {@link Converter} to instantiate DTOs.
+	 * 
+	 * @param dtoType must not be {@literal null}.
+	 * @param context must not be {@literal null}.
+	 * @param instantiators must not be {@literal null}.
+	 */
+	DtoInstantiatingConverter(Class<?> dtoType,
+			MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> context,
+			EntityInstantiators instantiator) {
+
+		Assert.notNull(dtoType, "DTO type must not be null!");
+		Assert.notNull(context, "MappingContext must not be null!");
+		Assert.notNull(instantiator, "EntityInstantiators must not be null!");
+
+		this.targetType = dtoType;
+		this.context = context;
+		this.instantiator = instantiator.getInstantiatorFor(context.getPersistentEntity(dtoType));
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
+	 */
+	@Override
+	public Object convert(Object source) {
+
+		if (targetType.isInterface()) {
+			return source;
+		}
+
+		final PersistentEntity<?, ?> sourceEntity = context.getPersistentEntity(source.getClass());
+		final PersistentPropertyAccessor sourceAccessor = sourceEntity.getPropertyAccessor(source);
+		final PersistentEntity<?, ?> targetEntity = context.getPersistentEntity(targetType);
+		final PreferredConstructor<?, ? extends PersistentProperty<?>> constructor = targetEntity
+				.getPersistenceConstructor();
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		Object dto = instantiator.createInstance(targetEntity, new ParameterValueProvider() {
+
+			@Override
+			public Object getParameterValue(Parameter parameter) {
+				return sourceAccessor.getProperty(sourceEntity.getPersistentProperty(parameter.getName()));
+			}
+		});
+
+		final PersistentPropertyAccessor dtoAccessor = targetEntity.getPropertyAccessor(dto);
+
+		targetEntity.doWithProperties(new SimplePropertyHandler() {
+
+			@Override
+			public void doWithPersistentProperty(PersistentProperty<?> property) {
+
+				if (constructor.isConstructorParameter(property)) {
+					return;
+				}
+
+				dtoAccessor.setProperty(property,
+						sourceAccessor.getProperty(sourceEntity.getPersistentProperty(property.getName())));
+			}
+		});
+
+		return dto;
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/mapping/BasicCassandraMappingContextUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/mapping/BasicCassandraMappingContextUnitTests.java
@@ -66,7 +66,7 @@ public class BasicCassandraMappingContextUnitTests {
 		});
 	}
 
-	@Test(expected = MappingException.class)
+	@Test
 	public void testGetPersistentEntityOfTransientType() {
 		mappingContext.getPersistentEntity(Transient.class);
 	}
@@ -392,11 +392,11 @@ public class BasicCassandraMappingContextUnitTests {
 
 		CassandraPersistentEntity<?> existingPersistentEntity = mappingContext.getPersistentEntity(MappedUdt.class);
 
-		assertThat(mappingContext.getNonPrimaryKeyEntities()).doesNotContain(existingPersistentEntity);
+		assertThat(mappingContext.getTableEntities()).doesNotContain(existingPersistentEntity);
 	}
 
 	/**
-	 * @see DATACASS-172
+	 * @see DATACASS-172, DATACASS-359
 	 */
 	@Test
 	public void getPersistentEntitiesShouldContainUdt() {
@@ -404,7 +404,9 @@ public class BasicCassandraMappingContextUnitTests {
 		CassandraPersistentEntity<?> existingPersistentEntity = mappingContext.getPersistentEntity(MappedUdt.class);
 
 		assertThat(mappingContext.getPersistentEntities(true)).contains(existingPersistentEntity);
+		assertThat(mappingContext.getUserDefinedTypeEntities()).contains(existingPersistentEntity);
 		assertThat(mappingContext.getPersistentEntities(false)).doesNotContain(existingPersistentEntity);
+		assertThat(mappingContext.getTableEntities()).doesNotContain(existingPersistentEntity);
 	}
 
 	/**

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/mapping/CompositeCassandraPersistentEntityMetadataVerifierUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/mapping/CompositeCassandraPersistentEntityMetadataVerifierUnitTests.java
@@ -65,18 +65,11 @@ public class CompositeCassandraPersistentEntityMetadataVerifierUnitTests {
 	}
 
 	/**
-	 * @see DATACASS-258
+	 * @see DATACASS-258, DATACASS-359
 	 */
 	@Test
-	public void shouldFailWithNonPersistentClasses() {
-
-		try {
-			verifier.verify(getEntity(NonPersistentClass.class));
-			fail("Missing MappingException");
-		} catch (MappingException e) {
-			assertThat(e).hasMessageContaining(
-					"Cassandra entities must be annotated with either @Persistent, @Table, @UserDefinedType or @PrimaryKeyClass");
-		}
+	public void shouldNotFailWithNonPersistentClasses() {
+		verifier.verify(getEntity(NonPersistentClass.class));
 	}
 
 	/**

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/CassandraQueryCreatorUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/CassandraQueryCreatorUnitTests.java
@@ -36,12 +36,13 @@ import org.springframework.data.cassandra.convert.MappingCassandraConverter;
 import org.springframework.data.cassandra.domain.Person;
 import org.springframework.data.cassandra.mapping.BasicCassandraMappingContext;
 import org.springframework.data.cassandra.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.mapping.CassandraPersistentEntity;
 import org.springframework.data.cassandra.mapping.Column;
 import org.springframework.data.cassandra.mapping.PrimaryKey;
 import org.springframework.data.cassandra.mapping.PrimaryKeyClass;
 import org.springframework.data.cassandra.mapping.PrimaryKeyColumn;
 import org.springframework.data.cassandra.mapping.Table;
-import org.springframework.data.repository.core.EntityMetadata;
+import org.springframework.data.cassandra.repository.support.MappingCassandraEntityInformation;
 import org.springframework.data.repository.query.parser.PartTree;
 
 /**
@@ -350,13 +351,10 @@ public class CassandraQueryCreatorUnitTests {
 		return creator.createQuery().toString();
 	}
 
-	private <T> EntityMetadata<T> getEntityInformation(final Class<T> entityClass) {
-		return new EntityMetadata<T>() {
-			@Override
-			public Class<T> getJavaType() {
-				return entityClass;
-			}
-		};
+	@SuppressWarnings("unchecked")
+	private <T> CassandraEntityInformation<T, Serializable> getEntityInformation(final Class<T> entityClass) {
+		return new MappingCassandraEntityInformation<T, Serializable>(
+				(CassandraPersistentEntity) context.getPersistentEntity(entityClass), converter);
 	}
 
 	@Table

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/cdi/CassandraOperationsProducer.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/cdi/CassandraOperationsProducer.java
@@ -80,7 +80,7 @@ class CassandraOperationsProducer {
 		schemaCreator.createTables(false, false, true);
 
 		for (CassandraPersistentEntity<?> entity : cassandraTemplate.getConverter().getMappingContext()
-				.getNonPrimaryKeyEntities()) {
+				.getTableEntities()) {
 			cassandraTemplate.truncate(entity.getTableName());
 		}
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/derived/PersonRepository.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/repository/querymethods/derived/PersonRepository.java
@@ -19,6 +19,8 @@ import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 
+import lombok.Data;
+import lombok.Getter;
 import org.springframework.data.cassandra.repository.CassandraRepository;
 import org.springframework.data.cassandra.repository.Query;
 import org.springframework.data.cassandra.test.integration.repository.querymethods.declared.Address;
@@ -53,6 +55,10 @@ interface PersonRepository extends CassandraRepository<Person> {
 
 	Collection<PersonProjection> findPersonProjectedBy();
 
+	Collection<PersonDto> findPersonDtoBy();
+
+	<T> T findDtoByNicknameStartsWith(String prefix, Class<T> projectionType);
+
 	@Query("select * from person where firstname = ?0 and lastname = 'White'")
 	List<Person> findByFirstname(String firstname);
 
@@ -65,5 +71,16 @@ interface PersonRepository extends CassandraRepository<Person> {
 		String getFirstname();
 
 		String getLastname();
+	}
+
+	static class PersonDto {
+
+		public String firstname, lastname;
+
+		public PersonDto(String firstname, String lastname) {
+
+			this.firstname = firstname;
+			this.lastname = lastname;
+		}
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/support/AbstractSpringDataEmbeddedCassandraIntegrationTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/integration/support/AbstractSpringDataEmbeddedCassandraIntegrationTest.java
@@ -38,7 +38,8 @@ public abstract class AbstractSpringDataEmbeddedCassandraIntegrationTest
 	 * Truncate table for all known {@link org.springframework.data.mapping.PersistentEntity entities}.
 	 */
 	public void deleteAllEntities() {
-		for (CassandraPersistentEntity<?> entity : template.getConverter().getMappingContext().getPersistentEntities()) {
+
+		for (CassandraPersistentEntity<?> entity : template.getConverter().getMappingContext().getTableEntities()) {
 
 			if (entity.getType().isInterface()) {
 				continue;


### PR DESCRIPTION
We no longer require entities to be annotated with `@Table` for data mapping and CRUD operations to support DTO projections for query methods. DTO projection selects records from Cassandra and projects results on the DTO. DTOs are plain Java objects that fit the underlying entity.

```java
@Table
class Person {

  @PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED, ordinal = 0) private String lastname;
  @PrimaryKeyColumn(type = PrimaryKeyType.CLUSTERED, ordinal = 1) private String firstname;

  private String nickname;
  private Date birthDate;

  // more columns
}

interface PersonRepository extends CrudRepository<Person, String> {
  Collection<PersonDto> findPersonDtoBy();

  <T> T findDtoByFirstnameStartsWith(String prefix, Class<T> projectionType);
}

class PersonDto {
  public String firstname, lastname;

  public PersonDto(String firstname, String lastname) {

    this.firstname = firstname;
    this.lastname = lastname;
  }
}
```

---- 

Related tickets: [DATACASS-360](https://jira.spring.io/browse/DATACASS-360), [DATACASS-359](https://jira.spring.io/browse/DATACASS-359)

DTO projection for reactive repositories is prepared on [spring-projects/spring-data-cassandra@issue/2.0.x/DATACASS-360](https://github.com/spring-projects/spring-data-cassandra/tree/issue/2.0.x/DATACASS-360).