### PR TITLE
DATACASS-250 - Support lightweight transactions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACASS-250-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-250-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-250-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraOperations.java
@@ -37,7 +37,10 @@ import com.datastax.driver.core.Statement;
  * @author John Blum
  * @since 2.0
  * @see AsyncCassandraTemplate
- * @see CassandraOperations
+ * @see AsyncCqlOperations
+ * @see Statement
+ * @see InsertOptions
+ * @see UpdateOptions
  */
 public interface AsyncCassandraOperations {
 
@@ -234,10 +237,11 @@ public interface AsyncCassandraOperations {
 	 *
 	 * @param entity The entity to insert, must not be {@literal null}.
 	 * @param options may be {@literal null}.
-	 * @return the inserted entity.
+	 * @return the inserted entity or a {@literal null} inside of {@link ListenableFuture} if the {@code INSERT} operation
+	 *         was not applied.
 	 * @throws DataAccessException if there is any problem executing the query.
 	 */
-	<T> ListenableFuture<T> insert(T entity, WriteOptions options) throws DataAccessException;
+	<T> ListenableFuture<T> insert(T entity, InsertOptions options) throws DataAccessException;
 
 	/**
 	 * Update the given entity and return the entity if the update was applied.
@@ -253,10 +257,11 @@ public interface AsyncCassandraOperations {
 	 *
 	 * @param entity The entity to update, must not be {@literal null}.
 	 * @param options may be {@literal null}.
-	 * @return the updated entity.
+	 * @return the updated entityor a {@literal null} inside of {@link ListenableFuture} if the {@code UPDATE} operation
+	 *         was not applied.
 	 * @throws DataAccessException if there is any problem executing the query.
 	 */
-	<T> ListenableFuture<T> update(T entity, WriteOptions options) throws DataAccessException;
+	<T> ListenableFuture<T> update(T entity, UpdateOptions options) throws DataAccessException;
 
 	/**
 	 * Delete the given entity and return the entity if the delete was applied.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
@@ -36,7 +36,6 @@ import org.springframework.data.cql.core.CqlIdentifier;
 import org.springframework.data.cql.core.CqlProvider;
 import org.springframework.data.cql.core.GuavaListenableFutureAdapter;
 import org.springframework.data.cql.core.QueryOptions;
-import org.springframework.data.cql.core.WriteOptions;
 import org.springframework.data.cql.core.session.DefaultSessionFactory;
 import org.springframework.data.cql.core.session.SessionFactory;
 import org.springframework.data.cql.support.CqlExceptionTranslator;
@@ -424,10 +423,10 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#insert(java.lang.Object, org.springframework.data.cql.core.WriteOptions)
+	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#insert(java.lang.Object, org.springframework.data.cassandra.core.InsertOptions)
 	 */
 	@Override
-	public <T> ListenableFuture<T> insert(T entity, WriteOptions options) {
+	public <T> ListenableFuture<T> insert(T entity, InsertOptions options) {
 
 		Assert.notNull(entity, "Entity must not be null");
 
@@ -448,10 +447,10 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#update(java.lang.Object, org.springframework.data.cql.core.WriteOptions)
+	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#update(java.lang.Object, org.springframework.data.cassandra.core.UpdateOptions)
 	 */
 	@Override
-	public <T> ListenableFuture<T> update(T entity, WriteOptions options) {
+	public <T> ListenableFuture<T> update(T entity, UpdateOptions options) {
 
 		Assert.notNull(entity, "Entity must not be null");
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
@@ -41,6 +41,8 @@ import com.datastax.driver.core.Statement;
  * @see CassandraTemplate
  * @see CqlOperations
  * @see Statement
+ * @see InsertOptions
+ * @see UpdateOptions
  */
 public interface CassandraOperations {
 
@@ -266,10 +268,10 @@ public interface CassandraOperations {
 	 *
 	 * @param entity The entity to insert, must not be {@literal null}.
 	 * @param options may be {@literal null}.
-	 * @return the inserted entity.
+	 * @return the inserted entity or {@literal null} if the {@code INSERT} operation was not applied.
 	 * @throws DataAccessException if there is any problem executing the query.
 	 */
-	<T> T insert(T entity, WriteOptions options) throws DataAccessException;
+	<T> T insert(T entity, InsertOptions options) throws DataAccessException;
 
 	/**
 	 * Update the given entity and return the entity if the update was applied.
@@ -285,10 +287,10 @@ public interface CassandraOperations {
 	 *
 	 * @param entity The entity to update, must not be {@literal null}.
 	 * @param options may be {@literal null}.
-	 * @return the updated entity.
+	 * @return the updated entity or {@literal null} if the {@code UPDATE} operation was not applied.
 	 * @throws DataAccessException if there is any problem executing the query.
 	 */
-	<T> T update(T entity, WriteOptions options) throws DataAccessException;
+	<T> T update(T entity, UpdateOptions options) throws DataAccessException;
 
 	/**
 	 * Delete the given entity and return the entity if the delete was applied.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -37,7 +37,6 @@ import org.springframework.data.cql.core.CqlProvider;
 import org.springframework.data.cql.core.CqlTemplate;
 import org.springframework.data.cql.core.QueryOptions;
 import org.springframework.data.cql.core.SessionCallback;
-import org.springframework.data.cql.core.WriteOptions;
 import org.springframework.data.cql.core.session.DefaultSessionFactory;
 import org.springframework.data.cql.core.session.SessionFactory;
 import org.springframework.data.mapping.context.MappingContext;
@@ -433,10 +432,10 @@ public class CassandraTemplate implements CassandraOperations {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.cassandra.core.CassandraOperations#insert(java.lang.Object, org.springframework.data.cql.core.WriteOptions)
+	 * @see org.springframework.data.cassandra.core.CassandraOperations#insert(java.lang.Object, org.springframework.data.cassandra.core.InsertOptions)
 	 */
 	@Override
-	public <T> T insert(T entity, WriteOptions options) {
+	public <T> T insert(T entity, InsertOptions options) {
 
 		Assert.notNull(entity, "Entity must not be null");
 
@@ -456,10 +455,10 @@ public class CassandraTemplate implements CassandraOperations {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.cassandra.core.CassandraOperations#update(java.lang.Object, org.springframework.data.cql.core.WriteOptions)
+	 * @see org.springframework.data.cassandra.core.CassandraOperations#update(java.lang.Object, org.springframework.data.cassandra.core.UpdateOptions)
 	 */
 	@Override
-	public <T> T update(T entity, WriteOptions options) {
+	public <T> T update(T entity, UpdateOptions options) {
 
 		Assert.notNull(entity, "Entity must not be null");
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/InsertOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/InsertOptions.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.cql.core.WriteOptions;
+
+/**
+ * Extension to {@link WriteOptions} for use with {@code INSERT} operations.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+public class InsertOptions extends WriteOptions {
+
+	private boolean ifNotExists;
+
+	/**
+	 * Creates new {@link InsertOptions}.
+	 */
+	InsertOptions() {}
+
+	/**
+	 * Create a new {@link InsertOptionsBuilder}.
+	 *
+	 * @return a new {@link InsertOptionsBuilder}.
+	 */
+	public static InsertOptionsBuilder builder() {
+		return new InsertOptionsBuilder();
+	}
+
+	/**
+	 * @return {@literal true} to apply {@code IF NOT EXISTS} to {@code INSERT} operations.
+	 */
+	public boolean isIfNotExists() {
+		return ifNotExists;
+	}
+
+	/**
+	 * Builder for {@link InsertOptions}.
+	 *
+	 * @author Mark Paluch
+	 * @since 2.0
+	 */
+	public static class InsertOptionsBuilder extends WriteOptionsBuilder {
+
+		private boolean ifNotExists;
+
+		private InsertOptionsBuilder() {}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#consistencyLevel(com.datastax.driver.core.ConsistencyLevel)
+		 */
+		@Override
+		public InsertOptionsBuilder consistencyLevel(com.datastax.driver.core.ConsistencyLevel consistencyLevel) {
+			return (InsertOptionsBuilder) super.consistencyLevel(consistencyLevel);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#retryPolicy(org.springframework.data.cql.core.RetryPolicy)
+		 */
+		@Override
+		public InsertOptionsBuilder retryPolicy(com.datastax.driver.core.policies.RetryPolicy driverRetryPolicy) {
+			return (InsertOptionsBuilder) super.retryPolicy(driverRetryPolicy);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#fetchSize(int)
+		 */
+		@Override
+		public InsertOptionsBuilder fetchSize(int fetchSize) {
+			return (InsertOptionsBuilder) super.fetchSize(fetchSize);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#readTimeout(long)
+		 */
+		@Override
+		public InsertOptionsBuilder readTimeout(long readTimeout) {
+			return (InsertOptionsBuilder) super.readTimeout(readTimeout);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#readTimeout(long, java.util.concurrent.TimeUnit)
+		 */
+		@Override
+		public InsertOptionsBuilder readTimeout(long readTimeout, TimeUnit timeUnit) {
+			return (InsertOptionsBuilder) super.readTimeout(readTimeout, timeUnit);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#tracing(boolean)
+		 */
+		@Override
+		public InsertOptionsBuilder tracing(boolean tracing) {
+			return (InsertOptionsBuilder) super.tracing(tracing);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#withTracing()
+		 */
+		@Override
+		public InsertOptionsBuilder withTracing() {
+			return (InsertOptionsBuilder) super.withTracing();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.WriteOptions.WriteOptionsBuilder#ttl(int)
+		 */
+		public InsertOptionsBuilder ttl(int ttl) {
+			return (InsertOptionsBuilder) super.ttl(ttl);
+		}
+
+		/**
+		 * Use light-weight transactions by applying {@code IF NOT EXISTS}.
+		 *
+		 * @return {@code this} {@link InsertOptionsBuilder}
+		 */
+		public InsertOptionsBuilder withIfNotExists() {
+			return ifNotExists(true);
+		}
+
+		/**
+		 * Use light-weight transactions by applying {@code IF NOT EXISTS}.
+		 *
+		 * @param ifNotExists {@literal true} to enable {@code IF NOT EXISTS}.
+		 * @return {@code this} {@link InsertOptionsBuilder}
+		 */
+		public InsertOptionsBuilder ifNotExists(boolean ifNotExists) {
+
+			this.ifNotExists = ifNotExists;
+
+			return this;
+		}
+
+		/**
+		 * Builds a new {@link InsertOptions} with the configured values.
+		 *
+		 * @return a new {@link InsertOptions} with the configured values
+		 */
+		public InsertOptions build() {
+
+			InsertOptions insertOptions = applyOptions(new InsertOptions());
+
+			insertOptions.ifNotExists = ifNotExists;
+
+			return insertOptions;
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/QueryUtils.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/QueryUtils.java
@@ -55,6 +55,15 @@ class QueryUtils {
 
 		Insert insert = QueryOptionsUtil.addWriteOptions(QueryBuilder.insertInto(tableName), options);
 
+		if (options instanceof InsertOptions) {
+
+			InsertOptions insertOptions = (InsertOptions) options;
+
+			if (insertOptions.isIfNotExists()) {
+				insert = insert.ifNotExists();
+			}
+		}
+
 		entityWriter.write(objectToUpdate, insert);
 
 		return insert;
@@ -78,6 +87,15 @@ class QueryUtils {
 		Assert.notNull(entityWriter, "EntityWriter must not be null");
 
 		Update update = QueryOptionsUtil.addWriteOptions(QueryBuilder.update(tableName), options);
+
+		if (options instanceof UpdateOptions) {
+
+			UpdateOptions updateOptions = (UpdateOptions) options;
+
+			if (updateOptions.isIfExists()) {
+				update.where().ifExists();
+			}
+		}
 
 		entityWriter.write(objectToUpdate, update);
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraOperations.java
@@ -36,6 +36,10 @@ import com.datastax.driver.core.Statement;
  * @author Mark Paluch
  * @since 2.0
  * @see ReactiveCassandraTemplate
+ * @see ReactiveCqlOperations
+ * @see Statement
+ * @see InsertOptions
+ * @see UpdateOptions
  * @see Flux
  * @see Mono
  */
@@ -180,10 +184,10 @@ public interface ReactiveCassandraOperations {
 	 *
 	 * @param entity The entity to insert, must not be {@literal null}.
 	 * @param options may be {@literal null}.
-	 * @@return the inserted entity.
+	 * @return the inserted entity or {@link Mono#empty()} if the {@code INSERT} operation was not applied.
 	 * @throws DataAccessException if there is any problem issuing the execution.
 	 */
-	<T> Mono<T> insert(T entity, WriteOptions options) throws DataAccessException;
+	<T> Mono<T> insert(T entity, InsertOptions options) throws DataAccessException;
 
 	/**
 	 * Insert the given entities and emit the entity if the insert was applied.
@@ -199,10 +203,10 @@ public interface ReactiveCassandraOperations {
 	 *
 	 * @param entities The entities to insert, must not be {@literal null}.
 	 * @param options may be {@literal null}.
-	 * @return the inserted entities.
+	 * @return the inserted entities. Does not emit items for which the {@code INSERT} operation was not applied.
 	 * @throws DataAccessException if there is any problem issuing the execution.
 	 */
-	<T> Flux<T> insert(Publisher<? extends T> entities, WriteOptions options) throws DataAccessException;
+	<T> Flux<T> insert(Publisher<? extends T> entities, InsertOptions options) throws DataAccessException;
 
 	/**
 	 * Update the given entity and emit the entity if the update was applied.
@@ -218,10 +222,10 @@ public interface ReactiveCassandraOperations {
 	 *
 	 * @param entity The entity to update, must not be {@literal null}.
 	 * @param options may be {@literal null}.
-	 * @return the updated entity.
+	 * @return the updated entity or {@link Mono#empty()} if the {@code UPDATE} operation was not applied.
 	 * @throws DataAccessException if there is any problem issuing the execution.
 	 */
-	<T> Mono<T> update(T entity, WriteOptions options) throws DataAccessException;
+	<T> Mono<T> update(T entity, UpdateOptions options) throws DataAccessException;
 
 	/**
 	 * Update the given entities and emit the entity if the update was applied.
@@ -237,10 +241,10 @@ public interface ReactiveCassandraOperations {
 	 *
 	 * @param entities The entities to update.
 	 * @param options may be {@literal null}.
-	 * @return the updated entities.
+	 * @return the updated entities. Does not emit items for which the {@code UPDATE} operation was not applied.
 	 * @throws DataAccessException if there is any problem issuing the execution.
 	 */
-	<T> Flux<T> update(Publisher<? extends T> entities, WriteOptions options) throws DataAccessException;
+	<T> Flux<T> update(Publisher<? extends T> entities, UpdateOptions options) throws DataAccessException;
 
 	/**
 	 * Remove the given object from the table by id.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
@@ -34,7 +34,6 @@ import org.springframework.data.cql.core.QueryOptions;
 import org.springframework.data.cql.core.ReactiveCqlOperations;
 import org.springframework.data.cql.core.ReactiveCqlTemplate;
 import org.springframework.data.cql.core.ReactiveSessionCallback;
-import org.springframework.data.cql.core.WriteOptions;
 import org.springframework.data.cql.core.session.DefaultReactiveSessionFactory;
 import org.springframework.data.cql.core.session.ReactiveResultSet;
 import org.springframework.data.cql.core.session.ReactiveSession;
@@ -380,10 +379,10 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#insert(java.lang.Object, org.springframework.data.cql.core.WriteOptions)
+	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#insert(java.lang.Object, org.springframework.data.cassandra.core.InsertOptions)
 	 */
 	@Override
-	public <T> Mono<T> insert(T entity, WriteOptions options) {
+	public <T> Mono<T> insert(T entity, InsertOptions options) {
 
 		Assert.notNull(entity, "Entity must not be null");
 
@@ -417,10 +416,10 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#insert(org.reactivestreams.Publisher, org.springframework.data.cql.core.WriteOptions)
+	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#insert(org.reactivestreams.Publisher, org.springframework.data.cassandra.core.InsertOptions)
 	 */
 	@Override
-	public <T> Flux<T> insert(Publisher<? extends T> entities, WriteOptions options) {
+	public <T> Flux<T> insert(Publisher<? extends T> entities, InsertOptions options) {
 
 		Assert.notNull(entities, "Entity publisher must not be null");
 
@@ -438,10 +437,10 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#update(java.lang.Object, org.springframework.data.cql.core.WriteOptions)
+	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#update(java.lang.Object, org.springframework.data.cassandra.core.UpdateOptions)
 	 */
 	@Override
-	public <T> Mono<T> update(T entity, WriteOptions options) {
+	public <T> Mono<T> update(T entity, UpdateOptions options) {
 
 		Assert.notNull(entity, "Entity must not be null");
 
@@ -475,10 +474,10 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#update(org.reactivestreams.Publisher, org.springframework.data.cql.core.WriteOptions)
+	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#update(org.reactivestreams.Publisher, org.springframework.data.cassandra.core.UpdateOptions)
 	 */
 	@Override
-	public <T> Flux<T> update(Publisher<? extends T> entities, WriteOptions options) {
+	public <T> Flux<T> update(Publisher<? extends T> entities, UpdateOptions options) {
 
 		Assert.notNull(entities, "Entity publisher must not be null");
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/UpdateOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/UpdateOptions.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.cql.core.WriteOptions;
+
+/**
+ * Extension to {@link WriteOptions} for use with {@code UPDATE} operations.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+public class UpdateOptions extends WriteOptions {
+
+	private boolean ifExists;
+
+	/**
+	 * Creates new {@link UpdateOptions}.
+	 */
+	UpdateOptions() {}
+
+	/**
+	 * Create a new {@link UpdateOptionsBuilder}.
+	 *
+	 * @return a new {@link UpdateOptionsBuilder}.
+	 */
+	public static UpdateOptionsBuilder builder() {
+		return new UpdateOptionsBuilder();
+	}
+
+	/**
+	 * @return {@literal true} to apply {@code IF EXISTS} to {@code UPDATE} operations.
+	 */
+	public boolean isIfExists() {
+		return ifExists;
+	}
+
+	/**
+	 * Builder for {@link UpdateOptions}.
+	 *
+	 * @author Mark Paluch
+	 * @since 2.0
+	 */
+	public static class UpdateOptionsBuilder extends WriteOptionsBuilder {
+
+		private boolean ifExists;
+
+		private UpdateOptionsBuilder() {}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#consistencyLevel(com.datastax.driver.core.ConsistencyLevel)
+		 */
+		@Override
+		public UpdateOptionsBuilder consistencyLevel(com.datastax.driver.core.ConsistencyLevel consistencyLevel) {
+			return (UpdateOptionsBuilder) super.consistencyLevel(consistencyLevel);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#retryPolicy(org.springframework.data.cql.core.RetryPolicy)
+		 */
+		@Override
+		public UpdateOptionsBuilder retryPolicy(com.datastax.driver.core.policies.RetryPolicy driverRetryPolicy) {
+			return (UpdateOptionsBuilder) super.retryPolicy(driverRetryPolicy);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#fetchSize(int)
+		 */
+		@Override
+		public UpdateOptionsBuilder fetchSize(int fetchSize) {
+			return (UpdateOptionsBuilder) super.fetchSize(fetchSize);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#readTimeout(long)
+		 */
+		@Override
+		public UpdateOptionsBuilder readTimeout(long readTimeout) {
+			return (UpdateOptionsBuilder) super.readTimeout(readTimeout);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#readTimeout(long, java.util.concurrent.TimeUnit)
+		 */
+		@Override
+		public UpdateOptionsBuilder readTimeout(long readTimeout, TimeUnit timeUnit) {
+			return (UpdateOptionsBuilder) super.readTimeout(readTimeout, timeUnit);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#tracing(boolean)
+		 */
+		@Override
+		public UpdateOptionsBuilder tracing(boolean tracing) {
+			return (UpdateOptionsBuilder) super.tracing(tracing);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.QueryOptions.QueryOptionsBuilder#withTracing()
+		 */
+		@Override
+		public UpdateOptionsBuilder withTracing() {
+			return (UpdateOptionsBuilder) super.withTracing();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.cql.core.WriteOptions.WriteOptionsBuilder#ttl(int)
+		 */
+		public UpdateOptionsBuilder ttl(int ttl) {
+			return (UpdateOptionsBuilder) super.ttl(ttl);
+		}
+
+		/**
+		 * Use light-weight transactions by applying {@code IF EXISTS}.
+		 *
+		 * @return {@code this} {@link UpdateOptionsBuilder}
+		 */
+		public UpdateOptionsBuilder withIfExists() {
+			return ifExists(true);
+		}
+
+		/**
+		 * Use light-weight transactions by applying {@code IF EXISTS}.
+		 *
+		 * @param ifNotExists {@literal true} to enable {@code IF EXISTS}.
+		 * @return {@code this} {@link UpdateOptionsBuilder}
+		 */
+		public UpdateOptionsBuilder ifExists(boolean ifNotExists) {
+
+			this.ifExists = ifNotExists;
+
+			return this;
+		}
+
+		/**
+		 * Builds a new {@link UpdateOptions} with the configured values.
+		 *
+		 * @return a new {@link UpdateOptions} with the configured values
+		 */
+		public UpdateOptions build() {
+
+			UpdateOptions insertOptions = applyOptions(new UpdateOptions());
+
+			insertOptions.ifExists = ifExists;
+
+			return insertOptions;
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cql/core/QueryOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cql/core/QueryOptions.java
@@ -313,7 +313,9 @@ public class QueryOptions {
 			return applyOptions(new QueryOptions());
 		}
 
-		<T extends QueryOptions> T applyOptions(T queryOptions) {
+		protected <T> T applyOptions(T options) {
+
+			QueryOptions queryOptions = (QueryOptions) options;
 
 			queryOptions.setConsistencyLevel(consistencyLevel);
 			queryOptions.setRetryPolicy(retryPolicy);
@@ -330,7 +332,7 @@ public class QueryOptions {
 				queryOptions.setTracing(tracing);
 			}
 
-			return queryOptions;
+			return options;
 		}
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cql/core/WriteOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cql/core/WriteOptions.java
@@ -95,7 +95,7 @@ public class WriteOptions extends QueryOptions {
 
 		private Integer ttl;
 
-		private WriteOptionsBuilder() {}
+		protected WriteOptionsBuilder() {}
 
 		/*
 		 * (non-Javadoc)
@@ -177,12 +177,16 @@ public class WriteOptions extends QueryOptions {
 		 * @return a new {@link WriteOptions} with the configured values
 		 */
 		public WriteOptions build() {
+			return applyOptions(new WriteOptions());
+		}
 
-			WriteOptions queryOptions = applyOptions(new WriteOptions());
+		@Override
+		protected <T> T applyOptions(T queryOptions) {
 
-			queryOptions.setTtl(ttl);
+			WriteOptions writeOptions = (WriteOptions) queryOptions;
+			writeOptions.setTtl(ttl);
 
-			return queryOptions;
+			return super.applyOptions(queryOptions);
 		}
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/CassandraTemplateIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/CassandraTemplateIntegrationTests.java
@@ -146,6 +146,35 @@ public class CassandraTemplateIntegrationTests extends AbstractKeyspaceCreatingI
 		assertThat(template.selectOneById(user.getId(), User.class)).isEqualTo(user);
 	}
 
+	@Test // DATACASS-250
+	public void insertShouldCreateEntityWithLwt() {
+
+		InsertOptions lwtOptions = InsertOptions.builder().withIfNotExists().build();
+
+		User user = new User("heisenberg", "Walter", "White");
+
+		User inserted = template.insert(user, lwtOptions);
+
+		assertThat(inserted).isEqualTo(user);
+	}
+
+	@Test // DATACASS-250
+	public void insertShouldNotUpdateEntityWithLwt() {
+
+		InsertOptions lwtOptions = InsertOptions.builder().withIfNotExists().build();
+
+		User user = new User("heisenberg", "Walter", "White");
+
+		template.insert(user, lwtOptions);
+
+		user.setFirstname("Walter Hartwell");
+
+		User lwt = template.insert(user, lwtOptions);
+
+		assertThat(lwt).isNull();
+		assertThat(template.selectOneById(user.getId(), User.class).getFirstname()).isEqualTo("Walter");
+	}
+
 	@Test // DATACASS-292
 	public void shouldInsertAndCountEntities() {
 
@@ -169,6 +198,35 @@ public class CassandraTemplateIntegrationTests extends AbstractKeyspaceCreatingI
 
 		assertThat(updated).isNotNull();
 		assertThat(template.selectOneById(user.getId(), User.class)).isEqualTo(user);
+	}
+
+	@Test // DATACASS-292
+	public void updateShouldNotCreateEntityWithLwt() {
+
+		UpdateOptions lwtOptions = UpdateOptions.builder().withIfExists().build();
+
+		User user = new User("heisenberg", "Walter", "White");
+
+		User lwt = template.update(user, lwtOptions);
+
+		assertThat(lwt).isNull();
+		assertThat(template.selectOneById(user.getId(), User.class)).isNull();
+	}
+
+	@Test // DATACASS-292
+	public void updateShouldUpdateEntityWithLwt() {
+
+		UpdateOptions lwtOptions = UpdateOptions.builder().withIfExists().build();
+
+		User user = new User("heisenberg", "Walter", "White");
+		template.insert(user);
+
+		user.setFirstname("Walter Hartwell");
+
+		User updated = template.update(user, lwtOptions);
+
+		assertThat(updated).isNotNull();
+		assertThat(template.selectOneById(user.getId(), User.class).getFirstname()).isEqualTo("Walter Hartwell");
 	}
 
 	@Test // DATACASS-343

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/CassandraTemplateUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/CassandraTemplateUnitTests.java
@@ -204,6 +204,23 @@ public class CassandraTemplateUnitTests {
 				.isEqualTo("INSERT INTO users (firstname,id,lastname) VALUES ('Walter','heisenberg','White');");
 	}
 
+	@Test // DATACASS-250
+	public void insertShouldInsertWithOptionsEntity() {
+
+		InsertOptions insertOptions = InsertOptions.builder().withIfNotExists().build();
+
+		when(resultSet.wasApplied()).thenReturn(true);
+
+		User user = new User("heisenberg", "Walter", "White");
+
+		User inserted = template.insert(user, insertOptions);
+
+		assertThat(inserted).isEqualTo(user);
+		verify(session).execute(statementCaptor.capture());
+		assertThat(statementCaptor.getValue().toString())
+				.isEqualTo("INSERT INTO users (firstname,id,lastname) VALUES ('Walter','heisenberg','White') IF NOT EXISTS;");
+	}
+
 	@Test // DATACASS-292
 	public void insertShouldTranslateException() throws Exception {
 
@@ -244,6 +261,23 @@ public class CassandraTemplateUnitTests {
 		verify(session).execute(statementCaptor.capture());
 		assertThat(statementCaptor.getValue().toString())
 				.isEqualTo("UPDATE users SET firstname='Walter',lastname='White' WHERE id='heisenberg';");
+	}
+
+	@Test // DATACASS-250
+	public void updateShouldUpdateEntityWithOptions() {
+
+		when(resultSet.wasApplied()).thenReturn(true);
+
+		UpdateOptions updateOptions = UpdateOptions.builder().withIfExists().build();
+
+		User user = new User("heisenberg", "Walter", "White");
+
+		User updated = template.update(user, updateOptions);
+
+		assertThat(updated).isEqualTo(user);
+		verify(session).execute(statementCaptor.capture());
+		assertThat(statementCaptor.getValue().toString())
+				.isEqualTo("UPDATE users SET firstname='Walter',lastname='White' WHERE id='heisenberg' IF EXISTS;");
 	}
 
 	@Test // DATACASS-292

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/InsertOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/InsertOptionsUnitTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link InsertOptions}.
+ *
+ * @author Mark Paluch
+ */
+public class InsertOptionsUnitTests {
+
+	@Test // DATACASS-250
+	public void shouldConfigureInsertOptions() {
+
+		InsertOptions insertOptions = InsertOptions.builder() //
+				.ttl(10) //
+				.withIfNotExists() //
+				.build();
+
+		assertThat(insertOptions.getTtl()).isEqualTo(10);
+		assertThat(insertOptions.isIfNotExists()).isTrue();
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/UpdateOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/UpdateOptionsUnitTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link UpdateOptions}.
+ *
+ * @author Mark Paluch
+ */
+public class UpdateOptionsUnitTests {
+
+	@Test // DATACASS-250
+	public void shouldConfigureInsertOptions() {
+
+		UpdateOptions insertOptions = UpdateOptions.builder() //
+				.ttl(10) //
+				.withIfExists() //
+				.build();
+
+		assertThat(insertOptions.getTtl()).isEqualTo(10);
+		assertThat(insertOptions.isIfExists()).isTrue();
+	}
+}

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -5,6 +5,7 @@
 == What's new in Spring Data for Apache Cassandra 2.0
 * `Update` and `Query` objects.
 * CRUD repository interface renaming: `CassandraRepository` using `MapId` is now renamed to `MapIdCassandraRepository`. `TypedIdCassandraRepository` is renamed to `CassandraRepository`.
+* Lightweight transactions via `InsertOptions` and `UpdateOptions` using the Template API.
 
 [[new-features.1-5-0]]
 == What's new in Spring Data for Apache Cassandra 1.5

--- a/src/main/asciidoc/reference/cassandra.adoc
+++ b/src/main/asciidoc/reference/cassandra.adoc
@@ -1160,14 +1160,15 @@ Person qp = cassandraTemplate.selectOne(query(where("age").is(33)), Person.class
 The insert/save operations available to you are listed below.
 
 * `T` *insert* `(T objectToSave)` Insert the object in an Apache Cassandra table.
-* `T` *insert* `(T objectToSave, WriteOptions writeOptions)` Insert the object in an Apache Cassandra table applying `WriteOptions`.
+* `T` *insert* `(T objectToSave, InsertOptions options)` Insert the object in an Apache Cassandra table applying `InsertOptions`.
 
 A similar set of update operations is listed below
 
 * `T` *update* `(T objectToSave)` Update the object in an Apache Cassandra table.
-* `T` *update* `(T objectToSave, WriteOptions writeOptions)` Update the object in an Apache Cassandra table applying `WriteOptions`.
+* `T` *update* `(T objectToSave, UpdateOptions options)` Update the object in an Apache Cassandra table applying `UpdateOptions`.
 
-Then, there is always the old fashioned way. You can write your own CQL statements.
+Then, there is always the old fashioned way. You can write your own CQL statements. You can configure with `InsertOptions` and `UpdateOptions`
+additional options such as TTL, consistency level and lightweight transactions.
 
 [source,java]
 ----


### PR DESCRIPTION
We now support lightweight transactions via `InsertOptions` and `UpdateOptions`. Options can be used with the imperative, asynchronous and reactive templates using `insert(…)` and `update(…)` write methods. Write methods do not return the entity if the operation is not applied because of a lightweight transaction. Specifically, the resulting entity is `null` using the imperative and asynchronous Cassandra templates.

The reactive Cassandra template suppresses particular entities (inserted/updated through a entity stream) if its write operation was not applied due to a lightweight transaction.

```java
InsertOptions lwtInsertOptions = InsertOptions.builder().withIfNotExists().build();

User user = new User("heisenberg", "Walter", "White");
User inserted = template.insert(user, lwtInsertOptions);

UpdateOptions lwtUpdateOptions = UpdateOptions.builder().withIfExists().build();

User user = new User("heisenberg", "Walter", "White");
User updated = template.update(user, lwtUpdateOptions);
```

---

Related ticket: [DATACASS-250](https://jira.spring.io/browse/DATACASS-250).