### PR TITLE
DATACASS-397 added id attribute to xml schema for cassandra converter.

### DIFF
--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.5.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.5.xsd
@@ -749,6 +749,13 @@ Defines a CassandraConverter for getting rich mapping functionality.
 			</xsd:appinfo>
 		</xsd:annotation>
 		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:ID" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	The name of the converter ; default is "cassandraConverter".
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="mapping-ref" type="mappingContextRef" use="optional">
 				<xsd:annotation>
 					<xsd:documentation

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessorUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraMappingBeanFactoryPostProcessorUnitTests.java
@@ -36,7 +36,7 @@ import com.datastax.driver.core.Session;
  * 
  * @author Mark Paluch
  */
-public class CassandraMappingBeanFactoryPostProcessorTests {
+public class CassandraMappingBeanFactoryPostProcessorUnitTests {
 
 	@Rule public final ExpectedException expectedException = ExpectedException.none();
 
@@ -47,7 +47,7 @@ public class CassandraMappingBeanFactoryPostProcessorTests {
 	public void clusterRegistrationTriggersDefaultBeanRegistration() {
 
 		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
-		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "cluster-and-mock-session.xml");
+		context.load(CassandraMappingBeanFactoryPostProcessorUnitTests.class, "cluster-and-mock-session.xml");
 		context.refresh();
 
 		assertThat(context.getBeanNamesForType(CassandraOperations.class), hasItemInArray("cqlTemplate"));
@@ -62,7 +62,7 @@ public class CassandraMappingBeanFactoryPostProcessorTests {
 	public void MappingAndConverterRegistrationTriggersDefaultBeanRegistration() {
 
 		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
-		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "mock-session-mapping-converter.xml");
+		context.load(CassandraMappingBeanFactoryPostProcessorUnitTests.class, "mock-session-mapping-converter.xml");
 		context.refresh();
 
 		assertThat(context.getBeanNamesForType(CassandraOperations.class), hasItemInArray("cqlTemplate"));
@@ -78,7 +78,7 @@ public class CassandraMappingBeanFactoryPostProcessorTests {
 		expectedException.expectMessage(containsString("No bean named 'cassandraMapping'"));
 
 		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
-		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "mock-session-converter.xml");
+		context.load(CassandraMappingBeanFactoryPostProcessorUnitTests.class, "mock-session-converter.xml");
 		context.refresh();
 	}
 
@@ -92,7 +92,7 @@ public class CassandraMappingBeanFactoryPostProcessorTests {
 		expectedException.expectMessage(allOf(containsString("found 2 beans of type"), containsString("Session")));
 
 		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
-		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-sessions.xml");
+		context.load(CassandraMappingBeanFactoryPostProcessorUnitTests.class, "multiple-sessions.xml");
 		context.refresh();
 	}
 
@@ -106,7 +106,7 @@ public class CassandraMappingBeanFactoryPostProcessorTests {
 		expectedException.expectMessage(allOf(containsString("found 2 beans of type"), containsString("Session")));
 
 		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
-		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-session-factories.xml");
+		context.load(CassandraMappingBeanFactoryPostProcessorUnitTests.class, "multiple-session-factories.xml");
 		context.refresh();
 	}
 
@@ -121,7 +121,7 @@ public class CassandraMappingBeanFactoryPostProcessorTests {
 				.expectMessage(allOf(containsString("found 2 beans of type"), containsString("CassandraMappingContext")));
 
 		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
-		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-mapping-contexts.xml");
+		context.load(CassandraMappingBeanFactoryPostProcessorUnitTests.class, "multiple-mapping-contexts.xml");
 		context.refresh();
 	}
 
@@ -136,7 +136,7 @@ public class CassandraMappingBeanFactoryPostProcessorTests {
 				.expectMessage(allOf(containsString("found 2 beans of type"), containsString("CassandraConverter")));
 
 		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
-		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "multiple-converters.xml");
+		context.load(CassandraMappingBeanFactoryPostProcessorUnitTests.class, "multiple-converters.xml");
 		context.refresh();
 	}
 
@@ -147,7 +147,7 @@ public class CassandraMappingBeanFactoryPostProcessorTests {
 	public void shouldAllowTwoKeyspaces() {
 
 		GenericXmlApplicationContext context = new GenericXmlApplicationContext();
-		context.load(CassandraMappingBeanFactoryPostProcessorTests.class, "two-keyspaces-namespace.xml");
+		context.load(CassandraMappingBeanFactoryPostProcessorUnitTests.class, "two-keyspaces-namespace.xml");
 		context.refresh();
 
 		assertThat(context.getBeanNamesForType(CassandraOperations.class), arrayContaining("c-1", "c-2"));

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/cluster-and-mock-session.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/cluster-and-mock-session.xml
@@ -7,6 +7,6 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<cass:cluster/>
-	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>
 
 </beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-converter.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-converter.xml
@@ -6,7 +6,7 @@
 
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
-	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>
 	<cass:converter />
 
 </beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-mapping-converter.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-mapping-converter.xml
@@ -6,7 +6,7 @@
 
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
-	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>
 	<cass:mapping/>
 	<cass:converter/>
 

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-converters.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-converters.xml
@@ -8,7 +8,7 @@
 
 	<cass:cluster/>
 
-	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>
 
 	<cass:mapping/>
 	<cass:converter/>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-mapping-contexts.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-mapping-contexts.xml
@@ -6,7 +6,7 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<cass:cluster/>
-	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>
 	<cass:mapping/>
 	<bean class="org.springframework.data.cassandra.mapping.BasicCassandraMappingContext"/>
 

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-sessions.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-sessions.xml
@@ -7,7 +7,7 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<cass:cluster/>
-	<bean id="mockSession1" class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
-	<bean id="mockSession2" class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+	<bean id="mockSession1" class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>
+	<bean id="mockSession2" class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>
 
 </beans>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/two-keyspaces-namespace.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/two-keyspaces-namespace.xml
@@ -2,15 +2,15 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
-	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.5.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<cass:cluster/>
 
 	<bean id="keyspace-1"
-		  class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+		  class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>
 	<bean id="keyspace-2"
-		  class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorTests.MockSessionFactory"/>
+		  class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>
 
 	<cass:mapping id="mapping-1"/>
 	<cass:mapping id="mapping-2"/>


### PR DESCRIPTION
Due to naming error one of test classes has not be executed by maven ( before: CassandraMappingBeanFactoryPostProcessorTests ). And there happed to be one failing test - shouldAllowTwoKeyspaces.

It was failing due to wrong schema in test context as well as missing id attribute for cassandra converer in new schema (1.5)

Following fixes both, the name of class - so it will be executed along other tests -  as well as failing test.
