### PR TITLE
DATACASS-516 - Missing return type in example 52.

### DIFF
--- a/src/main/asciidoc/reference/cassandra.adoc
+++ b/src/main/asciidoc/reference/cassandra.adoc
@@ -345,7 +345,7 @@ public class AppConfig extends AbstractCassandraConfiguration {
   /*
    * Provide a keyspace name to the configuration.
    */
-  public getKeyspaceName() {
+  public String getKeyspaceName() {
     return "mykeyspace";
   }
 }


### PR DESCRIPTION
Tiny change to docs. 

Ticket: [DATACASS-516](https://jira.spring.io/browse/DATACASS-516)