### PR TITLE
DATACASS-145, DATACASS-146 - Enhance repository methods to accept QueryOptions as arguments.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACASS-145-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-145-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-145-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/Consistency.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/Consistency.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.data.annotation.QueryAnnotation;
+
+import com.datastax.driver.core.ConsistencyLevel;
+
+/**
+ * Annotation to declare a {@link ConsistencyLevel} for CQL queries executed through query methods.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ * @see org.springframework.data.cassandra.core.cql.QueryOptions
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@QueryAnnotation
+public @interface Consistency {
+
+	/**
+	 * @return the {@link ConsistencyLevel} applied to the query executed using a query method.
+	 */
+	ConsistencyLevel value();
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/AbstractCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/AbstractCassandraQuery.java
@@ -57,6 +57,8 @@ public abstract class AbstractCassandraQuery implements RepositoryQuery {
 
 	private final EntityInstantiators instantiators;
 
+	QueryMethodStatementFactory queryMethodStatementFactory;
+
 	/**
 	 * Create a new {@link AbstractCassandraQuery} from the given {@link CassandraQueryMethod} and
 	 * {@link CassandraOperations}.
@@ -72,6 +74,7 @@ public abstract class AbstractCassandraQuery implements RepositoryQuery {
 		this.queryMethod = queryMethod;
 		this.operations = operations;
 		this.instantiators = new EntityInstantiators();
+		this.queryMethodStatementFactory = new QueryMethodStatementFactory(queryMethod);
 	}
 
 	/* (non-Javadoc) */

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/AbstractReactiveCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/AbstractReactiveCassandraQuery.java
@@ -48,6 +48,8 @@ public abstract class AbstractReactiveCassandraQuery implements RepositoryQuery 
 
 	private final EntityInstantiators instantiators;
 
+	QueryMethodStatementFactory queryMethodStatementFactory;
+
 	/**
 	 * Create a new {@link AbstractReactiveCassandraQuery} from the given {@link CassandraQueryMethod} and
 	 * {@link CassandraOperations}.
@@ -63,6 +65,7 @@ public abstract class AbstractReactiveCassandraQuery implements RepositoryQuery 
 		this.method = method;
 		this.operations = operations;
 		this.instantiators = new EntityInstantiators();
+		this.queryMethodStatementFactory = new QueryMethodStatementFactory(method);
 	}
 
 	/* (non-Javadoc) */

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParameterAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParameterAccessor.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.cassandra.repository.query;
 
+import org.springframework.data.cassandra.core.cql.QueryOptions;
 import org.springframework.data.cassandra.core.mapping.CassandraType;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.lang.Nullable;
@@ -69,4 +70,13 @@ public interface CassandraParameterAccessor extends ParameterAccessor {
 	 * @since 1.5
 	 */
 	Object[] getValues();
+
+	/**
+	 * Returns the {@link QueryOptions} associated of the associated query method.
+	 *
+	 * @return the {@link QueryOptions} or {@literal null} if none.
+	 * @since 2.0
+	 */
+	@Nullable
+	QueryOptions getQueryOptions();
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParametersParameterAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParametersParameterAccessor.java
@@ -54,15 +54,6 @@ public class CassandraParametersParameterAccessor extends ParametersParameterAcc
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#findCassandraType(int)
-	 */
-	@Nullable
-	public CassandraType findCassandraType(int index) {
-		return getParameters().getParameter(index).getCassandraType();
-	}
-
-	/*
-	 * (non-Javadoc)
 	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#getDataType(int)
 	 */
 	@Override
@@ -76,11 +67,11 @@ public class CassandraParametersParameterAccessor extends ParametersParameterAcc
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.query.ParametersParameterAccessor#getParameters()
+	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#findCassandraType(int)
 	 */
-	@Override
-	public CassandraParameters getParameters() {
-		return (CassandraParameters) super.getParameters();
+	@Nullable
+	public CassandraType findCassandraType(int index) {
+		return getParameters().getParameter(index).getCassandraType();
 	}
 
 	/*
@@ -90,6 +81,15 @@ public class CassandraParametersParameterAccessor extends ParametersParameterAcc
 	@Override
 	public Class<?> getParameterType(int index) {
 		return getParameters().getParameter(index).getType();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.ParametersParameterAccessor#getParameters()
+	 */
+	@Override
+	public CassandraParameters getParameters() {
+		return (CassandraParameters) super.getParameters();
 	}
 
 	/*

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParametersParameterAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParametersParameterAccessor.java
@@ -18,6 +18,7 @@ package org.springframework.data.cassandra.repository.query;
 import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.data.cassandra.core.cql.QueryOptions;
 import org.springframework.data.cassandra.core.mapping.CassandraSimpleTypeHolder;
 import org.springframework.data.cassandra.core.mapping.CassandraType;
 import org.springframework.data.repository.query.ParameterAccessor;
@@ -98,5 +99,28 @@ public class CassandraParametersParameterAccessor extends ParametersParameterAcc
 	@Override
 	public Object[] getValues() {
 		return values.toArray();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mongodb.repository.query.CassandraParameterAccessor#getQueryOptions()
+	 */
+	@Nullable
+	@Override
+	public QueryOptions getQueryOptions() {
+
+		int queryOptionsIndex = getParameters().getQueryOptionsIndex();
+
+		if (queryOptionsIndex == -1) {
+			return null;
+		}
+
+		Object value = getValue(queryOptionsIndex);
+
+		if (value == null) {
+			return null;
+		}
+
+		return (QueryOptions) value;
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraQueryCreator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraQueryCreator.java
@@ -115,10 +115,6 @@ class CassandraQueryCreator extends AbstractQueryCreator<Query, CriteriaDefiniti
 	@Override
 	protected CriteriaDefinition and(Part part, CriteriaDefinition base, Iterator<Object> iterator) {
 
-		if (base == null) {
-			return getQueryBuilder().and(create(part, iterator));
-		}
-
 		getQueryBuilder().and(base);
 
 		return create(part, iterator);

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraRepositoryQuerySupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraRepositoryQuerySupport.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.query;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.convert.CustomConversions;
+import org.springframework.data.convert.EntityInstantiators;
+import org.springframework.data.repository.query.RepositoryQuery;
+import org.springframework.data.repository.query.ReturnedType;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Base class for Cassandra {@link RepositoryQuery} implementations providing common infrastructure such as
+ * {@link EntityInstantiators} and {@link QueryStatementCreator}.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+public abstract class CassandraRepositoryQuerySupport implements RepositoryQuery {
+
+	protected final Logger log = LoggerFactory.getLogger(getClass());
+
+	private final CassandraQueryMethod queryMethod;
+
+	private final EntityInstantiators instantiators;
+
+	private final QueryStatementCreator queryStatementCreator;
+
+	/**
+	 * Create a new {@link AbstractCassandraQuery} from the given {@link CassandraQueryMethod} and
+	 * {@link CassandraOperations}.
+	 *
+	 * @param queryMethod must not be {@literal null}.
+	 * @param operations must not be {@literal null}.
+	 */
+	public CassandraRepositoryQuerySupport(CassandraQueryMethod queryMethod) {
+
+		Assert.notNull(queryMethod, "CassandraQueryMethod must not be null");
+
+		this.queryMethod = queryMethod;
+		this.instantiators = new EntityInstantiators();
+		this.queryStatementCreator = new QueryStatementCreator(queryMethod);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.repository.query.RepositoryQuery#getQueryMethod()
+	 */
+	@Override
+	public CassandraQueryMethod getQueryMethod() {
+		return this.queryMethod;
+	}
+
+	protected EntityInstantiators getEntityInstantiators() {
+		return this.instantiators;
+	}
+
+	protected QueryStatementCreator getQueryStatementCreator() {
+		return queryStatementCreator;
+	}
+
+	@RequiredArgsConstructor
+	class CassandraReturnedType {
+
+		private final ReturnedType returnedType;
+		private final CustomConversions customConversions;
+
+		boolean isProjecting() {
+
+			if (!returnedType.isProjecting()) {
+				return false;
+			}
+
+			// Spring Data Cassandra allows List<Map<String, Object> and Map<String, Object> declarations
+			// on query methods so we don't want to let projection kick in
+			if (ClassUtils.isAssignable(Map.class, returnedType.getReturnedType())) {
+				return false;
+			}
+
+			// Type conversion using registered conversions is handled on template level
+			if (customConversions.hasCustomWriteTarget(returnedType.getReturnedType())) {
+				return false;
+			}
+
+			// Don't apply projection on Cassandra simple types
+			return !customConversions.isSimpleType(returnedType.getReturnedType());
+		}
+
+		Class<?> getDomainType() {
+			return returnedType.getDomainType();
+		}
+
+		Class<?> getReturnedType() {
+			return returnedType.getReturnedType();
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ConvertingParameterAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ConvertingParameterAccessor.java
@@ -90,6 +90,14 @@ class ConvertingParameterAccessor implements CassandraParameterAccessor {
 	}
 
 	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#getDataType(int)
+	 */
+	@Override
+	public DataType getDataType(int index) {
+		return delegate.getDataType(index);
+	}
+
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#findCassandraType(int)
 	 */
 	@Override
@@ -97,13 +105,6 @@ class ConvertingParameterAccessor implements CassandraParameterAccessor {
 		return delegate.findCassandraType(index);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#getDataType(int)
-	 */
-	@Override
-	public DataType getDataType(int index) {
-		return delegate.getDataType(index);
-	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#getParameterType(int)

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ConvertingParameterAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ConvertingParameterAccessor.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.data.cassandra.core.convert.CassandraConverter;
+import org.springframework.data.cassandra.core.cql.QueryOptions;
 import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty;
 import org.springframework.data.cassandra.core.mapping.CassandraSimpleTypeHolder;
@@ -110,6 +111,15 @@ class ConvertingParameterAccessor implements CassandraParameterAccessor {
 	@Override
 	public Class<?> getParameterType(int index) {
 		return delegate.getParameterType(index);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#getQueryOptions()
+	 */
+	@Nullable
+	@Override
+	public QueryOptions getQueryOptions() {
+		return delegate.getQueryOptions();
 	}
 
 	/* (non-Javadoc)

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQuery.java
@@ -94,6 +94,7 @@ public class PartTreeCassandraQuery extends AbstractCassandraQuery {
 	 */
 	@Override
 	protected Statement createQuery(CassandraParameterAccessor parameterAccessor) {
-		return queryMethodStatementFactory.select(statementFactory, getTree(), getMappingContext(), parameterAccessor);
+		return getQueryStatementCreator().select(getStatementFactory(), getTree(), getMappingContext(),
+				parameterAccessor);
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQuery.java
@@ -22,9 +22,7 @@ import org.springframework.data.cassandra.core.convert.UpdateMapper;
 import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
 import org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty;
-import org.springframework.data.cassandra.core.query.Query;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.repository.query.QueryCreationException;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.parser.PartTree;
@@ -96,30 +94,6 @@ public class PartTreeCassandraQuery extends AbstractCassandraQuery {
 	 */
 	@Override
 	protected Statement createQuery(CassandraParameterAccessor parameterAccessor) {
-
-		CassandraQueryCreator queryCreator = new CassandraQueryCreator(getTree(), parameterAccessor, getMappingContext());
-
-		Query query = queryCreator.createQuery();
-
-		try {
-
-			if (getTree().isLimiting()) {
-				query = query.limit(getTree().getMaxResults());
-			}
-
-			if (getQueryMethod().getQueryAnnotation().map(org.springframework.data.cassandra.repository.Query::allowFiltering)
-					.orElse(false)) {
-
-				query = query.withAllowFiltering();
-			}
-
-			CassandraPersistentEntity<?> persistentEntity = getMappingContext()
-					.getRequiredPersistentEntity(getQueryMethod().getDomainClass());
-
-			return getStatementFactory().select(query, persistentEntity);
-
-		} catch (RuntimeException e) {
-			throw QueryCreationException.create(getQueryMethod(), e);
-		}
+		return queryMethodStatementFactory.select(statementFactory, getTree(), getMappingContext(), parameterAccessor);
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/QueryMethodStatementFactory.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/QueryMethodStatementFactory.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.query;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.cassandra.core.StatementFactory;
+import org.springframework.data.cassandra.core.cql.QueryOptions;
+import org.springframework.data.cassandra.core.cql.QueryOptionsUtil;
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.repository.query.QueryCreationException;
+import org.springframework.data.repository.query.parser.PartTree;
+
+import com.datastax.driver.core.RegularStatement;
+import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.Statement;
+
+/**
+ * @author Mark Paluch
+ * @since 2.0
+ */
+@RequiredArgsConstructor
+class QueryMethodStatementFactory {
+
+	private static final Logger LOG = LoggerFactory.getLogger(QueryMethodStatementFactory.class);
+
+	private final CassandraQueryMethod queryMethod;
+
+	Statement select(StatementFactory statementFactory, PartTree tree,
+			MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> mappingContext,
+			CassandraParameterAccessor parameterAccessor) {
+
+		CassandraQueryCreator queryCreator = new CassandraQueryCreator(tree, parameterAccessor, mappingContext);
+
+		Query query = queryCreator.createQuery();
+
+		try {
+
+			if (tree.isLimiting()) {
+				query = query.limit(tree.getMaxResults());
+			}
+
+			if (queryMethod.getQueryAnnotation().map(org.springframework.data.cassandra.repository.Query::allowFiltering)
+					.orElse(false)) {
+
+				query = query.withAllowFiltering();
+			}
+
+			Optional<QueryOptions> queryOptions = Optional.ofNullable(parameterAccessor.getQueryOptions());
+
+			if (queryOptions.isPresent()) {
+				query = Optional.ofNullable(parameterAccessor.getQueryOptions()).map(query::queryOptions).orElse(query);
+			} else if (queryMethod.hasConsistencyLevel()) {
+				query = query.queryOptions(
+						QueryOptions.builder().consistencyLevel(queryMethod.getRequiredAnnotatedConsistencyLevel()).build());
+			}
+
+			CassandraPersistentEntity<?> persistentEntity = mappingContext
+					.getRequiredPersistentEntity(queryMethod.getDomainClass());
+
+			RegularStatement statement = statementFactory.select(query, persistentEntity);
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug(String.format("Created query [%s].", statement));
+			}
+
+			return statement;
+
+		} catch (RuntimeException e) {
+			throw QueryCreationException.create(queryMethod, e);
+		}
+	}
+
+	SimpleStatement select(StringBasedQuery stringBasedQuery, CassandraParameterAccessor parameterAccessor) {
+
+		try {
+
+			SimpleStatement boundQuery = stringBasedQuery.bindQuery(parameterAccessor, queryMethod);
+
+			Optional<QueryOptions> queryOptions = Optional.ofNullable(parameterAccessor.getQueryOptions());
+
+			SimpleStatement queryToUse = boundQuery;
+
+			if (queryOptions.isPresent()) {
+				queryToUse = Optional.ofNullable(parameterAccessor.getQueryOptions())
+						.map(it -> QueryOptionsUtil.addQueryOptions(boundQuery, it)).orElse(boundQuery);
+			} else if (queryMethod.hasConsistencyLevel()) {
+				queryToUse.setConsistencyLevel(queryMethod.getRequiredAnnotatedConsistencyLevel());
+			}
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug(String.format("Created query [%s].", queryToUse));
+			}
+
+			return queryToUse;
+		} catch (RuntimeException e) {
+			throw QueryCreationException.create(queryMethod, e);
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/QueryStatementCreator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/QueryStatementCreator.java
@@ -36,16 +36,28 @@ import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.Statement;
 
 /**
+ * Creates {@link Statement}s for {@link CassandraQueryMethod query methods} based on {@link PartTree} and
+ * {@link StringBasedQuery}.
+ *
  * @author Mark Paluch
  * @since 2.0
  */
 @RequiredArgsConstructor
-class QueryMethodStatementFactory {
+class QueryStatementCreator {
 
-	private static final Logger LOG = LoggerFactory.getLogger(QueryMethodStatementFactory.class);
+	private static final Logger LOG = LoggerFactory.getLogger(QueryStatementCreator.class);
 
 	private final CassandraQueryMethod queryMethod;
 
+	/**
+	 * Create a {@literal SELECT} {@link Statement} from a {@link PartTree} and apply query options.
+	 *
+	 * @param statementFactory must not be {@literal null}.
+	 * @param tree must not be {@literal null}.
+	 * @param mappingContext must not be {@literal null}.
+	 * @param parameterAccessor must not be {@literal null}.
+	 * @return the {@literal SELECT} {@link Statement}.
+	 */
 	Statement select(StatementFactory statementFactory, PartTree tree,
 			MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> mappingContext,
 			CassandraParameterAccessor parameterAccessor) {
@@ -91,6 +103,13 @@ class QueryMethodStatementFactory {
 		}
 	}
 
+	/**
+	 * Create a {@link Statement} from a {@link StringBasedQuery} and apply query options.
+	 *
+	 * @param stringBasedQuery must not be {@literal null}.
+	 * @param parameterAccessor must not be {@literal null}.
+	 * @return the {@link Statement}.
+	 */
 	SimpleStatement select(StringBasedQuery stringBasedQuery, CassandraParameterAccessor parameterAccessor) {
 
 		try {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQuery.java
@@ -21,9 +21,7 @@ import org.springframework.data.cassandra.core.convert.UpdateMapper;
 import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
 import org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty;
-import org.springframework.data.cassandra.core.query.Query;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.repository.query.QueryCreationException;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.parser.PartTree;
 
@@ -96,30 +94,6 @@ public class ReactivePartTreeCassandraQuery extends AbstractReactiveCassandraQue
 	 */
 	@Override
 	protected Statement createQuery(CassandraParameterAccessor parameterAccessor) {
-
-		CassandraQueryCreator queryCreator = new CassandraQueryCreator(getTree(), parameterAccessor, getMappingContext());
-
-		Query query = queryCreator.createQuery();
-
-		try {
-
-			if (getTree().isLimiting()) {
-				query = query.limit(getTree().getMaxResults());
-			}
-
-			if (getQueryMethod().getQueryAnnotation().map(org.springframework.data.cassandra.repository.Query::allowFiltering)
-					.orElse(false)) {
-
-				query = query.withAllowFiltering();
-			}
-
-			CassandraPersistentEntity<?> persistentEntity = getMappingContext()
-					.getRequiredPersistentEntity(getQueryMethod().getDomainClass());
-
-			return getStatementFactory().select(query, persistentEntity);
-
-		} catch (RuntimeException e) {
-			throw QueryCreationException.create(getQueryMethod(), e);
-		}
+		return queryMethodStatementFactory.select(statementFactory, getTree(), getMappingContext(), parameterAccessor);
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQuery.java
@@ -94,6 +94,6 @@ public class ReactivePartTreeCassandraQuery extends AbstractReactiveCassandraQue
 	 */
 	@Override
 	protected Statement createQuery(CassandraParameterAccessor parameterAccessor) {
-		return queryMethodStatementFactory.select(statementFactory, getTree(), getMappingContext(), parameterAccessor);
+		return getQueryStatementCreator().select(statementFactory, getTree(), getMappingContext(), parameterAccessor);
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactiveStringBasedCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactiveStringBasedCassandraQuery.java
@@ -15,11 +15,9 @@
  */
 package org.springframework.data.cassandra.repository.query;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datastax.driver.core.Statement;
 import org.springframework.data.cassandra.core.ReactiveCassandraOperations;
 import org.springframework.data.repository.query.EvaluationContextProvider;
-import org.springframework.data.repository.query.QueryCreationException;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.util.Assert;
 
@@ -37,8 +35,6 @@ import com.datastax.driver.core.SimpleStatement;
  * @see org.springframework.data.cassandra.repository.Query
  */
 public class ReactiveStringBasedCassandraQuery extends AbstractReactiveCassandraQuery {
-
-	private static final Logger LOG = LoggerFactory.getLogger(ReactiveStringBasedCassandraQuery.class);
 
 	private final StringBasedQuery stringBasedQuery;
 
@@ -91,17 +87,6 @@ public class ReactiveStringBasedCassandraQuery extends AbstractReactiveCassandra
 	 */
 	@Override
 	public SimpleStatement createQuery(CassandraParameterAccessor parameterAccessor) {
-
-		try {
-			SimpleStatement boundQuery = getStringBasedQuery().bindQuery(parameterAccessor, getQueryMethod());
-
-			if (LOG.isDebugEnabled()) {
-				LOG.debug(String.format("Created query [%s].", boundQuery));
-			}
-
-			return boundQuery;
-		} catch (RuntimeException e) {
-			throw QueryCreationException.create(getQueryMethod(), e);
-		}
+		return queryMethodStatementFactory.select(getStringBasedQuery(), parameterAccessor);
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactiveStringBasedCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactiveStringBasedCassandraQuery.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.cassandra.repository.query;
 
-import com.datastax.driver.core.Statement;
 import org.springframework.data.cassandra.core.ReactiveCassandraOperations;
 import org.springframework.data.repository.query.EvaluationContextProvider;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -77,7 +76,6 @@ public class ReactiveStringBasedCassandraQuery extends AbstractReactiveCassandra
 				new ExpressionEvaluatingParameterBinder(expressionParser, evaluationContextProvider));
 	}
 
-	/* (non-Javadoc) */
 	protected StringBasedQuery getStringBasedQuery() {
 		return this.stringBasedQuery;
 	}
@@ -87,6 +85,6 @@ public class ReactiveStringBasedCassandraQuery extends AbstractReactiveCassandra
 	 */
 	@Override
 	public SimpleStatement createQuery(CassandraParameterAccessor parameterAccessor) {
-		return queryMethodStatementFactory.select(getStringBasedQuery(), parameterAccessor);
+		return getQueryStatementCreator().select(getStringBasedQuery(), parameterAccessor);
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/StringBasedCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/StringBasedCassandraQuery.java
@@ -15,11 +15,8 @@
  */
 package org.springframework.data.cassandra.repository.query;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.data.repository.query.EvaluationContextProvider;
-import org.springframework.data.repository.query.QueryCreationException;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 import com.datastax.driver.core.SimpleStatement;
@@ -36,8 +33,6 @@ import com.datastax.driver.core.SimpleStatement;
  * @see org.springframework.data.cassandra.repository.Query
  */
 public class StringBasedCassandraQuery extends AbstractCassandraQuery {
-
-	private static final Logger LOG = LoggerFactory.getLogger(StringBasedCassandraQuery.class);
 
 	private final StringBasedQuery stringBasedQuery;
 
@@ -87,17 +82,6 @@ public class StringBasedCassandraQuery extends AbstractCassandraQuery {
 	 */
 	@Override
 	public SimpleStatement createQuery(CassandraParameterAccessor parameterAccessor) {
-
-		try {
-			SimpleStatement boundQuery = getStringBasedQuery().bindQuery(parameterAccessor, getQueryMethod());
-
-			if (LOG.isDebugEnabled()) {
-				LOG.debug(String.format("Created query [%s].", boundQuery));
-			}
-
-			return boundQuery;
-		} catch (RuntimeException e) {
-			throw QueryCreationException.create(getQueryMethod(), e);
-		}
+		return queryMethodStatementFactory.select(getStringBasedQuery(), parameterAccessor);
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/StringBasedCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/StringBasedCassandraQuery.java
@@ -72,7 +72,6 @@ public class StringBasedCassandraQuery extends AbstractCassandraQuery {
 				new ExpressionEvaluatingParameterBinder(expressionParser, evaluationContextProvider));
 	}
 
-	/* (non-Javadoc) */
 	protected StringBasedQuery getStringBasedQuery() {
 		return this.stringBasedQuery;
 	}
@@ -82,6 +81,6 @@ public class StringBasedCassandraQuery extends AbstractCassandraQuery {
 	 */
 	@Override
 	public SimpleStatement createQuery(CassandraParameterAccessor parameterAccessor) {
-		return queryMethodStatementFactory.select(getStringBasedQuery(), parameterAccessor);
+		return getQueryStatementCreator().select(getStringBasedQuery(), parameterAccessor);
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/InsertUtil.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/InsertUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.support;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.springframework.data.cassandra.core.convert.CassandraConverter;
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
+
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+
+/**
+ * Utility to create {@link com.datastax.driver.core.querybuilder.Insert} statements for repository use.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+@UtilityClass
+class InsertUtil {
+
+	/**
+	 * Create a {@link Insert} statement containing all properties including these with {@literal null} values.
+	 *
+	 * @param entity the entity, must not be {@literal null}.
+	 * @return the constructed {@link Insert} statement.
+	 */
+	static Insert createInsert(CassandraConverter converter, Object entity) {
+
+		CassandraPersistentEntity<?> persistentEntity = converter.getMappingContext()
+				.getRequiredPersistentEntity(entity.getClass());
+
+		Map<String, Object> toInsert = new LinkedHashMap<>();
+
+		converter.write(entity, toInsert, persistentEntity);
+
+		Insert insert = QueryBuilder.insertInto(persistentEntity.getTableName().toCql());
+
+		for (Entry<String, Object> entry : toInsert.entrySet()) {
+			insert.value(entry.getKey(), entry.getValue());
+		}
+
+		return insert;
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/SimpleCassandraRepository.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/SimpleCassandraRepository.java
@@ -76,7 +76,7 @@ public class SimpleCassandraRepository<T, ID> implements CassandraRepository<T, 
 
 		Assert.notNull(entity, "Entity must not be null");
 
-		Insert insert = createFullInsert(entity);
+		Insert insert = createInsert(entity);
 
 		operations.getCqlOperations().execute(insert);
 
@@ -96,30 +96,20 @@ public class SimpleCassandraRepository<T, ID> implements CassandraRepository<T, 
 		for (S entity : entities) {
 
 			result.add(entity);
-			operations.getCqlOperations().execute(createFullInsert(entity));
+			operations.getCqlOperations().execute(createInsert(entity));
 		}
 
 		return result;
 	}
 
-	private <S extends T> Insert createFullInsert(S entity) {
-
-		CassandraConverter converter = operations.getConverter();
-
-		CassandraPersistentEntity<?> persistentEntity = converter.getMappingContext()
-				.getRequiredPersistentEntity(entity.getClass());
-
-		Map<String, Object> toInsert = new LinkedHashMap<>();
-
-		converter.write(entity, toInsert, persistentEntity);
-
-		Insert insert = QueryBuilder.insertInto(persistentEntity.getTableName().toCql());
-
-		for (Entry<String, Object> entry : toInsert.entrySet()) {
-			insert.value(entry.getKey(), entry.getValue());
-		}
-
-		return insert;
+	/**
+	 * Create a {@link Insert} statement containing all properties including these with {@literal null} values.
+	 *
+	 * @param entity the entity, must not be {@literal null}.
+	 * @return the constructed {@link Insert} statement.
+	 */
+	protected <S extends T> Insert createInsert(S entity) {
+		return InsertUtil.createInsert(operations.getConverter(), entity);
 	}
 
 	/* (non-Javadoc)

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/StubParameterAccessor.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/StubParameterAccessor.java
@@ -20,10 +20,12 @@ import java.util.Iterator;
 import java.util.Optional;
 
 import org.springframework.data.cassandra.core.convert.CassandraConverter;
+import org.springframework.data.cassandra.core.cql.QueryOptions;
 import org.springframework.data.cassandra.core.mapping.CassandraType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.query.ParameterAccessor;
+import org.springframework.lang.Nullable;
 
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.DataType;
@@ -62,6 +64,12 @@ class StubParameterAccessor implements CassandraParameterAccessor {
 	@Override
 	public Class<?> getParameterType(int index) {
 		return values[index].getClass();
+	}
+
+	@Nullable
+	@Override
+	public QueryOptions getQueryOptions() {
+		return null;
 	}
 
 	@Override

--- a/src/main/asciidoc/reference/cassandra-repositories.adoc
+++ b/src/main/asciidoc/reference/cassandra-repositories.adoc
@@ -147,23 +147,26 @@ the Apache Cassandra database. Defining such a query is just a matter of declari
 ----
 public interface PersonRepository extends CrudRepository<Person, String> {
 
-    List<Person> findByLastname(String lastname);                      <1>
+    List<Person> findByLastname(String lastname);                        <1>
 
-    List<Person> findByFirstname(String firstname, Sort sort);         <2>
+    List<Person> findByFirstname(String firstname, Sort sort);           <2>
 
-    Person findByShippingAddress(Address address);                     <3>
+    List<Person> findByFirstname(String firstname, QueryOptions opts);   <3>
 
-    Stream<Person> findAllBy();                                        <4>
+    Person findByShippingAddress(Address address);                       <4>
+
+    Stream<Person> findAllBy();                                          <5>
 }
 ----
 <1> The method shows a query for all people with the given `lastname`. The query will be derived from parsing
 the method name for constraints which can be concatenated with `And`. Thus the method name will result in
 a query expression of `SELECT * from person WHERE lastname = 'lastname'`.
-<2> Applies dynamic sorting to a query. Just add a `Sort` parameter to your method signature and Spring Data
+<2> Applies dynamic sorting to a query. Just add a `Sort` parameter to your method signature and Spring Data.
 will automatically apply ordering to the query accordingly.
-<3> Shows that you can query based on properties which are not a primitive type using registered `Converter`'s
+<3> Passing a `QueryOptions` object will apply the query options to the resulting query before it's execution.
+<4> Shows that you can query based on properties which are not a primitive type using registered `Converter`'s.
 in `CustomConversions`.
-<4> Uses a Java 8 `Stream` which reads and converts individual elements while iterating the stream.
+<5> Uses a Java 8 `Stream` which reads and converts individual elements while iterating the stream.
 ====
 
 NOTE: Querying non-primary key properties requires secondary indexes.
@@ -230,6 +233,31 @@ NOTE: Querying non-primary key properties requires secondary indexes.
 |===
 
 include::../{spring-data-commons-docs}/repository-projections.adoc[leveloffset=+2]
+
+=== Query options
+
+You can specify query options for query methods by passing a `QueryOptions` object
+to apply options to the query before the actual query execution.
+`QueryOptions` is treated as non-query parameter and isn't considered as query parameter value.
+
+For static declaration of a consistency level, use the `@Consistency` annotation on query methods.
+The declared consistency level is applied to the query each time it is executed.
+
+Query options are applicable to derived and string `@Query` repository methods.
+
+----
+public interface PersonRepository extends CrudRepository<Person, String> {
+
+    @Consistency(ConsistencyLevel.LOCAL_ONE)
+    List<Person> findByLastname(String lastname);
+
+    List<Person> findByFirstname(String firstname, QueryOptions options);
+}
+----
+
+NOTE: You can control fetch size, consistency level and retry policy defaults by configuring these parameters
+on the CQL API instances `CqlTemplate`, `AsyncCqlTemplate`, and `ReactiveCqlTemplate`. Defaults apply if the particular
+query option is not set.
 
 [[cassandra.repositories.misc]]
 == Miscellaneous

--- a/src/main/asciidoc/reference/cassandra.adoc
+++ b/src/main/asciidoc/reference/cassandra.adoc
@@ -732,6 +732,10 @@ All CQL issued by this class is logged at the `DEBUG` level under the category c
 name of the template instance (typically `CqlTemplate`, but it may be different if you are using a custom subclass of the
 `CqlTemplate` class).
 
+You can control fetch size, consistency level and retry policy defaults by configuring these parameters
+on the CQL API instances `CqlTemplate`, `AsyncCqlTemplate`, and `ReactiveCqlTemplate`. Defaults apply if the particular
+query option is not set.
+
 NOTE: `CqlTemplate` comes in different execution model flavors. The basic `CqlTemplate` uses a blocking execution model.
 You can use `AsyncCqlTemplate` for asynchronous execution and synchronization with ``Future``s or
 `ReactiveCqlTemplate` for reactive execution.


### PR DESCRIPTION
We now support query options using repository query methods. Query options can be passed either as additional parameter to a query method or
applied with annotations. Annotation-based query options are supported via @Consistency. A query options parameter has precedence over the annotation if a method declares both, an annotation-based consistency level and accepts a query options parameter.

```java
interface SampleRepository extends Repository<Person, String> {

  @Query("SELECT * FROM person WHERE lastname = ?0;")
  @Consistency(ConsistencyLevel.LOCAL_ONE)
  Person findByLastname(String lastname);

  @Consistency(ConsistencyLevel.LOCAL_ONE)
  Person findByAge(int age);

  Person findByAge(int age, QueryOptions options);
}

SampleRepository repository = …;

repository.findByAge(42, QueryOptions.builder().fetchSize(44).build());
```

Expose createInsert(…) in the synchronous and reactive repository base classes to simplify base class extension. Derived classes are no longer required to implement createInsert(…) themselves but can reuse the existing methods. Extract createInsert(…) body to InsertUtil.

---

Related tickets: [DATACASS-145](https://jira.spring.io/browse/DATACASS-145), [DATACASS-146](https://jira.spring.io/browse/DATACASS-146).