### PR TITLE
DATACASS-509 - Request subsequent result pages in ReactiveSession asynchronously.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACASS-509-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-509-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/AbstractReactiveCassandraConfiguration.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/AbstractReactiveCassandraConfiguration.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.data.cassandra.config;
 
-import reactor.core.scheduler.Schedulers;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.cassandra.ReactiveSession;
 import org.springframework.data.cassandra.ReactiveSessionFactory;
@@ -47,7 +45,7 @@ public abstract class AbstractReactiveCassandraConfiguration extends AbstractCas
 	 */
 	@Bean
 	public ReactiveSession reactiveSession() {
-		return new DefaultBridgedReactiveSession(getRequiredSession(), Schedulers.elastic());
+		return new DefaultBridgedReactiveSession(getRequiredSession());
 	}
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/session/DefaultBridgedReactiveSession.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/session/DefaultBridgedReactiveSession.java
@@ -17,8 +17,8 @@ package org.springframework.data.cassandra.core.cql.session;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoProcessor;
 import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
 import java.util.Map;
@@ -40,13 +40,12 @@ import com.google.common.util.concurrent.ListenableFuture;
  * Calls are deferred until a subscriber subscribes to the resulting {@link org.reactivestreams.Publisher}. The calls
  * are executed by subscribing to {@link ListenableFuture} and returning the result as calls complete.
  * <p>
- * {@link ResultSet} implements transparent paging that invokes in the middle of result streaming blocking calls to
- * Cassandra. {@link DefaultBridgedReactiveSession} uses therefore {@link ReactiveResultSet} to avoid client thread
- * blocking. Elements are emitted on netty EventLoop threads and transported by the provided {@link Scheduler}. However,
- * this is an intermediate solution until Datastax can provide a fully reactive driver.
+ * Elements are emitted on netty EventLoop threads. {@link ResultSet} allows {@link ResultSet#fetchMoreResults()
+ * asynchronous requesting} of subsequent pages. The next page is requested after emitting all elements of the previous
+ * page. However, this is an intermediate solution until Datastax can provide a fully reactive driver.
  * <p>
  * All CQL operations performed by this class are logged at debug level, using
- * "org.springframework.data.cassandra.core.cql.DefaultBridgedReactiveSession" as log category.
+ * {@code org.springframework.data.cassandra.core.cql.DefaultBridgedReactiveSession} as log category.
  * <p>
  *
  * @author Mark Paluch
@@ -61,21 +60,31 @@ public class DefaultBridgedReactiveSession implements ReactiveSession {
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	private final Session session;
-	private final Scheduler scheduler;
+
+	/**
+	 * Create a new {@link DefaultBridgedReactiveSession} for a {@link Session}.
+	 *
+	 * @param session must not be {@literal null}.
+	 * @since 2.1
+	 */
+	public DefaultBridgedReactiveSession(Session session) {
+
+		Assert.notNull(session, "Session must not be null");
+
+		this.session = session;
+	}
 
 	/**
 	 * Create a new {@link DefaultBridgedReactiveSession} for a {@link Session} and {@link Scheduler}.
 	 *
 	 * @param session must not be {@literal null}.
 	 * @param scheduler must not be {@literal null}.
+	 * @deprecated since 2.1. Use {@link #DefaultBridgedReactiveSession(Session)} as a {@link Scheduler} is no longer
+	 *             required to off-load {@link ResultSet}'s blocking behavior.
 	 */
+	@Deprecated
 	public DefaultBridgedReactiveSession(Session session, Scheduler scheduler) {
-
-		Assert.notNull(session, "Session must not be null");
-		Assert.notNull(scheduler, "Scheduler must not be null");
-
-		this.session = session;
-		this.scheduler = scheduler;
+		this(session);
 	}
 
 	/* (non-Javadoc)
@@ -133,7 +142,7 @@ public class DefaultBridgedReactiveSession implements ReactiveSession {
 					if (resultSetFuture.isDone()) {
 
 						try {
-							future.complete(new DefaultReactiveResultSet(resultSetFuture.getUninterruptibly(), scheduler));
+							future.complete(new DefaultReactiveResultSet(resultSetFuture.getUninterruptibly()));
 						} catch (Exception e) {
 							future.completeExceptionally(e);
 						}
@@ -144,8 +153,7 @@ public class DefaultBridgedReactiveSession implements ReactiveSession {
 			} catch (Exception e) {
 				return Mono.error(e);
 			}
-
-		}).subscribeOn(scheduler);
+		});
 	}
 
 	/* (non-Javadoc)
@@ -191,8 +199,7 @@ public class DefaultBridgedReactiveSession implements ReactiveSession {
 			} catch (Exception e) {
 				return Mono.error(e);
 			}
-
-		}).subscribeOn(scheduler);
+		});
 	}
 
 	/* (non-Javadoc)
@@ -219,14 +226,12 @@ public class DefaultBridgedReactiveSession implements ReactiveSession {
 		return session.getCluster();
 	}
 
-	private static class DefaultReactiveResultSet implements ReactiveResultSet {
+	static class DefaultReactiveResultSet implements ReactiveResultSet {
 
 		private final ResultSet resultSet;
-		private final Scheduler scheduler;
 
-		DefaultReactiveResultSet(ResultSet resultSet, Scheduler scheduler) {
+		DefaultReactiveResultSet(ResultSet resultSet) {
 			this.resultSet = resultSet;
-			this.scheduler = scheduler;
 		}
 
 		/* (non-Javadoc)
@@ -234,12 +239,50 @@ public class DefaultBridgedReactiveSession implements ReactiveSession {
 		 */
 		@Override
 		public Flux<Row> rows() {
+			return getRows(Mono.just(resultSet));
+		}
+
+		Flux<Row> getRows(Mono<ResultSet> nextResults) {
+
+			return nextResults.flatMapMany(it -> {
+
+				Flux<Row> rows = toRows(it);
+
+				if (it.isFullyFetched()) {
+					return rows;
+				}
+
+				MonoProcessor<ResultSet> processor = MonoProcessor.create();
+				return rows //
+						.doOnComplete(() -> fetchMore(it.fetchMoreResults(), processor)) //
+						.concatWith(getRows(processor));
+			});
+		}
+
+		static Flux<Row> toRows(ResultSet resultSet) {
 
 			int prefetch = Math.max(1, resultSet.getAvailableWithoutFetching());
+			return Flux.fromIterable(resultSet).take(prefetch);
+		}
 
-			return Flux.fromIterable(resultSet) //
-					.subscribeOn(scheduler) //
-					.publishOn(Schedulers.immediate(), prefetch); // limit prefetching to available size
+		static void fetchMore(ListenableFuture<ResultSet> future, MonoProcessor<ResultSet> sink) {
+
+			try {
+
+				future.addListener(() -> {
+
+					try {
+
+						sink.onNext(future.get());
+						sink.onComplete();
+					} catch (Exception e) {
+						sink.onError(e);
+					}
+				}, Runnable::run);
+
+			} catch (Exception e) {
+				sink.onError(e);
+			}
 		}
 
 		/* (non-Javadoc)

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/DefaultBridgedReactiveSessionUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/DefaultBridgedReactiveSessionUnitTests.java
@@ -168,8 +168,7 @@ public class DefaultBridgedReactiveSessionUnitTests {
 			return null;
 		}).when(future).addListener(any(), any());
 
-		when(future.getUninterruptibly()).thenReturn(resultSet);
-		when(future.isDone()).thenReturn(true);
+		when(future.get()).thenReturn(resultSet);
 		when(resultSet.isFullyFetched()).thenReturn(true);
 
 		reactiveSession.execute(new SimpleStatement("")).flatMapMany(ReactiveResultSet::rows).collectList().subscribe();
@@ -199,8 +198,7 @@ public class DefaultBridgedReactiveSessionUnitTests {
 			return null;
 		}).when(future).addListener(any(), any());
 
-		when(future.getUninterruptibly()).thenReturn(resultSet);
-		when(future.isDone()).thenReturn(true);
+		when(future.get()).thenReturn(resultSet);
 		when(resultSet.isFullyFetched()).thenReturn(false, true);
 		when(resultSet.fetchMoreResults()).thenReturn(Futures.immediateFuture(emptyResultSet));
 
@@ -228,9 +226,7 @@ public class DefaultBridgedReactiveSessionUnitTests {
 			return null;
 		}).when(future).addListener(any(), any());
 
-		when(future.getUninterruptibly()).thenReturn(resultSet);
 		when(future.get()).thenReturn(resultSet);
-		when(future.isDone()).thenReturn(true);
 		when(resultSet.isFullyFetched()).thenReturn(false, false, true);
 		when(resultSet.fetchMoreResults()).thenReturn(future);
 


### PR DESCRIPTION
We now no longer require a `Scheduler` to offload `ResultSet`'s blocking paging but request the next result page asynchronously by adapting `ResultSet.fetchMoreResults()`. Result pages are requested once all elements of the previous `ResultSet` are emitted and the row publisher completes successfully. The Scheduler is no longer required.

The request progress is stored in a `MonoProcessor` to extend the result stream. Increase visibility of utility methods to avoid synthetic accessor creation.

---

Related ticket: [DATACASS-509](https://jira.spring.io/browse/DATACASS-509).