### PR TITLE
DATACASS-375 - Map UUID to Cassandra's uuid type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACASS-375-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-375-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-375-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraSimpleTypeHolder.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraSimpleTypeHolder.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.data.mapping.model.SimpleTypeHolder;
@@ -48,6 +49,7 @@ public class CassandraSimpleTypeHolder extends SimpleTypeHolder {
 	private static final Map<DataType.Name, DataType> nameToDataType;
 
 	static {
+
 		CodecRegistry codecRegistry = CodecRegistry.DEFAULT_INSTANCE;
 
 		Map<Class<?>, Class<?>> primitiveWrappers = new HashMap<>(8);
@@ -97,8 +99,8 @@ public class CassandraSimpleTypeHolder extends SimpleTypeHolder {
 
 	/**
 	 * @return the map between {@link Class} and {@link DataType}.
-	 * @param codecRegistry the Cassandra codec registry
-	 * @param primitiveWrappers map of primitive to wrapper type
+	 * @param codecRegistry the Cassandra codec registry.
+	 * @param primitiveWrappers map of primitive to wrapper type.
 	 */
 	private static Map<Class<?>, DataType> classToDataType(CodecRegistry codecRegistry,
 			Map<Class<?>, Class<?>> primitiveWrappers) {
@@ -122,13 +124,16 @@ public class CassandraSimpleTypeHolder extends SimpleTypeHolder {
 		classToDataType.put(Long.class, DataType.bigint());
 		classToDataType.put(long.class, DataType.bigint());
 
+		// override UUID to timeuuid as regular uuid is the favored default
+		classToDataType.put(UUID.class, DataType.uuid());
+
 		return classToDataType;
 	}
 
 	/**
 	 * Returns a {@link Set} containing all Cassandra primitive types.
 	 *
-	 * @param codecRegistry the Cassandra codec registry
+	 * @param codecRegistry the Cassandra codec registry.
 	 * @return the set of Cassandra primitive types.
 	 */
 	private static Set<Class<?>> getCassandraPrimitiveTypes(CodecRegistry codecRegistry) {

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentPropertyUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentPropertyUnitTests.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Field;
 import java.util.Date;
+import java.util.UUID;
 
 import org.junit.Test;
 import org.springframework.core.annotation.AliasFor;
@@ -95,6 +96,16 @@ public class BasicCassandraPersistentPropertyUnitTests {
 		assertThat(persistentProperty.findAnnotation(CassandraType.class)).isNotNull();
 	}
 
+	@Test // DATACASS-375
+	public void uuidShouldMapToUUIDByDefault() {
+
+		CassandraPersistentProperty uuidProperty = getPropertyFor(TypeWithUUIDColumn.class, "uuid");
+		CassandraPersistentProperty timeUUIDProperty = getPropertyFor(TypeWithUUIDColumn.class, "timeUUID");
+
+		assertThat(uuidProperty.getDataType().getName()).isEqualTo(Name.UUID);
+		assertThat(timeUUIDProperty.getDataType().getName()).isEqualTo(Name.TIMEUUID);
+	}
+
 	private CassandraPersistentProperty getPropertyFor(Class<?> type, String fieldName) {
 
 		Field field = ReflectionUtils.findField(type, fieldName);
@@ -161,5 +172,12 @@ public class BasicCassandraPersistentPropertyUnitTests {
 
 	static class TypeWithComposedCassandraTypeAnnotation {
 		@ComposedCassandraTypeAnnotation String column;
+	}
+
+	static class TypeWithUUIDColumn {
+
+		UUID uuid;
+
+		@CassandraType(type = Name.TIMEUUID) UUID timeUUID;
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/AllPossibleTypes.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/AllPossibleTypes.java
@@ -50,7 +50,7 @@ public class AllPossibleTypes {
 
 	private InetAddress inet;
 
-	@CassandraType(type = Name.UUID) private UUID uuid;
+	private UUID uuid;
 
 	@CassandraType(type = Name.INT) private Number justNumber;
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/UserToken.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/UserToken.java
@@ -19,13 +19,10 @@ import lombok.Data;
 
 import java.util.UUID;
 
-import org.springframework.data.cassandra.core.mapping.CassandraType;
 import org.springframework.data.cassandra.core.mapping.Column;
 import org.springframework.data.cassandra.core.mapping.PrimaryKeyColumn;
 import org.springframework.data.cassandra.core.mapping.Table;
 import org.springframework.data.cql.core.PrimaryKeyType;
-
-import com.datastax.driver.core.DataType.Name;
 
 /**
  * @author Mark Paluch
@@ -34,10 +31,8 @@ import com.datastax.driver.core.DataType.Name;
 @Data
 public class UserToken {
 
-	@PrimaryKeyColumn(name = "user_id", type = PrimaryKeyType.PARTITIONED,
-			ordinal = 0) @CassandraType(type = Name.UUID) private UUID userId;
-	@PrimaryKeyColumn(name = "auth_token", type = PrimaryKeyType.CLUSTERED,
-			ordinal = 1) @CassandraType(type = Name.UUID) private UUID token;
+	@PrimaryKeyColumn(name = "user_id", type = PrimaryKeyType.PARTITIONED, ordinal = 0) private UUID userId;
+	@PrimaryKeyColumn(name = "auth_token", type = PrimaryKeyType.CLUSTERED, ordinal = 1) private UUID token;
 
 	@Column("user_comment") String userComment;
 	String adminComment;


### PR DESCRIPTION
We now map Java's UUID by default to uuid instead of previously timeuuid. The uuid type is a better default after all and comes without the time type restriction.

---

Related ticket: [DATACASS-375](https://jira.spring.io/browse/DATACASS-375).