### PR TITLE
DATACASS-376 - Support ALLOW FILTERING using derived query methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACASS-376-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-376-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-376-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/AllowFiltering.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/AllowFiltering.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013-2017 the original author or authors
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,31 +21,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.data.annotation.QueryAnnotation;
-
 /**
- * Annotation to declare finder queries directly on repository methods.
+ * Annotation to declare filtering for a derived query.
  *
- * @author Alex Shvid
- * @author Matthew T. Adams
  * @author Mark Paluch
+ * @since 2.0
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Documented
-@QueryAnnotation
-public @interface Query {
-
-	/**
-	 * A Cassandra CQL3 string to define the actual query to be executed. Placeholders {@code ?0}, {@code ?1}, etc are
-	 * supported.
-	 */
-	String value() default "";
-
-	/**
-	 * Specifies whether to allow filtering using query derivation without a {@link #value() string query}.
-	 *
-	 * @since 2.0
-	 */
-	boolean allowFiltering() default false;
+@Query(allowFiltering = true)
+public @interface AllowFiltering {
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQuery.java
@@ -102,8 +102,13 @@ public class PartTreeCassandraQuery extends AbstractCassandraQuery {
 		Query query = queryCreator.createQuery();
 
 		try {
+
 			if (getTree().isLimiting()) {
-				query.limit(getTree().getMaxResults());
+				query = query.limit(getTree().getMaxResults());
+			}
+
+			if (getQueryMethod().getQueryAnnotation().map(q -> q.allowFiltering()).orElse(false)) {
+				query = query.withAllowFiltering();
 			}
 
 			CassandraPersistentEntity<?> persistentEntity = getMappingContext()

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQuery.java
@@ -102,8 +102,13 @@ public class ReactivePartTreeCassandraQuery extends AbstractReactiveCassandraQue
 		Query query = queryCreator.createQuery();
 
 		try {
+
 			if (getTree().isLimiting()) {
-				query.limit(getTree().getMaxResults());
+				query = query.limit(getTree().getMaxResults());
+			}
+
+			if (getQueryMethod().getQueryAnnotation().map(q -> q.allowFiltering()).orElse(false)) {
+				query = query.withAllowFiltering();
 			}
 
 			CassandraPersistentEntity<?> persistentEntity = getMappingContext()

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQueryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQueryUnitTests.java
@@ -38,6 +38,7 @@ import org.springframework.data.cassandra.core.mapping.UserTypeResolver;
 import org.springframework.data.cassandra.domain.AddressType;
 import org.springframework.data.cassandra.domain.Group;
 import org.springframework.data.cassandra.domain.Person;
+import org.springframework.data.cassandra.repository.AllowFiltering;
 import org.springframework.data.cassandra.repository.MapIdCassandraRepository;
 import org.springframework.data.cassandra.repository.Query;
 import org.springframework.data.cql.core.CqlIdentifier;
@@ -155,6 +156,14 @@ public class PartTreeCassandraQueryUnitTests {
 		assertThat(query.toString()).isEqualTo("SELECT * FROM group WHERE hash_prefix='foo';");
 	}
 
+	@Test // DATACASS-376
+	public void shouldAllowFiltering() {
+
+		Statement query = deriveQueryFromMethod(Repo.class, "findByFirstname", new Class[] { String.class }, "foo");
+
+		assertThat(query.toString()).isEqualTo("SELECT * FROM person WHERE firstname='foo' ALLOW FILTERING;");
+	}
+
 	private String deriveQueryFromMethod(String method, Object... args) {
 
 		Class<?>[] types = new Class<?>[args.length];
@@ -223,6 +232,9 @@ public class PartTreeCassandraQueryUnitTests {
 		Person findByMainAddressIn(Collection<AddressType> address);
 
 		Person findByFirstnameIn(Collection<String> firstname);
+
+		@AllowFiltering
+		Person findByFirstname(String firstname);
 
 		PersonProjection findPersonProjectedBy();
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQueryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQueryUnitTests.java
@@ -87,6 +87,14 @@ public class ReactivePartTreeCassandraQueryUnitTests {
 		assertThat(query).isEqualTo("SELECT * FROM person WHERE firstname='foo' AND lastname='bar';");
 	}
 
+	@Test // DATACASS-376
+	public void shouldAllowFiltering() {
+
+		String query = deriveQueryFromMethod("findPersonByFirstname", "foo");
+
+		assertThat(query).isEqualTo("SELECT * FROM person WHERE firstname='foo' ALLOW FILTERING;");
+	}
+
 	@Test // DATACASS-335
 	public void usesDynamicProjection() {
 		String query = deriveQueryFromMethod("findDynamicallyProjectedBy", PersonProjection.class);
@@ -139,6 +147,9 @@ public class ReactivePartTreeCassandraQueryUnitTests {
 		Flux<Person> findByAge(Integer age);
 
 		Flux<Person> findPersonBy();
+
+		@Query(allowFiltering = true)
+		Flux<Person> findPersonByFirstname(String name);
 
 		Mono<PersonProjection> findPersonProjectedBy();
 


### PR DESCRIPTION
We now support allow filtering using derived query methods by annotating query methods with `@AllowFiltering`.

```java
interface PersonRepository extends Repository<Person, String> {

    @AllowFiltering
    List<Person> findAllByFirstname(String firstname);
}
```
---

Related ticket: [DATACASS-376](https://jira.spring.io/browse/DATACASS-376).