### PR TITLE
DATACASS-512 - Support exists and count projections.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACASS-512-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-512-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-512-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraOperations.java
@@ -230,7 +230,18 @@ public interface AsyncCassandraOperations {
 	ListenableFuture<Long> count(Class<?> entityClass) throws DataAccessException;
 
 	/**
-	 * Determine whether the row {@code entityClass} with the given {@code id} exists.
+	 * Returns the number of rows for the given entity class applying {@link Query}.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @param entityClass must not be {@literal null}.
+	 * @return the number of existing entities.
+	 * @throws DataAccessException if there is any problem executing the query.
+	 * @since 2.1
+	 */
+	ListenableFuture<Long> count(Query query, Class<?> entityClass) throws DataAccessException;
+
+	/**
+	 * Determine whether a row of {@code entityClass} with the given {@code id} exists.
 	 *
 	 * @param id the Id value. For single primary keys it's the plain value. For composite primary keys either the
 	 *          {@link org.springframework.data.cassandra.core.mapping.PrimaryKeyClass} or
@@ -240,6 +251,17 @@ public interface AsyncCassandraOperations {
 	 * @throws DataAccessException if there is any problem executing the query.
 	 */
 	ListenableFuture<Boolean> exists(Object id, Class<?> entityClass) throws DataAccessException;
+
+	/**
+	 * Determine whether the result for {@code entityClass} {@link Query} yields at least one row.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @param entityClass The entity type must not be {@literal null}.
+	 * @return true, if the object exists.
+	 * @throws DataAccessException if there is any problem executing the query.
+	 * @since 2.1
+	 */
+	ListenableFuture<Boolean> exists(Query query, Class<?> entityClass) throws DataAccessException;
 
 	/**
 	 * Execute the Select by {@code id} for the given {@code entityClass}.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
@@ -257,7 +257,18 @@ public interface CassandraOperations {
 	long count(Class<?> entityClass) throws DataAccessException;
 
 	/**
-	 * Determine whether the row {@code entityClass} with the given {@code id} exists.
+	 * Returns the number of rows for the given entity class applying {@link Query}.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @param entityClass must not be {@literal null}.
+	 * @return the number of existing entities.
+	 * @throws DataAccessException if there is any problem executing the query.
+	 * @since 2.1
+	 */
+	long count(Query query, Class<?> entityClass) throws DataAccessException;
+
+	/**
+	 * Determine whether a row of {@code entityClass} with the given {@code id} exists.
 	 *
 	 * @param id the Id value. For single primary keys it's the plain value. For composite primary keys either the
 	 *          {@link org.springframework.data.cassandra.core.mapping.PrimaryKeyClass} or
@@ -267,6 +278,17 @@ public interface CassandraOperations {
 	 * @throws DataAccessException if there is any problem executing the query.
 	 */
 	boolean exists(Object id, Class<?> entityClass) throws DataAccessException;
+
+	/**
+	 * Determine whether the result for {@code entityClass} {@link Query} yields at least one row.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @param entityClass The entity type must not be {@literal null}.
+	 * @return true, if the object exists.
+	 * @throws DataAccessException if there is any problem executing the query.
+	 * @since 2.1
+	 */
+	boolean exists(Query query, Class<?> entityClass) throws DataAccessException;
 
 	/**
 	 * Execute the Select by {@code id} for the given {@code entityClass}.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraOperations.java
@@ -165,7 +165,18 @@ public interface ReactiveCassandraOperations {
 	Mono<Long> count(Class<?> entityClass) throws DataAccessException;
 
 	/**
-	 * Determine whether the row {@code entityClass} with the given {@code id} exists.
+	 * Returns the number of rows for the given entity class applying {@link Query}.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @param entityClass must not be {@literal null}.
+	 * @return the number of existing entities.
+	 * @throws DataAccessException if there is any problem executing the query.
+	 * @since 2.1
+	 */
+	Mono<Long> count(Query query, Class<?> entityClass) throws DataAccessException;
+
+	/**
+	 * Determine whether a row of {@code entityClass} with the given {@code id} exists.
 	 *
 	 * @param id the Id value. For single primary keys it's the plain value. For composite primary keys either the
 	 *          {@link org.springframework.data.cassandra.core.mapping.PrimaryKeyClass} or
@@ -175,6 +186,17 @@ public interface ReactiveCassandraOperations {
 	 * @throws DataAccessException if there is any problem issuing the execution.
 	 */
 	Mono<Boolean> exists(Object id, Class<?> entityClass) throws DataAccessException;
+
+	/**
+	 * Determine whether the result for {@code entityClass} {@link Query} yields at least one row.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @param entityClass The entity type must not be {@literal null}.
+	 * @return true, if the object exists.
+	 * @throws DataAccessException if there is any problem executing the query.
+	 * @since 2.1
+	 */
+	Mono<Boolean> exists(Query query, Class<?> entityClass) throws DataAccessException;
 
 	/**
 	 * Execute the Select by {@code id} for the given {@code entityClass}.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/CountQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/CountQuery.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,45 +21,25 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.data.annotation.QueryAnnotation;
+import org.springframework.core.annotation.AliasFor;
 
 /**
- * Annotation to declare finder queries directly on repository methods.
+ * Annotation to declare count queries directly on repository methods. Both attributes allow using a placeholder
+ * notation of {@code ?0}, {@code ?1} and so on.
  *
- * @author Alex Shvid
- * @author Matthew T. Adams
  * @author Mark Paluch
+ * @since 2.1
  */
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Documented
-@QueryAnnotation
-public @interface Query {
+@Query(count = true)
+public @interface CountQuery {
 
 	/**
 	 * A Cassandra CQL3 string to define the actual query to be executed. Placeholders {@code ?0}, {@code ?1}, etc are
 	 * supported.
 	 */
+	@AliasFor(annotation = Query.class)
 	String value() default "";
-
-	/**
-	 * Specifies whether to allow filtering using query derivation without a {@link #value() string query}.
-	 *
-	 * @since 2.0
-	 */
-	boolean allowFiltering() default false;
-
-	/**
-	 * Returns whether the query defined should be executed as count projection.
-	 *
-	 * @since 2.1
-	 */
-	boolean count() default false;
-
-	/**
-	 * Returns whether the query defined should be executed as exists projection.
-	 *
-	 * @since 2.1
-	 */
-	boolean exists() default false;
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/ExistsQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/ExistsQuery.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,45 +21,25 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.data.annotation.QueryAnnotation;
+import org.springframework.core.annotation.AliasFor;
 
 /**
- * Annotation to declare finder queries directly on repository methods.
+ * Annotation to declare exists queries directly on repository methods. Both attributes allow using a placeholder
+ * notation of {@code ?0}, {@code ?1} and so on.
  *
- * @author Alex Shvid
- * @author Matthew T. Adams
  * @author Mark Paluch
+ * @since 2.1
  */
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Documented
-@QueryAnnotation
-public @interface Query {
+@Query(exists = true)
+public @interface ExistsQuery {
 
 	/**
 	 * A Cassandra CQL3 string to define the actual query to be executed. Placeholders {@code ?0}, {@code ?1}, etc are
 	 * supported.
 	 */
+	@AliasFor(annotation = Query.class)
 	String value() default "";
-
-	/**
-	 * Specifies whether to allow filtering using query derivation without a {@link #value() string query}.
-	 *
-	 * @since 2.0
-	 */
-	boolean allowFiltering() default false;
-
-	/**
-	 * Returns whether the query defined should be executed as count projection.
-	 *
-	 * @since 2.1
-	 */
-	boolean count() default false;
-
-	/**
-	 * Returns whether the query defined should be executed as exists projection.
-	 *
-	 * @since 2.1
-	 */
-	boolean exists() default false;
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraRepositoryQuerySupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraRepositoryQuerySupport.java
@@ -15,20 +15,23 @@
  */
 package org.springframework.data.cassandra.repository.query;
 
-import java.util.Map;
-
 import lombok.RequiredArgsConstructor;
 
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.EntityInstantiators;
+import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ReturnedType;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base class for Cassandra {@link RepositoryQuery} implementations providing common infrastructure such as
@@ -53,15 +56,35 @@ public abstract class CassandraRepositoryQuerySupport implements RepositoryQuery
 	 * {@link CassandraOperations}.
 	 *
 	 * @param queryMethod must not be {@literal null}.
-	 * @param operations must not be {@literal null}.
+	 * @deprecated use {@link #CassandraRepositoryQuerySupport(CassandraQueryMethod, MappingContext)}
 	 */
+	@Deprecated
 	public CassandraRepositoryQuerySupport(CassandraQueryMethod queryMethod) {
 
 		Assert.notNull(queryMethod, "CassandraQueryMethod must not be null");
 
 		this.queryMethod = queryMethod;
 		this.instantiators = new EntityInstantiators();
-		this.queryStatementCreator = new QueryStatementCreator(queryMethod);
+		this.queryStatementCreator = new QueryStatementCreator(queryMethod, new CassandraMappingContext());
+	}
+
+	/**
+	 * Create a new {@link AbstractCassandraQuery} from the given {@link CassandraQueryMethod} and
+	 * {@link CassandraOperations}.
+	 *
+	 * @param queryMethod must not be {@literal null}.
+	 * @param mappingContext must not be {@literal null}.
+	 * @since 2.1
+	 */
+	public CassandraRepositoryQuerySupport(CassandraQueryMethod queryMethod,
+			MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> mappingContext) {
+
+		Assert.notNull(queryMethod, "CassandraQueryMethod must not be null");
+		Assert.notNull(mappingContext, "CassandraMappingContext must not be null");
+
+		this.queryMethod = queryMethod;
+		this.instantiators = new EntityInstantiators();
+		this.queryStatementCreator = new QueryStatementCreator(queryMethod, mappingContext);
 	}
 
 	/* (non-Javadoc)

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQuery.java
@@ -95,7 +95,31 @@ public class PartTreeCassandraQuery extends AbstractCassandraQuery {
 	 */
 	@Override
 	protected Statement createQuery(CassandraParameterAccessor parameterAccessor) {
-		return getQueryStatementCreator().select(getStatementFactory(), getTree(), getMappingContext(),
-				parameterAccessor);
+
+		if (isCountQuery()) {
+			return getQueryStatementCreator().count(getStatementFactory(), getTree(), parameterAccessor);
+		}
+
+		if (isExistsQuery()) {
+			return getQueryStatementCreator().exists(getStatementFactory(), getTree(), parameterAccessor);
+		}
+
+		return getQueryStatementCreator().select(getStatementFactory(), getTree(), parameterAccessor);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.AbstractCassandraQuery#isCountQuery()
+	 */
+	@Override
+	protected boolean isCountQuery() {
+		return tree.isCountProjection();
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.AbstractCassandraQuery#isExistsQuery()
+	 */
+	@Override
+	protected boolean isExistsQuery() {
+		return tree.isExistsProjection();
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ProjectionUtil.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ProjectionUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.query;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.datastax.driver.core.ColumnDefinitions;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.Row;
+
+/**
+ * Utility methods for projections.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@UtilityClass
+class ProjectionUtil {
+
+	private final static Set<DataType> NUMERIC_TYPES = new HashSet<>(Arrays.asList(DataType.bigint(), DataType.varint(),
+			DataType.smallint(), DataType.cint(), DataType.counter(), DataType.tinyint()));
+
+	/**
+	 * Determine wether the {@link Row} qualifies for a count projection. Count projection candidates have a single
+	 * numeric column.
+	 *
+	 * @param row
+	 * @return
+	 */
+	static boolean isCountProjection(Row row) {
+
+		ColumnDefinitions columnDefinitions = row.getColumnDefinitions();
+		return columnDefinitions.size() == 1 && NUMERIC_TYPES.contains(columnDefinitions.getType(0));
+	}
+
+	/**
+	 * Determine whether multiple {@code boolean} flags are set. Allowed is at most a single {@literal true} value.
+	 *
+	 * @param flags
+	 * @return {@literal true} if more than one {@code flag} is set to {@literal true}.
+	 */
+	static boolean hasAmbiguousProjectionFlags(Boolean... flags) {
+		return Arrays.stream(flags).filter(Boolean::booleanValue).count() > 1;
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQuery.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQuery.java
@@ -95,6 +95,31 @@ public class ReactivePartTreeCassandraQuery extends AbstractReactiveCassandraQue
 	 */
 	@Override
 	protected Statement createQuery(CassandraParameterAccessor parameterAccessor) {
-		return getQueryStatementCreator().select(getStatementFactory(), getTree(), getMappingContext(), parameterAccessor);
+
+		if (isCountQuery()) {
+			return getQueryStatementCreator().count(getStatementFactory(), getTree(), parameterAccessor);
+		}
+
+		if (isExistsQuery()) {
+			return getQueryStatementCreator().exists(getStatementFactory(), getTree(), parameterAccessor);
+		}
+
+		return getQueryStatementCreator().select(getStatementFactory(), getTree(), parameterAccessor);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.AbstractReactiveCassandraQuery#isCountQuery()
+	 */
+	@Override
+	protected boolean isCountQuery() {
+		return tree.isCountProjection();
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.AbstractReactiveCassandraQuery#isExistsQuery()
+	 */
+	@Override
+	protected boolean isExistsQuery() {
+		return tree.isExistsProjection();
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/AsyncCassandraTemplateIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/AsyncCassandraTemplateIntegrationTests.java
@@ -51,7 +51,7 @@ public class AsyncCassandraTemplateIntegrationTests extends AbstractKeyspaceCrea
 	private AsyncCassandraTemplate template;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 
 		MappingCassandraConverter converter = new MappingCassandraConverter();
 		CassandraTemplate cassandraTemplate = new CassandraTemplate(session, converter);
@@ -142,7 +142,7 @@ public class AsyncCassandraTemplateIntegrationTests extends AbstractKeyspaceCrea
 	}
 
 	@Test // DATACASS-292
-	public void shouldInsertAndCountEntities() throws Exception {
+	public void shouldInsertAndCountEntities() {
 
 		User user = new User("heisenberg", "Walter", "White");
 
@@ -175,7 +175,7 @@ public class AsyncCassandraTemplateIntegrationTests extends AbstractKeyspaceCrea
 	}
 
 	@Test // DATACASS-292
-	public void updateShouldUpdateEntity() throws Exception {
+	public void updateShouldUpdateEntity() {
 
 		User user = new User("heisenberg", "Walter", "White");
 		getUninterruptibly(template.insert(user));
@@ -218,10 +218,10 @@ public class AsyncCassandraTemplateIntegrationTests extends AbstractKeyspaceCrea
 	}
 
 	@Test // DATACASS-343
-	public void updateShouldUpdateEntityByQuery() throws Exception {
+	public void updateShouldUpdateEntityByQuery() {
 
 		User user = new User("heisenberg", "Walter", "White");
-		template.insert(user).get();
+		getUninterruptibly(template.insert(user));
 
 		Query query = Query.query(where("id").is("heisenberg"));
 		boolean result = getUninterruptibly(
@@ -232,10 +232,10 @@ public class AsyncCassandraTemplateIntegrationTests extends AbstractKeyspaceCrea
 	}
 
 	@Test // DATACASS-343
-	public void deleteByQueryShouldRemoveEntity() throws Exception {
+	public void deleteByQueryShouldRemoveEntity() {
 
 		User user = new User("heisenberg", "Walter", "White");
-		template.insert(user).get();
+		getUninterruptibly(template.insert(user));
 
 		Query query = Query.query(where("id").is("heisenberg"));
 		assertThat(getUninterruptibly(template.delete(query, User.class))).isTrue();
@@ -244,10 +244,10 @@ public class AsyncCassandraTemplateIntegrationTests extends AbstractKeyspaceCrea
 	}
 
 	@Test // DATACASS-343
-	public void deleteColumnsByQueryShouldRemoveColumn() throws Exception {
+	public void deleteColumnsByQueryShouldRemoveColumn() {
 
 		User user = new User("heisenberg", "Walter", "White");
-		template.insert(user).get();
+		getUninterruptibly(template.insert(user));
 
 		Query query = Query.query(where("id").is("heisenberg")).columns(Columns.from("lastname"));
 
@@ -259,7 +259,7 @@ public class AsyncCassandraTemplateIntegrationTests extends AbstractKeyspaceCrea
 	}
 
 	@Test // DATACASS-292
-	public void deleteShouldRemoveEntity() throws Exception {
+	public void deleteShouldRemoveEntity() {
 
 		User user = new User("heisenberg", "Walter", "White");
 		getUninterruptibly(template.insert(user));
@@ -271,7 +271,7 @@ public class AsyncCassandraTemplateIntegrationTests extends AbstractKeyspaceCrea
 	}
 
 	@Test // DATACASS-292
-	public void deleteByIdShouldRemoveEntity() throws Exception {
+	public void deleteByIdShouldRemoveEntity() {
 
 		User user = new User("heisenberg", "Walter", "White");
 		getUninterruptibly(template.insert(user));

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplateIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplateIntegrationTests.java
@@ -50,7 +50,7 @@ public class ReactiveCassandraTemplateIntegrationTests extends AbstractKeyspaceC
 	ReactiveCassandraTemplate template;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 
 		MappingCassandraConverter converter = new MappingCassandraConverter();
 		CassandraTemplate cassandraTemplate = new CassandraTemplate(this.session, converter);

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplateIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplateIntegrationTests.java
@@ -16,6 +16,7 @@
 package org.springframework.data.cassandra.core;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.cassandra.core.query.Criteria.*;
 
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -107,13 +108,45 @@ public class ReactiveCassandraTemplateIntegrationTests extends AbstractKeyspaceC
 	}
 
 	@Test // DATACASS-335
-	public void shouldInsertAndCountEntities() {
+	public void shouldInsertEntityAndCount() {
 
 		User user = new User("heisenberg", "Walter", "White");
 
 		StepVerifier.create(template.insert(user)).expectNextCount(1).verifyComplete();
 
 		StepVerifier.create(template.count(User.class)).expectNext(1L).verifyComplete();
+	}
+
+	@Test // DATACASS-335
+	public void shouldInsertEntityAndCountByQuery() {
+
+		User user = new User("heisenberg", "Walter", "White");
+
+		StepVerifier.create(template.insert(user)).expectNextCount(1).verifyComplete();
+
+		StepVerifier.create(template.count(Query.query(where("id").is("heisenberg")), User.class)) //
+				.expectNext(1L) //
+				.verifyComplete();
+
+		StepVerifier.create(template.count(Query.query(where("id").is("foo")), User.class)) //
+				.expectNext(0L) //
+				.verifyComplete();
+	}
+
+	@Test // DATACASS-335
+	public void shouldInsertAndExistsByQueryEntities() {
+
+		User user = new User("heisenberg", "Walter", "White");
+
+		StepVerifier.create(template.insert(user)).expectNextCount(1).verifyComplete();
+
+		StepVerifier.create(template.exists(Query.query(where("id").is("heisenberg")), User.class)) //
+				.expectNext(true) //
+				.verifyComplete();
+
+		StepVerifier.create(template.exists(Query.query(where("id").is("foo")), User.class)) //
+				.expectNext(false) //
+				.verifyComplete();
 	}
 
 	@Test // DATACASS-335

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/StatementFactoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/StatementFactoryUnitTests.java
@@ -229,6 +229,17 @@ public class StatementFactoryUnitTests {
 		assertThat(update.toString()).isEqualTo("UPDATE person SET number=number-1;");
 	}
 
+	@Test // DATACASS-512
+	public void shouldCreateCountQuery() {
+
+		Query query = Query.query(Criteria.where("foo").is("bar"));
+
+		Statement count = statementFactory.count(query,
+				converter.getMappingContext().getRequiredPersistentEntity(Group.class));
+
+		assertThat(count.toString()).isEqualTo("SELECT COUNT(1) FROM group WHERE foo='bar';");
+	}
+
 	static class Person {
 
 		@Id String id;

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/QueryDerivationIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/QueryDerivationIntegrationTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.data.cassandra.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assume.assumeTrue;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assume.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -26,10 +26,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
@@ -54,8 +54,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.util.Version;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import org.assertj.core.api.Assertions;
 
 import com.datastax.driver.core.Session;
 
@@ -183,7 +181,7 @@ public class QueryDerivationIntegrationTests extends AbstractSpringDataEmbeddedC
 
 		Collection<PersonProjection> collection = personRepository.findPersonProjectedBy();
 
-		Assertions.assertThat(collection).hasSize(3).extracting("firstname").contains(flynn.getFirstname(),
+		assertThat(collection).hasSize(3).extracting("firstname").contains(flynn.getFirstname(),
 				skyler.getFirstname(), walter.getFirstname());
 	}
 
@@ -192,7 +190,7 @@ public class QueryDerivationIntegrationTests extends AbstractSpringDataEmbeddedC
 
 		Collection<PersonDto> collection = personRepository.findPersonDtoBy();
 
-		Assertions.assertThat(collection).hasSize(3).extracting("firstname").contains(flynn.getFirstname(),
+		assertThat(collection).hasSize(3).extracting("firstname").contains(flynn.getFirstname(),
 				skyler.getFirstname(), walter.getFirstname());
 	}
 
@@ -320,6 +318,21 @@ public class QueryDerivationIntegrationTests extends AbstractSpringDataEmbeddedC
 		assertThat(result).contains(walter, skyler, flynn);
 	}
 
+	@Test // DATACASS-512
+	public void shouldCountRecords() {
+
+		long count = personRepository.countByLastname("White");
+
+		assertThat(count).isEqualTo(3);
+	}
+
+	@Test // DATACASS-512
+	public void shouldApplyExistsProjection() {
+
+		assertThat(personRepository.existsByLastname("White")).isTrue();
+		assertThat(personRepository.existsByLastname("Schrader")).isFalse();
+	}
+
 	/**
 	 * @author Mark Paluch
 	 */
@@ -345,6 +358,10 @@ public class QueryDerivationIntegrationTests extends AbstractSpringDataEmbeddedC
 		Person findByNicknameContains(String contains);
 
 		Person findByNumberOfChildren(NumberOfChildren numberOfChildren);
+
+		long countByLastname(String lastname);
+
+		boolean existsByLastname(String lastname);
 
 		Slice<Person> findAllSlicedByLastname(String lastname, Pageable pageable);
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/ReactiveCassandraRepositoryIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/ReactiveCassandraRepositoryIntegrationTests.java
@@ -164,6 +164,26 @@ public class ReactiveCassandraRepositoryIntegrationTests extends AbstractKeyspac
 				.verifyComplete();
 	}
 
+	@Test // DATACASS-512
+	public void shouldCountRecords() {
+
+		StepVerifier.create(repository.countByLastname("Matthews")).expectNext(2L).verifyComplete();
+		StepVerifier.create(repository.countByLastname("None")).expectNext(0L).verifyComplete();
+
+		StepVerifier.create(repository.countQueryByLastname("Matthews")).expectNext(2L).verifyComplete();
+		StepVerifier.create(repository.countQueryByLastname("None")).expectNext(0L).verifyComplete();
+	}
+
+	@Test // DATACASS-512
+	public void shouldApplyExistsProjection() {
+
+		StepVerifier.create(repository.existsByLastname("Matthews")).expectNext(true).verifyComplete();
+		StepVerifier.create(repository.existsByLastname("None")).expectNext(false).verifyComplete();
+
+		StepVerifier.create(repository.existsQueryByLastname("Matthews")).expectNext(true).verifyComplete();
+		StepVerifier.create(repository.existsQueryByLastname("None")).expectNext(false).verifyComplete();
+	}
+
 	interface UserRepository extends ReactiveCassandraRepository<User, String> {
 
 		Flux<User> findByLastname(String lastname);
@@ -172,8 +192,18 @@ public class ReactiveCassandraRepositoryIntegrationTests extends AbstractKeyspac
 
 		Mono<User> findByLastname(Publisher<String> lastname);
 
+		Mono<Long> countByLastname(String lastname);
+
+		Mono<Boolean> existsByLastname(String lastname);
+
 		@Query("SELECT * FROM users WHERE lastname = ?0")
 		Flux<User> findStringQuery(Mono<String> lastname);
+
+		@CountQuery("SELECT COUNT(*) from users WHERE lastname = ?0")
+		Mono<Long> countQueryByLastname(String lastname);
+
+		@ExistsQuery("SELECT * from users WHERE lastname = ?0")
+		Mono<Boolean> existsQueryByLastname(String lastname);
 	}
 
 	interface GroupRepository extends ReactiveCassandraRepository<Group, GroupKey> {

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQueryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQueryUnitTests.java
@@ -207,6 +207,22 @@ public class PartTreeCassandraQueryUnitTests {
 		assertThat(statement.getConsistencyLevel()).isEqualTo(ConsistencyLevel.LOCAL_ONE);
 	}
 
+	@Test // DATACASS-512
+	public void shouldCreateCountQuery() {
+
+		Statement statement = deriveQueryFromMethod(Repo.class, "countBy", new Class[0]);
+
+		assertThat(statement.toString()).isEqualTo("SELECT COUNT(1) FROM person;");
+	}
+
+	@Test // DATACASS-512
+	public void shouldCreateExistsQuery() {
+
+		Statement statement = deriveQueryFromMethod(Repo.class, "existsBy", new Class[0]);
+
+		assertThat(statement.toString()).isEqualTo("SELECT * FROM person LIMIT 1;");
+	}
+
 	private String deriveQueryFromMethod(String method, Object... args) {
 
 		Class<?>[] types = new Class<?>[args.length];
@@ -276,6 +292,10 @@ public class PartTreeCassandraQueryUnitTests {
 		Person findByMainAddressIn(Collection<AddressType> address);
 
 		Person findByFirstnameIn(Collection<String> firstname);
+
+		long countBy();
+
+		boolean existsBy();
 
 		@AllowFiltering
 		Person findByFirstname(String firstname);

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/ReactiveStringBasedCassandraQueryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/ReactiveStringBasedCassandraQueryUnitTests.java
@@ -15,7 +15,8 @@
  */
 package org.springframework.data.cassandra.repository.query;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
 
@@ -24,7 +25,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import org.springframework.data.cassandra.ReactiveSession;
 import org.springframework.data.cassandra.core.ReactiveCassandraOperations;
 import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
@@ -77,6 +77,8 @@ public class ReactiveStringBasedCassandraQueryUnitTests {
 		this.factory = new SpelAwareProxyProjectionFactory();
 
 		this.converter.afterPropertiesSet();
+
+		when(operations.getConverter()).thenReturn(converter);
 	}
 
 	@Test // DATACASS-335

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/StringBasedCassandraQueryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/StringBasedCassandraQueryUnitTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.data.cassandra.repository.query;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -32,7 +32,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
 import org.springframework.data.cassandra.core.cql.CqlIdentifier;
@@ -94,6 +93,8 @@ public class StringBasedCassandraQueryUnitTests {
 		this.factory = new SpelAwareProxyProjectionFactory();
 
 		this.converter.afterPropertiesSet();
+
+		when(operations.getConverter()).thenReturn(converter);
 	}
 
 	@Test // DATACASS-117

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -3,6 +3,11 @@
 
 This chapter summarizes changes and new features for each release.
 
+[[new-features.2-1-0]]
+== What's new in Spring Data for Apache Cassandra 2.1
+* New annotations for `@CountQuery` and `@ExistsQuery`.
+* Template API extended with `count(…)` and `exists(…)` methods accepting `Query`.
+
 [[new-features.2-0-0]]
 == What's new in Spring Data for Apache Cassandra 2.0
 


### PR DESCRIPTION
We now support exists and count projections derived from query methods and on Template API level. Exists queries fetch rows limiting to a single row to optimize fetching. Exists queries also support count results, i.e. a single row with a single numeric column is considered a count result. It's evaluated by comparing the number being greater to zero.

```java
boolean exists = template.exists(Query.query(where("firstname").is("Walter")), Person.class);

long count = template.count(Query.query(where("lastname").is("White")), Person.class);

interface PersonRepository extends Repository<Person, String> {

    long countByLastname(String lastname); // derived query

    boolean existsByLastname(String lastname);  // derived query

    @CountQuery("SELECT COUNT(*) from users WHERE lastname = ?0")
    long countQueryByLastname(String lastname); // String-based query

    @ExistsQuery("SELECT * from users WHERE lastname = ?0 LIMIT 1")
    boolean existsQueryByLastname(String lastname);  // String-based query
}
```

---

Related ticket: [DATACASS-512](https://jira.spring.io/browse/DATACASS-512).