### PR TITLE
DATACASS-56 - Cassandra paging support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACASS-56-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-56-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATACASS-56-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraOperations.java
@@ -23,8 +23,10 @@ import org.springframework.data.cassandra.core.convert.CassandraConverter;
 import org.springframework.data.cassandra.core.cql.AsyncCqlOperations;
 import org.springframework.data.cassandra.core.cql.QueryOptions;
 import org.springframework.data.cassandra.core.cql.WriteOptions;
+import org.springframework.data.cassandra.core.query.CassandraPageRequest;
 import org.springframework.data.cassandra.core.query.Query;
 import org.springframework.data.cassandra.core.query.Update;
+import org.springframework.data.domain.Slice;
 import org.springframework.util.concurrent.ListenableFuture;
 
 import com.datastax.driver.core.Statement;
@@ -111,6 +113,18 @@ public interface AsyncCassandraOperations {
 	<T> ListenableFuture<List<T>> select(Statement statement, Class<T> entityClass) throws DataAccessException;
 
 	/**
+	 * Execute a {@code SELECT} query with paging and convert the resulting items to a {@link Slice} of entities. A sliced
+	 * query translates the effective {@link Statement#getFetchSize() fetch size} to the page size.
+	 *
+	 * @param statement the CQL statement, must not be {@literal null}.
+	 * @param entityClass The entity type must not be {@literal null}.
+	 * @return the converted results
+	 * @throws DataAccessException if there is any problem executing the query.
+	 * @see CassandraPageRequest
+	 */
+	<T> ListenableFuture<Slice<T>> slice(Statement statement, Class<T> entityClass) throws DataAccessException;
+
+	/**
 	 * Execute a {@code SELECT} query and convert the resulting items notifying {@link Consumer} for each entity.
 	 *
 	 * @param statement must not be {@literal null}.
@@ -146,6 +160,17 @@ public interface AsyncCassandraOperations {
 	 * @throws DataAccessException if there is any problem executing the query.
 	 */
 	<T> ListenableFuture<List<T>> select(Query query, Class<T> entityClass) throws DataAccessException;
+
+	/**
+	 * Execute a {@code SELECT} query with paging and convert the resulting items to a {@link Slice} of entities.
+	 *
+	 * @param query the query object used to create a CQL statement, must not be {@literal null}.
+	 * @param entityClass The entity type must not be {@literal null}.
+	 * @return the converted results
+	 * @throws DataAccessException if there is any problem executing the query.
+	 * @see CassandraPageRequest
+	 */
+	<T> ListenableFuture<Slice<T>> slice(Query query, Class<T> entityClass) throws DataAccessException;
 
 	/**
 	 * Execute a {@code SELECT} query and convert the resulting items notifying {@link Consumer} for each entity.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
@@ -150,8 +150,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 		this.statementFactory = new StatementFactory(new QueryMapper(converter), new UpdateMapper(converter));
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#getAsyncCqlOperations()
 	 */
 	@Override
@@ -159,8 +158,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 		return this.cqlOperations;
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#getConverter()
 	 */
 	@Override
@@ -206,8 +204,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 	// Methods dealing with static CQL
 	// -------------------------------------------------------------------------
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#select(java.lang.String, java.lang.Class)
 	 */
 	@Override
@@ -218,6 +215,9 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 		return select(new SimpleStatement(cql), entityClass);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#select(java.lang.String, java.util.function.Consumer, java.lang.Class)
+	 */
 	@Override
 	public <T> ListenableFuture<Void> select(String cql, Consumer<T> entityConsumer, Class<T> entityClass)
 			throws DataAccessException {
@@ -229,8 +229,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 		return select(new SimpleStatement(cql), entityConsumer, entityClass);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#selectOne(java.lang.String, java.lang.Class)
 	 */
 	@Override
@@ -390,8 +389,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 	// Methods dealing with entities
 	// -------------------------------------------------------------------------
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#count(java.lang.Class)
 	 */
 	@Override
@@ -405,8 +403,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 		return getAsyncCqlOperations().queryForObject(select, Long.class);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#exists(java.lang.Object, java.lang.Class)
 	 */
 	@Override
@@ -425,8 +422,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 				resultSet -> resultSet.iterator().hasNext());
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#selectOneById(java.lang.Object, java.lang.Class)
 	 */
 	@Override
@@ -444,8 +440,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 		return selectOne(select, entityClass);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#insert(java.lang.Object)
 	 */
 	@Override
@@ -453,8 +448,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 		return new MappingListenableFutureAdapter<>(insert(entity, InsertOptions.empty()), writeResult -> entity);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#insert(java.lang.Object, org.springframework.data.cassandra.core.InsertOptions)
 	 */
 	@Override
@@ -469,8 +463,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 				WriteResult::of);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#update(java.lang.Object)
 	 */
 	@Override
@@ -478,8 +471,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 		return new MappingListenableFutureAdapter<>(update(entity, UpdateOptions.empty()), writeResult -> entity);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#update(java.lang.Object, org.springframework.data.cassandra.core.UpdateOptions)
 	 */
 	@Override
@@ -494,8 +486,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 				WriteResult::of);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#delete(java.lang.Object)
 	 */
 	@Override
@@ -503,8 +494,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 		return new MappingListenableFutureAdapter<>(delete(entity, QueryOptions.empty()), writeResult -> entity);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#delete(java.lang.Object, org.springframework.data.cassandra.core.cql.QueryOptions)
 	 */
 	@Override
@@ -519,8 +509,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 				WriteResult::of);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#deleteById(java.lang.Object, java.lang.Class)
 	 */
 	@Override
@@ -538,8 +527,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 		return getAsyncCqlOperations().execute(delete);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.AsyncCassandraOperations#truncate(java.lang.Class)
 	 */
 	@Override
@@ -585,6 +573,9 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 			this.mapper = mapper;
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.util.concurrent.FutureAdapter#adapt(java.lang.Object)
+		 */
 		@Override
 		protected T adapt(@Nullable S adapteeResult) throws ExecutionException {
 			return mapper.apply(adapteeResult);
@@ -599,6 +590,9 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 			this.statement = statement;
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.AsyncSessionCallback#doInSession(com.datastax.driver.core.Session)
+		 */
 		@Override
 		public ListenableFuture<ResultSet> doInSession(Session session) throws DriverException, DataAccessException {
 			return new GuavaListenableFutureAdapter<>(session.executeAsync(statement),
@@ -607,6 +601,9 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations {
 							: exceptionTranslator.translateExceptionIfPossible(e)));
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.CqlProvider#getCql()
+		 */
 		@Override
 		public String getCql() {
 			return statement.toString();

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
@@ -25,8 +25,10 @@ import org.springframework.data.cassandra.core.cql.CqlIdentifier;
 import org.springframework.data.cassandra.core.cql.CqlOperations;
 import org.springframework.data.cassandra.core.cql.QueryOptions;
 import org.springframework.data.cassandra.core.cql.WriteOptions;
+import org.springframework.data.cassandra.core.query.CassandraPageRequest;
 import org.springframework.data.cassandra.core.query.Query;
 import org.springframework.data.cassandra.core.query.Update;
+import org.springframework.data.domain.Slice;
 import org.springframework.lang.Nullable;
 
 import com.datastax.driver.core.Statement;
@@ -132,6 +134,18 @@ public interface CassandraOperations {
 	<T> List<T> select(Statement statement, Class<T> entityClass) throws DataAccessException;
 
 	/**
+	 * Execute a {@code SELECT} query with paging and convert the resulting items to a {@link Slice} of entities. A sliced
+	 * query translates the effective {@link Statement#getFetchSize() fetch size} to the page size.
+	 *
+	 * @param statement the CQL statement, must not be {@literal null}.
+	 * @param entityClass The entity type must not be {@literal null}.
+	 * @return the converted results
+	 * @throws DataAccessException if there is any problem executing the query.
+	 * @since 2.0
+	 */
+	<T> Slice<T> slice(Statement statement, Class<T> entityClass) throws DataAccessException;
+
+	/**
 	 * Execute a {@code SELECT} query and convert the resulting items to a {@link Iterator} of entities.
 	 * <p>
 	 * Returns a {@link Iterator} that wraps the Cassandra {@link com.datastax.driver.core.ResultSet}.
@@ -159,6 +173,7 @@ public interface CassandraOperations {
 	// -------------------------------------------------------------------------
 	// Methods dealing with org.springframework.data.cassandra.core.query.Query
 	// -------------------------------------------------------------------------
+
 	/**
 	 * Execute a {@code SELECT} query and convert the resulting items to a {@link List} of entities.
 	 *
@@ -169,6 +184,18 @@ public interface CassandraOperations {
 	 * @since 2.0
 	 */
 	<T> List<T> select(Query query, Class<T> entityClass) throws DataAccessException;
+
+	/**
+	 * Execute a {@code SELECT} query with paging and convert the resulting items to a {@link Slice} of entities.
+	 *
+	 * @param query the query object used to create a CQL statement, must not be {@literal null}.
+	 * @param entityClass The entity type must not be {@literal null}.
+	 * @return the converted results
+	 * @throws DataAccessException if there is any problem executing the query.
+	 * @since 2.0
+	 * @see CassandraPageRequest
+	 */
+	<T> Slice<T> slice(Query query, Class<T> entityClass) throws DataAccessException;
 
 	/**
 	 * Execute a {@code SELECT} query and convert the resulting items to a {@link Iterator} of entities.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -161,8 +161,7 @@ public class CassandraTemplate implements CassandraOperations {
 		return converter;
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#CqlOperations()
 	 */
 	@Override
@@ -195,8 +194,7 @@ public class CassandraTemplate implements CassandraOperations {
 	// Methods dealing with static CQL
 	// -------------------------------------------------------------------------
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#select(java.lang.String, java.lang.Class)
 	 */
 	@Override
@@ -219,8 +217,7 @@ public class CassandraTemplate implements CassandraOperations {
 		return stream(new SimpleStatement(cql), entityClass);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#selectOne(java.lang.String, java.lang.Class)
 	 */
 	@Override
@@ -371,8 +368,7 @@ public class CassandraTemplate implements CassandraOperations {
 	// Methods dealing with entities
 	// -------------------------------------------------------------------------
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#count(java.lang.Class)
 	 */
 	@Override
@@ -388,8 +384,7 @@ public class CassandraTemplate implements CassandraOperations {
 		return count != null ? count : 0L;
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#exists(java.lang.Object, java.lang.Class)
 	 */
 	@Override
@@ -407,8 +402,7 @@ public class CassandraTemplate implements CassandraOperations {
 		return getCqlOperations().queryForResultSet(select).iterator().hasNext();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#selectOneById(java.lang.Object, java.lang.Class)
 	 */
 	@Override
@@ -426,8 +420,7 @@ public class CassandraTemplate implements CassandraOperations {
 		return selectOne(select, entityClass);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#insert(java.lang.Object)
 	 */
 	@Override
@@ -435,8 +428,7 @@ public class CassandraTemplate implements CassandraOperations {
 		insert(entity, InsertOptions.empty());
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#insert(java.lang.Object, org.springframework.data.cassandra.core.InsertOptions)
 	 */
 	@Override
@@ -451,8 +443,7 @@ public class CassandraTemplate implements CassandraOperations {
 		return getCqlOperations().execute(new StatementCallback(insert));
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#update(java.lang.Object)
 	 */
 	@Override
@@ -460,8 +451,7 @@ public class CassandraTemplate implements CassandraOperations {
 		update(entity, UpdateOptions.empty());
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#update(java.lang.Object, org.springframework.data.cassandra.core.UpdateOptions)
 	 */
 	@Override
@@ -476,8 +466,7 @@ public class CassandraTemplate implements CassandraOperations {
 		return getCqlOperations().execute(new StatementCallback(update));
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#delete(java.lang.Object)
 	 */
 	@Override
@@ -485,8 +474,7 @@ public class CassandraTemplate implements CassandraOperations {
 		delete(entity, QueryOptions.empty());
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#delete(java.lang.Object, org.springframework.data.cassandra.core.cql.QueryOptions)
 	 */
 	@Override
@@ -501,8 +489,7 @@ public class CassandraTemplate implements CassandraOperations {
 		return getCqlOperations().execute(new StatementCallback(delete));
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#deleteById(java.lang.Object, java.lang.Class)
 	 */
 	@Override
@@ -520,8 +507,7 @@ public class CassandraTemplate implements CassandraOperations {
 		return getCqlOperations().execute(delete);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#truncate(java.lang.Class)
 	 */
 	@Override
@@ -539,8 +525,7 @@ public class CassandraTemplate implements CassandraOperations {
 	// Implementation hooks and helper methods
 	// -------------------------------------------------------------------------
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#getTableName(java.lang.Class)
 	 */
 	@Override
@@ -567,8 +552,7 @@ public class CassandraTemplate implements CassandraOperations {
 				(SessionCallback<Integer>) session -> session.getCluster().getConfiguration().getQueryOptions().getFetchSize());
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#batchOps()
 	 */
 	@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/InsertOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/InsertOptions.java
@@ -18,6 +18,7 @@ package org.springframework.data.cassandra.core;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import lombok.EqualsAndHashCode;
 import org.springframework.data.cassandra.core.cql.WriteOptions;
 import org.springframework.lang.Nullable;
 
@@ -30,6 +31,7 @@ import com.datastax.driver.core.policies.RetryPolicy;
  * @author Mark Paluch
  * @since 2.0
  */
+@EqualsAndHashCode(callSuper = true)
 public class InsertOptions extends WriteOptions {
 
 	private static final InsertOptions EMPTY = new InsertOptionsBuilder().build();
@@ -63,6 +65,16 @@ public class InsertOptions extends WriteOptions {
 	}
 
 	/**
+	 * Create a new {@link InsertOptionsBuilder} to mutate properties of this {@link InsertOptions}.
+	 *
+	 * @return a new {@link InsertOptionsBuilder} initialized with this {@link InsertOptions}.
+	 */
+	@Override
+	public InsertOptionsBuilder mutate() {
+		return new InsertOptionsBuilder(this);
+	}
+
+	/**
 	 * @return {@literal true} to apply {@code IF NOT EXISTS} to {@code INSERT} operations.
 	 */
 	public boolean isIfNotExists() {
@@ -80,6 +92,12 @@ public class InsertOptions extends WriteOptions {
 		private boolean ifNotExists;
 
 		private InsertOptionsBuilder() {}
+
+		private InsertOptionsBuilder(InsertOptions insertOptions) {
+
+			super(insertOptions);
+			this.ifNotExists = insertOptions.ifNotExists;
+		}
 
 		@Override
 		public InsertOptionsBuilder consistencyLevel(com.datastax.driver.core.ConsistencyLevel consistencyLevel) {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraOperations.java
@@ -44,6 +44,21 @@ import com.datastax.driver.core.Statement;
  */
 public interface ReactiveCassandraOperations {
 
+	/**
+	 * Returns the underlying {@link CassandraConverter}.
+	 *
+	 * @return the underlying {@link CassandraConverter}.
+	 */
+	CassandraConverter getConverter();
+
+	/**
+	 * Expose the underlying {@link ReactiveCqlOperations} to allow CQL operations.
+	 *
+	 * @return the underlying {@link ReactiveCqlOperations}.
+	 * @see ReactiveCqlOperations
+	 */
+	ReactiveCqlOperations getReactiveCqlOperations();
+
 	// -------------------------------------------------------------------------
 	// Methods dealing with static CQL
 	// -------------------------------------------------------------------------
@@ -252,19 +267,4 @@ public interface ReactiveCassandraOperations {
 	 * @throws DataAccessException if there is any problem issuing the execution.
 	 */
 	Mono<Void> truncate(Class<?> entityClass) throws DataAccessException;
-
-	/**
-	 * Returns the underlying {@link CassandraConverter}.
-	 *
-	 * @return the underlying {@link CassandraConverter}.
-	 */
-	CassandraConverter getConverter();
-
-	/**
-	 * Expose the underlying {@link ReactiveCqlOperations} to allow CQL operations.
-	 *
-	 * @return the underlying {@link ReactiveCqlOperations}.
-	 * @see ReactiveCqlOperations
-	 */
-	ReactiveCqlOperations getReactiveCqlOperations();
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
@@ -159,7 +159,6 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return this.converter;
 	}
 
-	/* (non-Javadoc) */
 	private static MappingCassandraConverter newConverter() {
 
 		MappingCassandraConverter converter = new MappingCassandraConverter();
@@ -208,8 +207,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 	// Methods dealing with static CQL
 	// -------------------------------------------------------------------------
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#select(java.lang.String, java.lang.Class)
 	 */
 	@Override
@@ -220,8 +218,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return select(new SimpleStatement(cql), entityClass);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#selectOne(java.lang.String, java.lang.Class)
 	 */
 	@Override
@@ -246,8 +243,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return getReactiveCqlOperations().query(cql, (row, rowNum) -> getConverter().read(entityClass, row));
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#selectOne(com.datastax.driver.core.Statement, java.lang.Class)
 	 */
 	@Override
@@ -268,8 +264,8 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return select(getStatementFactory().select(query,
-				getMappingContext().getRequiredPersistentEntity(entityClass)), entityClass);
+		return select(getStatementFactory().select(query, getMappingContext().getRequiredPersistentEntity(entityClass)),
+				entityClass);
 	}
 
 	/* (non-Javadoc)
@@ -281,8 +277,8 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return selectOne(getStatementFactory().select(query,
-				getMappingContext().getRequiredPersistentEntity(entityClass)), entityClass);
+		return selectOne(getStatementFactory().select(query, getMappingContext().getRequiredPersistentEntity(entityClass)),
+				entityClass);
 	}
 
 	/* (non-Javadoc)
@@ -296,8 +292,8 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		Assert.notNull(update, "Update must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return getReactiveCqlOperations().execute(getStatementFactory().update(query, update,
-				getMappingContext().getRequiredPersistentEntity(entityClass)));
+		return getReactiveCqlOperations().execute(
+				getStatementFactory().update(query, update, getMappingContext().getRequiredPersistentEntity(entityClass)));
 	}
 
 	/* (non-Javadoc)
@@ -309,16 +305,15 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return getReactiveCqlOperations().execute(getStatementFactory().delete(query,
-				getMappingContext().getRequiredPersistentEntity(entityClass)));
+		return getReactiveCqlOperations()
+				.execute(getStatementFactory().delete(query, getMappingContext().getRequiredPersistentEntity(entityClass)));
 	}
 
 	// -------------------------------------------------------------------------
 	// Methods dealing with entities
 	// -------------------------------------------------------------------------
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#count(java.lang.Class)
 	 */
 	@Override
@@ -327,13 +322,12 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		Assert.notNull(entityClass, "Entity type must not be null");
 
 		Select select = QueryBuilder.select().countAll()
-			.from(getMappingContext().getRequiredPersistentEntity(entityClass).getTableName().toCql());
+				.from(getMappingContext().getRequiredPersistentEntity(entityClass).getTableName().toCql());
 
 		return getReactiveCqlOperations().queryForObject(select, Long.class);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#exists(java.lang.Object, java.lang.Class)
 	 */
 	@Override
@@ -351,8 +345,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return getReactiveCqlOperations().queryForRows(select).hasElements();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#selectOneById(java.lang.Object, java.lang.Class)
 	 */
 	@Override
@@ -370,8 +363,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return selectOne(select, entityClass);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#insert(java.lang.Object)
 	 */
 	@Override
@@ -379,8 +371,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return insert(entity, InsertOptions.empty()).map(writeResult -> entity);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#insert(java.lang.Object, org.springframework.data.cassandra.core.InsertOptions)
 	 */
 	@Override
@@ -394,8 +385,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return getReactiveCqlOperations().execute(new StatementCallback(insert)).next();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#update(java.lang.Object)
 	 */
 	@Override
@@ -403,8 +393,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return update(entity, UpdateOptions.empty()).map(writeResult -> entity);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#update(java.lang.Object, org.springframework.data.cassandra.core.UpdateOptions)
 	 */
 	@Override
@@ -418,8 +407,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return getReactiveCqlOperations().execute(new StatementCallback(update)).next();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#delete(java.lang.Object)
 	 */
 	@Override
@@ -427,8 +415,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return delete(entity, QueryOptions.empty()).map(reactiveWriteResult -> entity);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#delete(java.lang.Object, org.springframework.data.cql.core.QueryOptions)
 	 */
 	@Override
@@ -442,8 +429,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return getReactiveCqlOperations().execute(new StatementCallback(delete)).next();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#deleteById(java.lang.Object, java.lang.Class)
 	 */
 	@Override
@@ -461,8 +447,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 		return getReactiveCqlOperations().execute(delete);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.ReactiveCassandraOperations#truncate(java.lang.Class)
 	 */
 	@Override
@@ -481,11 +466,17 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations {
 
 		@NonNull Statement statement;
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.ReactiveSessionCallback#doInSession(org.springframework.data.cassandra.ReactiveSession)
+		 */
 		@Override
 		public Publisher<WriteResult> doInSession(ReactiveSession session) throws DriverException, DataAccessException {
 			return session.execute(statement).flatMap(StatementCallback::toWriteResult);
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.CqlProvider#getCql()
+		 */
 		@Override
 		public String getCql() {
 			return statement.toString();

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/UpdateOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/UpdateOptions.java
@@ -18,6 +18,7 @@ package org.springframework.data.cassandra.core;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import lombok.EqualsAndHashCode;
 import org.springframework.data.cassandra.core.cql.WriteOptions;
 import org.springframework.lang.Nullable;
 
@@ -30,6 +31,7 @@ import com.datastax.driver.core.policies.RetryPolicy;
  * @author Mark Paluch
  * @since 2.0
  */
+@EqualsAndHashCode(callSuper = true)
 public class UpdateOptions extends WriteOptions {
 
 	private static final UpdateOptions EMPTY = new UpdateOptionsBuilder().build();
@@ -63,6 +65,16 @@ public class UpdateOptions extends WriteOptions {
 	}
 
 	/**
+	 * Create a new {@link UpdateOptionsBuilder} to mutate properties of this {@link UpdateOptions}.
+	 *
+	 * @return a new {@link UpdateOptionsBuilder} initialized with this {@link UpdateOptions}.
+	 */
+	@Override
+	public UpdateOptionsBuilder mutate() {
+		return new UpdateOptionsBuilder(this);
+	}
+
+	/**
 	 * @return {@literal true} to apply {@code IF EXISTS} to {@code UPDATE} operations.
 	 */
 	public boolean isIfExists() {
@@ -80,6 +92,12 @@ public class UpdateOptions extends WriteOptions {
 		private boolean ifExists;
 
 		private UpdateOptionsBuilder() {}
+
+		private UpdateOptionsBuilder(UpdateOptions updateOptions) {
+
+			super(updateOptions);
+			this.ifExists = updateOptions.ifExists;
+		}
 
 		@Override
 		public UpdateOptionsBuilder consistencyLevel(com.datastax.driver.core.ConsistencyLevel consistencyLevel) {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/QueryOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/QueryOptions.java
@@ -18,6 +18,7 @@ package org.springframework.data.cassandra.core.cql;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import lombok.EqualsAndHashCode;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -32,6 +33,7 @@ import com.datastax.driver.core.policies.RetryPolicy;
  * @author David Webb
  * @author Mark Paluch
  */
+@EqualsAndHashCode
 public class QueryOptions {
 
 	private static final QueryOptions EMPTY = QueryOptions.builder().build();
@@ -91,6 +93,16 @@ public class QueryOptions {
 	 */
 	public static QueryOptionsBuilder builder() {
 		return new QueryOptionsBuilder();
+	}
+
+	/**
+	 * Create a new {@link QueryOptionsBuilder} to mutate properties of this {@link QueryOptions}.
+	 *
+	 * @return a new {@link QueryOptionsBuilder} initialized with this {@link QueryOptions}.
+	 * @since 2.0
+	 */
+	public QueryOptionsBuilder mutate() {
+		return new QueryOptionsBuilder(this);
 	}
 
 	/**
@@ -155,6 +167,15 @@ public class QueryOptions {
 		protected Duration readTimeout = Duration.ofMillis(-1);
 
 		QueryOptionsBuilder() {}
+
+		QueryOptionsBuilder(QueryOptions queryOptions) {
+
+			this.consistencyLevel = queryOptions.consistencyLevel;
+			this.retryPolicy = queryOptions.retryPolicy;
+			this.tracing = queryOptions.tracing;
+			this.fetchSize = queryOptions.fetchSize;
+			this.readTimeout = queryOptions.readTimeout;
+		}
 
 		/**
 		 * Sets the {@link ConsistencyLevel} to use.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/WriteOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/WriteOptions.java
@@ -18,6 +18,7 @@ package org.springframework.data.cassandra.core.cql;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import lombok.EqualsAndHashCode;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -32,6 +33,7 @@ import com.datastax.driver.core.policies.RetryPolicy;
  * @author Mark Paluch
  * @see QueryOptions
  */
+@EqualsAndHashCode(callSuper = true)
 public class WriteOptions extends QueryOptions {
 
 	private static final WriteOptions EMPTY = new WriteOptionsBuilder().build();
@@ -95,6 +97,17 @@ public class WriteOptions extends QueryOptions {
 	}
 
 	/**
+	 * Create a new {@link WriteOptionsBuilder} to mutate properties of this {@link WriteOptions}.
+	 *
+	 * @return a new {@link WriteOptionsBuilder} initialized with this {@link WriteOptions}.
+	 * @since 2.0
+	 */
+	@Override
+	public WriteOptionsBuilder mutate() {
+		return new WriteOptionsBuilder(this);
+	}
+
+	/**
 	 * @return the time to live, if set.
 	 */
 	public Duration getTtl() {
@@ -102,7 +115,7 @@ public class WriteOptions extends QueryOptions {
 	}
 
 	/**
-	 * Builder for {@link QueryOptions}.
+	 * Builder for {@link WriteOptions}.
 	 *
 	 * @author Mark Paluch
 	 * @since 1.5
@@ -112,6 +125,12 @@ public class WriteOptions extends QueryOptions {
 		protected Duration ttl = Duration.ofMillis(-1);
 
 		protected WriteOptionsBuilder() {}
+
+		protected WriteOptionsBuilder(WriteOptions writeOptions) {
+
+			super(writeOptions);
+			this.ttl = writeOptions.ttl;
+		}
 
 		/*
 		 * (non-Javadoc)

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/CassandraPageRequest.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/CassandraPageRequest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.query;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+import com.datastax.driver.core.PagingState;
+
+/**
+ * Cassandra-specific {@link PageRequest} implementation providing access to {@link PagingState}. This class allows
+ * creation of the first page request and represents through Cassandra paging is based on the progress of fetched pages
+ * and allows forward-only navigation. Accessing a particular page requires fetching of all pages until the desired page
+ * is reached.
+ * <p/>
+ * The fetching progress is represented as {@link PagingState}. Query {@link com.datastax.driver.core.ResultSet results}
+ * are associated with a {@link com.datastax.driver.core.ExecutionInfo#getPagingState paging state} that is used on the
+ * next query as input parameter to continue page fetching.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+public class CassandraPageRequest extends PageRequest {
+
+	private final @Nullable PagingState pagingState;
+
+	private final boolean nextAllowed;
+
+	private CassandraPageRequest(int page, int size, Sort sort, @Nullable PagingState pagingState, boolean nextAllowed) {
+
+		super(page, size, sort);
+
+		this.pagingState = pagingState;
+		this.nextAllowed = nextAllowed;
+	}
+
+	/**
+	 * Creates a new unsorted {@link PageRequest}.
+	 *
+	 * @param page zero-based page index.
+	 * @param size the size of the page to be returned.
+	 * @throws IllegalArgumentException for page requests other than the first page.
+	 */
+	public static CassandraPageRequest of(int page, int size) {
+
+		Assert.isTrue(page == 0,
+				"Cannot create a Cassandra page request for an indexed page other than the first page (0).");
+
+		return of(page, size, Sort.unsorted());
+	}
+
+	/**
+	 * Creates a new {@link PageRequest} with sort parameters applied.
+	 *
+	 * @param page zero-based page index.
+	 * @param size the size of the page to be returned.
+	 * @param sort must not be {@literal null}.
+	 * @throws IllegalArgumentException for page requests other than the first page.
+	 */
+	public static CassandraPageRequest of(int page, int size, Sort sort) {
+
+		Assert.isTrue(page == 0,
+				"Cannot create a Cassandra page request for an indexed page other than the first page (0).");
+
+		return new CassandraPageRequest(page, size, sort, null, false);
+	}
+
+	/**
+	 * Creates a new {@link PageRequest} with sort direction and properties applied.
+	 *
+	 * @param page zero-based page index.
+	 * @param size the size of the page to be returned.
+	 * @param direction must not be {@literal null}.
+	 * @param properties must not be {@literal null}.
+	 * @throws IllegalArgumentException for page requests other than the first page.
+	 */
+	public static CassandraPageRequest of(int page, int size, Direction direction, String... properties) {
+
+		Assert.isTrue(page == 0,
+				"Cannot create a Cassandra page request for an indexed page other than the first page (0).");
+
+		return of(page, size, Sort.by(direction, properties));
+	}
+
+	/**
+	 * Creates a a {@link PageRequest} with sort direction and properties applied.
+	 *
+	 * @param current the current {@link Pageable}, must not be {@literal null}.
+	 * @param pagingState the paging state associated with the current {@link Pageable}. Can be {@literal null} if there
+	 *          is no paging state associated.
+	 */
+	public static CassandraPageRequest of(Pageable current, @Nullable PagingState pagingState) {
+		return new CassandraPageRequest(current.getPageNumber(), current.getPageSize(), current.getSort(), pagingState,
+				pagingState != null);
+	}
+
+	/**
+	 * Creates a new unsorted {@link PageRequest} for the first page.
+	 *
+	 * @param size the size of the page to be returned.
+	 */
+	public static CassandraPageRequest first(int size) {
+		return of(0, size, Sort.unsorted());
+	}
+
+	/**
+	 * Creates a new {@link PageRequest} with sort parameters applied for the first page.
+	 *
+	 * @param size the size of the page to be returned.
+	 * @param sort must not be {@literal null}.
+	 */
+	public static CassandraPageRequest first(int size, Sort sort) {
+		return new CassandraPageRequest(0, size, sort, null, false);
+	}
+
+	/**
+	 * Creates a new {@link PageRequest} with sort direction and properties applied for the first page.
+	 *
+	 * @param size the size of the page to be returned.
+	 * @param direction must not be {@literal null}.
+	 * @param properties must not be {@literal null}.
+	 */
+	public static CassandraPageRequest first(int size, Direction direction, String... properties) {
+		return first(size, Sort.by(direction, properties));
+	}
+
+	/**
+	 * Validate the {@link Pageable} whether it can be used for querying. Valid pageables are either:
+	 * <ul>
+	 * <li>Unpaged</li>
+	 * <li>Request the first page</li>
+	 * <li>{@link CassandraPageRequest} with a {@link PagingState}</li>
+	 * </ul>
+	 *
+	 * @param pageable
+	 * @throws IllegalArgumentException if the {@link Pageable} is not valid.
+	 */
+	public static void validatePageable(Pageable pageable) {
+
+		if (pageable.isUnpaged() || pageable.getPageNumber() == 0) {
+			return;
+		}
+
+		if (pageable instanceof CassandraPageRequest) {
+
+			CassandraPageRequest pageRequest = (CassandraPageRequest) pageable;
+
+			if (pageRequest.getPagingState() != null) {
+				return;
+			}
+		}
+
+		throw new IllegalArgumentException(
+				"Paging queries for pages other than the first one require a CassandraPageRequest with a valid paging state");
+	}
+
+	/**
+	 * @return the {@link PagingState} for the current {@link CassandraPageRequest} or {@literal null} if the current
+	 *         {@link Pageable} represents the last page.
+	 */
+	@Nullable
+	public PagingState getPagingState() {
+		return pagingState;
+	}
+
+	/**
+	 * Returns whether there's a next {@link Pageable} we can access from the current one. Will return {@literal false} in
+	 * case the current {@link Pageable} already refers to the next page.
+	 *
+	 * @return {@literal true } if there's a next {@link Pageable} we can access from the current one.
+	 */
+	public boolean hasNext() {
+		return getPagingState() != null && nextAllowed;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.domain.PageRequest#next()
+	 */
+	@Override
+	public CassandraPageRequest next() {
+
+		Assert.state(hasNext(), "Cannot create a next page request without a PagingState");
+
+		return new CassandraPageRequest(getPageNumber() + 1, getPageSize(), getSort(), pagingState, false);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.domain.PageRequest#previous()
+	 */
+	@Override
+	public PageRequest previous() {
+
+		Assert.state(getPageNumber() < 2, "Cannot navigate to an intermediate page");
+
+		return super.previous();
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.domain.PageRequest#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(@Nullable Object o) {
+
+		if (this == o)
+			return true;
+		if (!(o instanceof CassandraPageRequest))
+			return false;
+		if (!super.equals(o))
+			return false;
+
+		CassandraPageRequest that = (CassandraPageRequest) o;
+
+		if (nextAllowed != that.nextAllowed)
+			return false;
+		return pagingState != null ? pagingState.equals(that.pagingState) : that.pagingState == null;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.domain.PageRequest#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+
+		int result = super.hashCode();
+		result = 31 * result + (pagingState != null ? pagingState.hashCode() : 0);
+		result = 31 * result + (nextAllowed ? 1 : 0);
+		return result;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return String.format("Cassandra page request [number: %d, size %d, sort: %s, paging state: %s]", getPageNumber(),
+				getPageSize(), getSort(), getPagingState());
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/CassandraRepository.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/CassandraRepository.java
@@ -19,7 +19,10 @@ import java.util.List;
 
 import org.springframework.data.cassandra.core.mapping.MapId;
 import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.core.query.CassandraPageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Persistable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 
@@ -59,6 +62,16 @@ public interface CassandraRepository<T, ID> extends CrudRepository<T, ID> {
 	 */
 	@Override
 	List<T> findAllById(Iterable<ID> ids);
+
+	/**
+	 * Returns a {@link Slice} of entities meeting the paging restriction provided in the {@code Pageable} object.
+	 *
+	 * @param pageable must not be {@literal null}.
+	 * @return a {@link Slice} of entities.
+	 * @since 2.0
+	 * @see CassandraPageRequest
+	 */
+	Slice<T> findAll(Pageable pageable);
 
 	/**
 	 * Inserts the given entity. Assumes the instance to be new to be able to apply insertion optimizations. Use the

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/CassandraRepository.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/CassandraRepository.java
@@ -42,22 +42,19 @@ import org.springframework.data.repository.NoRepositoryBean;
 @NoRepositoryBean
 public interface CassandraRepository<T, ID> extends CrudRepository<T, ID> {
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.repository.CrudRepository#saveAll(java.lang.Iterable)
 	 */
 	@Override
 	<S extends T> List<S> saveAll(Iterable<S> entites);
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.repository.CrudRepository#findAll()
 	 */
 	@Override
 	List<T> findAll();
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.repository.CrudRepository#findAllById(java.lang.Iterable)
 	 */
 	@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraQueryMethod.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraQueryMethod.java
@@ -77,14 +77,13 @@ public class CassandraQueryMethod extends QueryMethod {
 	}
 
 	/**
-	 * Validates that this query is not a page or slice query.
+	 * Validates that this query is not a page query.
 	 */
 	@SuppressWarnings("unused")
 	public void verify(Method method, RepositoryMetadata metadata) {
 
-		// TODO: support Page & Slice queries
-		if (isSliceQuery() || isPageQuery()) {
-			throw new InvalidDataAccessApiUsageException("Slice and Page queries are not supported");
+		if (isPageQuery()) {
+			throw new InvalidDataAccessApiUsageException("Page queries are not supported. Use a Slice query.");
 		}
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/SimpleCassandraRepository.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/SimpleCassandraRepository.java
@@ -31,6 +31,8 @@ import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity
 import org.springframework.data.cassandra.core.query.Query;
 import org.springframework.data.cassandra.repository.CassandraRepository;
 import org.springframework.data.cassandra.repository.query.CassandraEntityInformation;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.util.StreamUtils;
 import org.springframework.data.util.Streamable;
 import org.springframework.util.Assert;
@@ -206,6 +208,17 @@ public class SimpleCassandraRepository<T, ID> implements CassandraRepository<T, 
 
 		return operations.select(Query.query(where(entityInformation.getIdAttribute()).in(idCollection)),
 				entityInformation.getJavaType());
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.CassandraRepository#findAll(org.springframework.data.domain.Pageable)
+	 */
+	@Override
+	public Slice<T> findAll(Pageable pageable) {
+
+		Assert.notNull(pageable, "Pageable must not be null");
+
+		return operations.slice(Query.empty().pageRequest(pageable), entityInformation.getJavaType());
 	}
 
 	/* (non-Javadoc)

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/InsertOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/InsertOptionsUnitTests.java
@@ -39,4 +39,18 @@ public class InsertOptionsUnitTests {
 		assertThat(insertOptions.getTtl()).isEqualTo(Duration.ofSeconds(10));
 		assertThat(insertOptions.isIfNotExists()).isTrue();
 	}
+
+	@Test // DATACASS-56
+	public void buildInsertOptionsMutate() {
+
+		InsertOptions insertOptions = InsertOptions.builder() //
+				.ttl(10) //
+				.withIfNotExists() //
+				.build();
+
+		InsertOptions mutated = insertOptions.mutate().ttl(Duration.ofSeconds(5)).build();
+
+		assertThat(mutated.getTtl()).isEqualTo(Duration.ofSeconds(5));
+		assertThat(mutated.isIfNotExists()).isTrue();
+	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/UpdateOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/UpdateOptionsUnitTests.java
@@ -39,4 +39,18 @@ public class UpdateOptionsUnitTests {
 		assertThat(updateOptions.getTtl()).isEqualTo(Duration.ofSeconds(10));
 		assertThat(updateOptions.isIfExists()).isTrue();
 	}
+
+	@Test // DATACASS-56
+	public void buildUpdateOptionsMutate() {
+
+		UpdateOptions updateOptions = UpdateOptions.builder() //
+				.ttl(10) //
+				.withIfExists() //
+				.build();
+
+		UpdateOptions mutated = updateOptions.mutate().ttl(20).build();
+
+		assertThat(mutated.getTtl()).isEqualTo(Duration.ofSeconds(20));
+		assertThat(mutated.isIfExists()).isTrue();
+	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/QueryOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/QueryOptionsUnitTests.java
@@ -73,4 +73,25 @@ public class QueryOptionsUnitTests {
 
 		assertThat(writeOptions.getRetryPolicy()).isEqualTo(DowngradingConsistencyRetryPolicy.INSTANCE);
 	}
+
+	@Test // DATACASS-56
+	public void buildQueryOptionsMutate() {
+
+		QueryOptions queryOptions = QueryOptions.builder() //
+				.consistencyLevel(ConsistencyLevel.ANY) //
+				.retryPolicy(FallthroughRetryPolicy.INSTANCE) //
+				.readTimeout(1, TimeUnit.SECONDS)//
+				.fetchSize(10)//
+				.tracing(true)//
+				.build(); //
+
+		QueryOptions mutated = queryOptions.mutate().readTimeout(Duration.ofSeconds(5)).build();
+
+		assertThat(mutated.getClass()).isEqualTo(QueryOptions.class);
+		assertThat(mutated.getRetryPolicy()).isEqualTo(FallthroughRetryPolicy.INSTANCE);
+		assertThat(mutated.getConsistencyLevel()).isEqualTo(ConsistencyLevel.ANY);
+		assertThat(mutated.getReadTimeout()).isEqualTo(Duration.ofSeconds(5));
+		assertThat(mutated.getFetchSize()).isEqualTo(10);
+		assertThat(mutated.getTracing()).isTrue();
+	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/query/CassandraPageRequestUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/query/CassandraPageRequestUnitTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.query;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.domain.Sort.Order.*;
+
+import org.junit.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+import com.datastax.driver.core.PagingState;
+
+/**
+ * Unit tests for {@link CassandraPageRequest}.
+ *
+ * @author Mark Paluch
+ */
+public class CassandraPageRequestUnitTests {
+
+	PagingState pagingState = PagingState
+			.fromString("001400100c68656973656e62657267313600f07ffffff5006f934c985d6110148e1385ca793a75780004");
+
+	@Test // DATACASS-56
+	public void shouldNotAllowNonZeroPageConstruction() {
+
+		assertThatThrownBy(() -> CassandraPageRequest.of(1, 1)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> CassandraPageRequest.of(1, 1, Sort.unsorted()))
+				.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> CassandraPageRequest.of(1, 1, Direction.ASC, "foo"))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test // DATACASS-56
+	public void shouldCreateFirstUnsortedPageRequest() {
+
+		CassandraPageRequest pageRequest = CassandraPageRequest.first(10);
+
+		assertThat(pageRequest.hasNext()).isFalse();
+		assertThat(pageRequest.getPageSize()).isEqualTo(10);
+		assertThat(pageRequest.getSort()).isEqualTo(Sort.unsorted());
+	}
+
+	@Test // DATACASS-56
+	public void shouldCreateFirstSortedPageRequest() {
+
+		CassandraPageRequest pageRequest = CassandraPageRequest.first(10, Direction.ASC, "foo");
+
+		assertThat(pageRequest.hasNext()).isFalse();
+		assertThat(pageRequest.getPageSize()).isEqualTo(10);
+		assertThat(pageRequest.getSort()).isEqualTo(Sort.by(asc("foo")));
+	}
+
+	@Test // DATACASS-56
+	public void shouldFailIfNoNextPageIsAvailable() {
+
+		CassandraPageRequest pageRequest = CassandraPageRequest.first(10, Direction.ASC, "foo");
+
+		assertThatThrownBy(pageRequest::next).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test // DATACASS-56
+	public void shouldCreateNextPageRequest() {
+
+		CassandraPageRequest pageRequest = CassandraPageRequest.first(10, Direction.ASC, "foo");
+		CassandraPageRequest next = CassandraPageRequest.of(pageRequest, pagingState).next();
+
+		assertThat(next.hasNext()).isFalse();
+		assertThat(next.getPageSize()).isEqualTo(10);
+	}
+
+	@Test // DATACASS-56
+	public void shouldNotAllowPreviousPageNavigationToIntermediatePages() {
+
+		CassandraPageRequest next = CassandraPageRequest.of(PageRequest.of(5, 10), pagingState);
+
+		assertThatThrownBy(next::previous).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test // DATACASS-56
+	public void shouldCheckEquality() {
+
+		CassandraPageRequest first = CassandraPageRequest.first(10);
+		CassandraPageRequest anotherFirst = CassandraPageRequest.first(10);
+
+		assertThat(first.hashCode()).isEqualTo(anotherFirst.hashCode());
+
+		assertThat(first).isEqualTo(anotherFirst);
+		assertThat(first).isEqualTo(first);
+
+		CassandraPageRequest withPaging = CassandraPageRequest.of(first, pagingState).next();
+		CassandraPageRequest anotherWithPaging = CassandraPageRequest.of(anotherFirst, pagingState).next();
+
+		assertThat(withPaging.hashCode()).isEqualTo(anotherWithPaging.hashCode());
+		assertThat(withPaging.hashCode()).isNotEqualTo(first.hashCode());
+
+		assertThat(withPaging).isEqualTo(anotherWithPaging);
+		assertThat(withPaging).isEqualTo(withPaging);
+		assertThat(withPaging).isNotEqualTo(anotherFirst);
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/query/QueryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/query/QueryUnitTests.java
@@ -16,9 +16,14 @@
 package org.springframework.data.cassandra.core.query;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.domain.Sort.Order.*;
 
 import org.junit.Test;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+import com.datastax.driver.core.PagingState;
 
 /**
  * Unit tests for {@link Query}.
@@ -63,5 +68,23 @@ public class QueryUnitTests {
 		assertThat(query.getSort()).isEqualTo(sort);
 		assertThat(query.getLimit()).isEqualTo(10);
 		assertThat(query.isAllowFiltering()).isTrue();
+	}
+
+	@Test // DATACASS-56
+	public void shouldApplyPageRequests() {
+
+		PagingState pagingState = PagingState
+				.fromString("001400100c68656973656e62657267313600f07ffffff5006f934c985d6110148e1385ca793a75780004");
+
+		CassandraPageRequest pageRequest = CassandraPageRequest.of(PageRequest.of(0, 42, Direction.ASC, "foo"), pagingState)
+				.next();
+
+		Query query = Query.empty().pageRequest(pageRequest);
+
+		assertThat(query.getSort()).isEqualTo(Sort.by(asc("foo")));
+		assertThat(query.getPagingState()).contains(pagingState);
+		assertThat(query.getQueryOptions()).hasValueSatisfying(actual -> {
+			assertThat(actual).extracting("fetchSize").contains(42);
+		});
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/SimpleCassandraRepositoryIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/SimpleCassandraRepositoryIntegrationTests.java
@@ -31,9 +31,11 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.core.query.CassandraPageRequest;
 import org.springframework.data.cassandra.domain.User;
 import org.springframework.data.cassandra.repository.CassandraRepository;
 import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.repository.query.DefaultEvaluationContextProvider;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -151,6 +153,16 @@ public class SimpleCassandraRepositoryIntegrationTests extends AbstractKeyspaceC
 		List<User> Users = repository.findAllById(Arrays.asList(dave.getId(), boyd.getId()));
 
 		assertThat(Users).hasSize(2);
+	}
+
+	@Test // DATACASS-56
+	public void findAllWithPaging() {
+
+		Slice<User> slice = repository.findAll(CassandraPageRequest.first(2));
+
+		assertThat(slice).hasSize(2);
+
+		assertThat(repository.findAll(slice.nextPageable())).hasSize(2);
 	}
 
 	@Test // DATACASS-396

--- a/src/main/asciidoc/reference/cassandra-repositories.adoc
+++ b/src/main/asciidoc/reference/cassandra-repositories.adoc
@@ -111,7 +111,7 @@ class ApplicationConfig extends AbstractCassandraConfiguration {
 As our domain Repository extends `CrudRepository` it provides you with basic CRUD operations.
 Working with the Repository instance is just a matter of injecting the Repository as a dependency into a client.
 
-.Paging access to Person entities
+.Basic access to Person entities
 ====
 [source,java]
 ----
@@ -131,6 +131,35 @@ public class PersonRepositoryTests {
 ----
 ====
 
+Cassandra repositories support paging and sorting for paginated and sorted access to the entities. Cassandra paging requires a paging state to forward-only navigate through pages. A `Slice` keeps track of the current paging state and allows creation of a `Pageable` to request the next page.
+
+.Paging access to Person entities
+====
+[source,java]
+----
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class PersonRepositoryTests {
+
+    @Autowired PersonRepository repository;
+
+    @Test
+    public void readsPagesCorrectly() {
+
+      Slice<Person> firstBatch = repository.findAll(CassandraPageRequest.first(10));
+
+      assertThat(firstBatch).hasSize(10);
+
+      Page<Person> nextBatch = repository.findAll(firstBatch.nextPageable());
+
+      // …
+    }
+}
+----
+====
+
+NOTE: Cassandra repositories do not extend `PagingAndSortingRepository` because classic paging patterns using limit/offset are not applicable to Cassandra.
+
 The sample creates an application context with Spring's unit test support, which will perform annotation-based
 dependency injection into the test class. Inside the test cases (test methods) we simply use the Repository to query
 the data store. We invoke the Repository query method that requests the all `Person` instances.
@@ -147,23 +176,26 @@ the Apache Cassandra database. Defining such a query is just a matter of declari
 ----
 public interface PersonRepository extends CrudRepository<Person, String> {
 
-    List<Person> findByLastname(String lastname);                      <1>
+    List<Person> findByLastname(String lastname);                           <1>
 
-    List<Person> findByFirstname(String firstname, Sort sort);         <2>
+    Slice<Person> findByFirstname(String firstname, Pageable pageRequest);  <2>
 
-    Person findByShippingAddress(Address address);                     <3>
+    List<Person> findByFirstname(String firstname, Sort sort);              <3>
 
-    Stream<Person> findAllBy();                                        <4>
+    Person findByShippingAddress(Address address);                          <4>
+
+    Stream<Person> findAllBy();                                             <5>
 }
 ----
 <1> The method shows a query for all people with the given `lastname`. The query will be derived from parsing
 the method name for constraints which can be concatenated with `And`. Thus the method name will result in
 a query expression of `SELECT * from person WHERE lastname = 'lastname'`.
-<2> Applies dynamic sorting to a query. Just add a `Sort` parameter to your method signature and Spring Data
+<2> Applies pagination to a query. Just equip your method signature with a `Pageable` parameter and let the method return a `Slice` instance and we will automatically page the query accordingly.
+<3> Applies dynamic sorting to a query. Just add a `Sort` parameter to your method signature and Spring Data
 will automatically apply ordering to the query accordingly.
-<3> Shows that you can query based on properties which are not a primitive type using registered `Converter`'s
+<4> Shows that you can query based on properties which are not a primitive type using registered `Converter`'s
 in `CustomConversions`.
-<4> Uses a Java 8 `Stream` which reads and converts individual elements while iterating the stream.
+<5> Uses a Java 8 `Stream` which reads and converts individual elements while iterating the stream.
 ====
 
 NOTE: Querying non-primary key properties requires secondary indexes.

--- a/src/main/asciidoc/reference/cassandra.adoc
+++ b/src/main/asciidoc/reference/cassandra.adoc
@@ -1327,6 +1327,7 @@ The `Query` class has some additional methods used to provide options for the qu
 * `Query` *and* `(CriteriaDefinition criteria)` used to add additional criteria to the query.
 * `Query` *columns* `(Columns columns)` used to define columns to be included in the query results.
 * `Query` *limit* `(long limit)` used to limit the size of the returned results to the provided limit (used for paging).
+* `Query` *pageRequest* `(Pageable pageRequest)` used to associate `Sort`, `PagingState` and `fetchSize` with the query (used for paging).
 * `Query` *pagingState* `(PagingState pagingState)` used to associate a `PagingState` with the query (used for paging).
 * `Query` *queryOptions* `(QueryOptions queryOptions)` used to associate `QueryOptions` with the query.
 * `Query` *sort* `(Sort sort)` used to provide sort definition for the results.
@@ -1340,6 +1341,7 @@ The `Query` class has some additional methods used to provide options for the qu
 The query methods need to specify the target type T that will be returned.
 
 * `List<T>` *select* `(Query query, Class<T> entityClass)` Query for a list of objects of type T from the table.
+* `Slice<T>` *slice* `(Query query, Class<T> entityClass)` Start or continue paging by querying for a `Slice` of objects of type T from the table.
 * `T` *selectOne* `(Query query, Class<T> entityClass)` Query for a single object of type T from the table.
 * `Stream<T>` *stream* `(Query query, Class<T> entityClass)` Query for a stream of objects of type T from the table.
 


### PR DESCRIPTION
We now support forward-only paging with Cassandra through the Template API and repositories. Results in Cassandra are paged by navigating forward-only through pages described by a binary paging state encapsulated by `CassandraPageRequest` and accessible via the returned Slice. Spring Data Page's do not fit to Cassandra's paging concept because Cassandra paging is not based on limit/offset.

Page requests are applicable to a Query and as a parameter of query methods.

```java
Query query = Query.empty().pageRequest(CassandraPageRequest.first(10));
Slice<User> slice = template.slice(query, User.class);

do {

// consume slice

if (slice.hasNext()) {
slice = template.select(query, slice.nextPageable(), User.class);
} else {
break;
}
} while (!slice.getContent().isEmpty());

assertThat(ids).hasSize(100);
assertThat(iterations).isEqualTo(10);

interface UserRepository implements Repository<User, String> {

Slice<User> findAllByName(String name, Pageable pageRequest);
}
```

---

Related ticket: [DATACASS-56](https://jira.spring.io/browse/DATACASS-56).