### PR TITLE
DATACASS-398 - Support RxJava 2 repositories.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACASS-398-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>
@@ -97,7 +97,7 @@
 		<failsafe.version>2.16</failsafe.version>
 		<multithreadedtc.version>1.01</multithreadedtc.version>
 		<project.type>multi</project.type>
-		<springdata.commons>2.0.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>2.0.0.DATACMNS-988-SNAPSHOT</springdata.commons>
 	</properties>
 
 	<repositories>

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-398-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-398-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-398-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -92,6 +92,13 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>io.reactivex.rxjava2</groupId>
+			<artifactId>rxjava</artifactId>
+			<version>${rxjava2}</version>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- CDI -->
 		<dependency>
 			<groupId>javax.enterprise</groupId>

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/ConvertingReactiveCassandraRepositoryTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/ConvertingReactiveCassandraRepositoryTests.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
-import io.reactivex.observers.TestObserver;
-import org.springframework.data.cassandra.core.ReactiveCassandraTemplate;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -38,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cassandra.test.integration.AbstractKeyspaceCreatingIntegrationTest;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate;
 import org.springframework.data.cassandra.domain.Person;
 import org.springframework.data.cassandra.repository.config.EnableReactiveCassandraRepositories;
 import org.springframework.data.cassandra.test.integration.support.IntegrationTestConfig;
@@ -56,6 +55,7 @@ import com.datastax.driver.core.TableMetadata;
  * Test for {@link ReactiveCassandraRepository} using reactive wrapper type conversion.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = ConvertingReactiveCassandraRepositoryTests.Config.class)
@@ -186,78 +186,72 @@ public class ConvertingReactiveCassandraRepositoryTests extends AbstractKeyspace
 	@Test // DATACASS-398
 	public void simpleRxJava2MethodsShouldWork() {
 
-		TestObserver<Boolean> testObserver = rxJava2PersonRepostitory.exists(dave.getId()).test();
-
-		testObserver.awaitTerminalEvent();
-		testObserver.assertComplete();
-		testObserver.assertNoErrors();
-		testObserver.assertValue(true);
+		rxJava2PersonRepostitory.exists(dave.getId()) //
+				.test()//
+				.assertValue(true) //
+				.assertNoErrors() //
+				.assertComplete() //
+				.awaitTerminalEvent();
 	}
 
 	@Test // DATACASS-398
 	public void existsWithSingleRxJava2IdMethodsShouldWork() {
 
-		TestObserver<Boolean> testObserver = rxJava2PersonRepostitory.exists(io.reactivex.Single.just(dave.getId())).test();
-
-		testObserver.awaitTerminalEvent();
-		testObserver.assertComplete();
-		testObserver.assertNoErrors();
-		testObserver.assertValue(true);
+		rxJava2PersonRepostitory.exists(io.reactivex.Single.just(dave.getId())).test() //
+				.assertValue(true) //
+				.assertNoErrors() //
+				.assertComplete() //
+				.awaitTerminalEvent();
 	}
 
 	@Test // DATACASS-398
 	public void flowableRxJava2QueryMethodShouldWork() {
 
-		io.reactivex.subscribers.TestSubscriber<Person> testSubscriber = rxJava2PersonRepostitory
-				.findManyByLastname(dave.getLastname()).test();
-
-		testSubscriber.awaitTerminalEvent();
-		testSubscriber.assertComplete();
-		testSubscriber.assertNoErrors();
-		testSubscriber.assertValueCount(2);
+		rxJava2PersonRepostitory.findManyByLastname(dave.getLastname()) //
+				.test() //
+				.assertValueCount(2) //
+				.assertNoErrors() //
+				.assertComplete() //
+				.awaitTerminalEvent();
 	}
 
 	@Test // DATACASS-398
 	public void singleProjectedRxJava2QueryMethodShouldWork() {
 
-		TestObserver<ProjectedPerson> testObserver = rxJava2PersonRepostitory
-				.findProjectedByLastname(Maybe.just(carter.getLastname())).test();
-
-		testObserver.awaitTerminalEvent();
-		testObserver.assertComplete();
-		testObserver.assertNoErrors();
-
-		testObserver.assertValue(actual -> {
-			assertThat(actual.getFirstname()).isEqualTo(carter.getFirstname());
-			return true;
-		});
+		rxJava2PersonRepostitory.findProjectedByLastname(Maybe.just(carter.getLastname())) //
+				.test() //
+				.assertValue(actual -> {
+					assertThat(actual.getFirstname()).isEqualTo(carter.getFirstname());
+					return true;
+				}) //
+				.assertComplete() //
+				.assertNoErrors() //
+				.awaitTerminalEvent();
 	}
 
 	@Test // DATACASS-398
 	public void observableProjectedRxJava2QueryMethodShouldWork() {
 
-		TestObserver<ProjectedPerson> testObserver = rxJava2PersonRepostitory
-				.findProjectedByLastname(Single.just(carter.getLastname())).test();
-
-		testObserver.awaitTerminalEvent();
-		testObserver.assertComplete();
-		testObserver.assertNoErrors();
-
-		testObserver.assertValue(actual -> {
-			assertThat(actual.getFirstname()).isEqualTo(carter.getFirstname());
-			return true;
-		});
+		rxJava2PersonRepostitory.findProjectedByLastname(Single.just(carter.getLastname())) //
+				.test() //
+				.assertValue(actual -> {
+					assertThat(actual.getFirstname()).isEqualTo(carter.getFirstname());
+					return true;
+				}) //
+				.assertComplete() //
+				.assertNoErrors() //
+				.awaitTerminalEvent();
 	}
 
 	@Test // DATACASS-398
 	public void maybeRxJava2QueryMethodShouldWork() {
 
-		TestObserver<Person> testObserver = rxJava2PersonRepostitory.findByLastname(boyd.getLastname()).test();
-
-		testObserver.awaitTerminalEvent();
-		testObserver.assertComplete();
-		testObserver.assertNoErrors();
-		testObserver.assertValue(boyd);
+		rxJava2PersonRepostitory.findByLastname(boyd.getLastname()) //
+				.test() //
+				.assertValue(boyd) //
+				.assertNoErrors() //
+				.assertComplete() //
+				.awaitTerminalEvent();
 	}
 
 	@Test // DATACASS-335
@@ -277,7 +271,6 @@ public class ConvertingReactiveCassandraRepositoryTests extends AbstractKeyspace
 		StepVerifier.create(reactiveRepository.findByLastname(Single.just(this.carter.getLastname()))) //
 				.expectNext(carter) //
 				.verifyComplete();
-
 	}
 
 	@Repository


### PR DESCRIPTION
Add RxJava 2 dependency. Add test to verify RxJava 2 interoperability.

---

Depends on: https://github.com/spring-projects/spring-data-commons/pull/194
Related ticket: [DATACASS-398](https://jira.spring.io/browse/DATACASS-398)