### PR TITLE
DATACASS-485 - Fluent Cassandra Operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACASS-485-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-485-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-485-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraAdminOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraAdminOperations.java
@@ -39,7 +39,7 @@ public interface CassandraAdminOperations extends CassandraOperations {
 	 * doesn't exist, parameter {@code ifNotExists} is ignored, the table is created and {@literal true} is returned.
 	 *
 	 * @param ifNotExists If true, will only create the table if it doesn't exist, else the create operation will be
-	 *          ignored and the method will return {@literal false}.
+	 *          ignored.
 	 * @param tableName The name of the table.
 	 * @param entityClass The class whose fields determine the columns created.
 	 * @param optionsByName Table options, given by the string option name and the appropriate option value.
@@ -53,6 +53,15 @@ public interface CassandraAdminOperations extends CassandraOperations {
 	 * @param tableName The name of the table.
 	 */
 	void dropTable(CqlIdentifier tableName);
+
+	/**
+	 * Drops the named table.
+	 *
+	 * @param ifExists If true, will only drop the table if it exists, else the create operation will be ignored.
+	 * @param tableName The name of the table.
+	 * @since 2.1
+	 */
+	void dropTable(boolean ifExists, CqlIdentifier tableName);
 
 	/**
 	 * Lookup {@link TableMetadata}.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraAdminTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraAdminTemplate.java
@@ -90,7 +90,13 @@ public class CassandraAdminTemplate extends CassandraTemplate implements Cassand
 	 */
 	@Override
 	public void dropTable(CqlIdentifier tableName) {
-		getCqlOperations().execute(DropTableCqlGenerator.toCql(DropTableSpecification.dropTable(tableName)));
+		dropTable(false, tableName);
+	}
+
+	@Override
+	public void dropTable(boolean ifExists, CqlIdentifier tableName) {
+		getCqlOperations()
+				.execute(DropTableCqlGenerator.toCql(DropTableSpecification.dropTable(tableName).ifExists(ifExists)));
 	}
 
 	/*

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraAdminTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraAdminTemplate.java
@@ -64,8 +64,7 @@ public class CassandraAdminTemplate extends CassandraTemplate implements Cassand
 		super(sessionFactory, converter);
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraAdminOperations#createTable(boolean, org.springframework.data.cassandra.core.cql.CqlIdentifier, java.lang.Class, java.util.Map)
 	 */
 	@Override
@@ -84,8 +83,7 @@ public class CassandraAdminTemplate extends CassandraTemplate implements Cassand
 		dropTable(getTableName(entityClass));
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraAdminOperations#dropTable(org.springframework.data.cassandra.core.cql.CqlIdentifier)
 	 */
 	@Override
@@ -93,14 +91,16 @@ public class CassandraAdminTemplate extends CassandraTemplate implements Cassand
 		dropTable(false, tableName);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.CassandraAdminOperations#dropTable(boolean, CqlIdentifier)
+	 */
 	@Override
 	public void dropTable(boolean ifExists, CqlIdentifier tableName) {
 		getCqlOperations()
 				.execute(DropTableCqlGenerator.toCql(DropTableSpecification.dropTable(tableName).ifExists(ifExists)));
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraAdminOperations#dropUserType(org.springframework.data.cassandra.core.cql.CqlIdentifier)
 	 */
 	@Override
@@ -111,8 +111,7 @@ public class CassandraAdminTemplate extends CassandraTemplate implements Cassand
 		getCqlOperations().execute(DropUserTypeCqlGenerator.toCql(DropUserTypeSpecification.dropType(typeName)));
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraAdminOperations#getTableMetadata(java.lang.String, org.springframework.data.cassandra.core.cql.CqlIdentifier)
 	 */
 	@Override
@@ -125,8 +124,7 @@ public class CassandraAdminTemplate extends CassandraTemplate implements Cassand
 				.getCluster().getMetadata().getKeyspace(keyspace).getTable(tableName.toCql())));
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraAdminOperations#getKeyspaceMetadata()
 	 */
 	@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
@@ -47,7 +47,7 @@ import com.datastax.driver.core.Statement;
  * @see InsertOptions
  * @see UpdateOptions
  */
-public interface CassandraOperations {
+public interface CassandraOperations extends FluentCassandraOperations {
 
 	/**
 	 * Returns a new {@link CassandraBatchOperations}. Each {@link CassandraBatchOperations} instance can be executed only

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableDeleteOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableDeleteOperation.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+
+/**
+ * {@link ExecutableDeleteOperation} allows creation and execution of Cassandra {@code DELETE} operations in a fluent
+ * API style.
+ * <p>
+ * The starting {@literal domainType} is used for mapping the {@link Query} provided via {@code matching} into the
+ * Cassandra specific representation. The table to operate on is by default derived from the initial
+ * {@literal domainType} and can be defined there via {@link org.springframework.data.cassandra.core.mapping.Table}.
+ * Using {@code inTable} allows to override the table name for the execution.
+ *
+ * <pre>
+ *     <code>
+ *         delete(Jedi.class)
+ *             .inTable("star_wars")
+ *             .matching(query(where("firstname").is("luke")))
+ *             .all();
+ *     </code>
+ * </pre>
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface ExecutableDeleteOperation {
+
+	/**
+	 * Start creating a {@code DELETE} operation for the given {@literal domainType}.
+	 *
+	 * @param domainType must not be {@literal null}.
+	 * @return new instance of {@link ExecutableDelete}.
+	 * @throws IllegalArgumentException if domainType is {@literal null}.
+	 */
+	ExecutableDelete delete(Class<?> domainType);
+
+	/**
+	 * Table override (optional).
+	 */
+	interface DeleteWithTable {
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null} or empty.
+		 * @return new instance of {@link DeleteWithTable}.
+		 * @throws IllegalArgumentException if {@code table} is {@literal null} or empty.
+		 */
+		DeleteWithQuery inTable(String table);
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null}.
+		 * @return new instance of {@link DeleteWithTable}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier} is {@literal null}.
+		 */
+		DeleteWithQuery inTable(CqlIdentifier table);
+	}
+
+	interface TerminatingDelete {
+
+		/**
+		 * Remove all matching rows.
+		 *
+		 * @return the {@link WriteResult}. Never {@literal null}.
+		 */
+		WriteResult all();
+	}
+
+	interface DeleteWithQuery {
+
+		/**
+		 * Define the query filtering elements.
+		 *
+		 * @param query must not be {@literal null}.
+		 * @return new instance of {@link TerminatingDelete}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 */
+		TerminatingDelete matching(Query query);
+	}
+
+	/**
+	 * {@link ExecutableDelete} provides methods for constructing {@code DELETE} operations in a fluent way.
+	 */
+	interface ExecutableDelete extends DeleteWithTable, DeleteWithQuery {}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableDeleteOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableDeleteOperationSupport.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Implementation of {@link ExecutableDeleteOperation}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@RequiredArgsConstructor
+class ExecutableDeleteOperationSupport implements ExecutableDeleteOperation {
+
+	private final @NonNull CassandraTemplate template;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.ExecutableDeleteOperation#remove(java.lang.Class)
+	 */
+	@Override
+	public ExecutableDelete delete(Class<?> domainType) {
+
+		Assert.notNull(domainType, "DomainType must not be null!");
+
+		return new ExecutableDeleteSupport(template, domainType, Query.empty(), null);
+	}
+
+	@RequiredArgsConstructor
+	@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+	static class ExecutableDeleteSupport implements ExecutableDelete, DeleteWithTable, TerminatingDelete {
+
+		@NonNull CassandraTemplate template;
+
+		@NonNull Class<?> domainType;
+
+		@NonNull Query query;
+
+		@Nullable CqlIdentifier tableName;
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableDeleteOperation.DeleteWithTable#inTable(java.lang.String)
+		 */
+		@Override
+		public DeleteWithQuery inTable(String tableName) {
+
+			Assert.hasText(tableName, "Table name must not be null or empty");
+
+			return new ExecutableDeleteSupport(template, domainType, query, CqlIdentifier.of(tableName));
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableDeleteOperation.DeleteWithTable#inTable(org.springframework.data.cassandra.core.cql.CqlIdentifier)
+		 */
+		@Override
+		public DeleteWithQuery inTable(CqlIdentifier tableName) {
+
+			Assert.notNull(tableName, "Table name must not be null");
+
+			return new ExecutableDeleteSupport(template, domainType, query, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableDeleteOperation.DeleteWithQuery#matching(org.springframework.data.cassandra.core.query.Query)
+		 */
+		@Override
+		public TerminatingDelete matching(Query query) {
+
+			Assert.notNull(query, "Query must not be null!");
+
+			return new ExecutableDeleteSupport(template, domainType, query, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableDeleteOperation.TerminatingDelete#all()
+		 */
+		public WriteResult all() {
+			return template.doDelete(query, domainType, getTableName());
+		}
+
+		private CqlIdentifier getTableName() {
+			return tableName != null ? tableName : template.getTableName(domainType);
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableInsertOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableInsertOperation.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+
+/**
+ * {@link ExecutableInsertOperation} allows creation and execution of Cassandra {@code INSERT} insert operations in a
+ * fluent API style.
+ * <p>
+ * The table to operate on is by default derived from the initial {@literal domainType} and can be defined there via
+ * {@link org.springframework.data.cassandra.core.mapping.Table}. Using {@code inTable} allows to override the
+ * collection name for the execution.
+ *
+ * <pre>
+ *     <code>
+ *         insert(Jedi.class)
+ *             .inTable("star_wars")
+ *             .one(luke);
+ *     </code>
+ * </pre>
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface ExecutableInsertOperation {
+
+	/**
+	 * Start creating an {@code INSERT} operation for given {@literal domainType}.
+	 *
+	 * @param domainType must not be {@literal null}.
+	 * @return new instance of {@link ExecutableInsert}.
+	 * @throws IllegalArgumentException if domainType is {@literal null}.
+	 */
+	<T> ExecutableInsert<T> insert(Class<T> domainType);
+
+	/**
+	 * Trigger insert execution by calling one of the terminating methods.
+	 */
+	interface TerminatingInsert<T> {
+
+		/**
+		 * Insert exactly one object.
+		 *
+		 * @param object must not be {@literal null}.
+		 * @throws IllegalArgumentException if object is {@literal null}.
+		 */
+		WriteResult one(T object);
+	}
+
+	/**
+	 * Collection override (optional).
+	 */
+	interface InsertWithTable<T> extends InsertWithOptions<T> {
+
+		/**
+		 * Explicitly set the name of the table.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null} or empty.
+		 * @return new instance of {@link TerminatingInsert}.
+		 * @throws IllegalArgumentException if {@code table} is {@literal null} or empty.
+		 */
+		InsertWithOptions<T> inTable(String table);
+
+		/**
+		 * Explicitly set the name of the table.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null}.
+		 * @return new instance of {@link TerminatingInsert}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier} is {@literal null}.
+		 */
+		InsertWithOptions<T> inTable(CqlIdentifier table);
+	}
+
+	/**
+	 * Apply {@link InsertOptions} (optional).
+	 */
+	interface InsertWithOptions<T> extends TerminatingInsert<T> {
+
+		/**
+		 * Set insert options.
+		 *
+		 * @param insertOptions insertOptions not be {@literal null}.
+		 * @return new instance of {@link TerminatingInsert}.
+		 * @throws IllegalArgumentException if {@link InsertOptions} is {@literal null}.
+		 */
+		TerminatingInsert<T> withOptions(InsertOptions insertOptions);
+	}
+
+	/**
+	 * {@link ExecutableInsert} provides methods for constructing {@code INSERT} operations in a fluent way.
+	 */
+	interface ExecutableInsert<T> extends TerminatingInsert<T>, InsertWithTable<T>, InsertWithOptions<T> {}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableInsertOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableInsertOperationSupport.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Implementation of {@link ExecutableInsertOperation}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@RequiredArgsConstructor
+class ExecutableInsertOperationSupport implements ExecutableInsertOperation {
+
+	private final @NonNull CassandraTemplate template;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.ExecutableInsertOperation#insert(java.lang.Class)
+	 */
+	@Override
+	public <T> ExecutableInsert<T> insert(Class<T> domainType) {
+
+		Assert.notNull(domainType, "DomainType must not be null!");
+
+		return new ExecutableInsertSupport<>(template, domainType, null, InsertOptions.empty());
+	}
+
+	@RequiredArgsConstructor
+	@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+	static class ExecutableInsertSupport<T> implements ExecutableInsert<T> {
+
+		@NonNull CassandraTemplate template;
+
+		@NonNull Class<T> domainType;
+
+		@Nullable CqlIdentifier tableName;
+
+		@NonNull InsertOptions insertOptions;
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableInsertOperation.InsertWithTable#inTable(java.lang.String)
+		 */
+		@Override
+		public InsertWithOptions<T> inTable(String tableName) {
+
+			Assert.hasText(tableName, "Table name must not be null or empty");
+
+			return new ExecutableInsertSupport<>(template, domainType, CqlIdentifier.of(tableName), insertOptions);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableInsertOperation.InsertWithTable#inTable(org.springframework.data.cassandra.core.cql.CqlIdentifier)
+		 */
+		@Override
+		public InsertWithOptions<T> inTable(CqlIdentifier tableName) {
+
+			Assert.notNull(tableName, "Table name must not be null");
+
+			return new ExecutableInsertSupport<>(template, domainType, tableName, insertOptions);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableInsertOperation.InsertWithOptions#withOptions(org.springframework.data.cassandra.core.InsertOptions)
+		 */
+		@Override
+		public TerminatingInsert<T> withOptions(InsertOptions insertOptions) {
+
+			Assert.notNull(insertOptions, "InsertOptions must not be null");
+
+			return new ExecutableInsertSupport<>(template, domainType, tableName, insertOptions);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableInsertOperation.TerminatingInsert#one(java.lang.Object)
+		 */
+		@Override
+		public WriteResult one(T object) {
+
+			Assert.notNull(object, "Object must not be null!");
+
+			return template.doInsert(object, insertOptions, getTableName());
+		}
+
+		private CqlIdentifier getTableName() {
+			return tableName != null ? tableName : template.getTableName(domainType);
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperation.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.lang.Nullable;
+
+/**
+ * {@link ExecutableSelectOperation} allows creation and execution of Cassandra {@code SELECT} operations in a fluent
+ * API style.
+ * <p>
+ * The starting {@literal domainType} is used for mapping the {@link Query} provided via {@code matching} into the
+ * Cassandra specific representation. By default, the originating {@literal domainType} is also used for mapping back
+ * the result from the {@link com.datastax.driver.core.Row}. However, it is possible to define an different
+ * {@literal returnType} via {@code as} to mapping the result.
+ * <p>
+ * The table to operate on is by default derived from the initial {@literal domainType} and can be defined there via
+ * {@link org.springframework.data.cassandra.core.mapping.Table}. Using {@code inTable} allows to override the table
+ * name for the execution.
+ *
+ * <pre>
+ *     <code>
+ *         query(Human.class)
+ *             .inTable("star_wars")
+ *             .as(Jedi.class)
+ *             .matching(query(where("firstname").is("luke")))
+ *             .all();
+ *     </code>
+ * </pre>
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface ExecutableSelectOperation {
+
+	/**
+	 * Start creating a {@code SELECT} operation for the given {@literal domainType}.
+	 *
+	 * @param domainType must not be {@literal null}.
+	 * @return new instance of {@link ExecutableSelect}.
+	 * @throws IllegalArgumentException if domainType is {@literal null}.
+	 */
+	<T> ExecutableSelect<T> query(Class<T> domainType);
+
+	/**
+	 * Trigger {@code SELECT} execution by calling one of the terminating methods.
+	 */
+	interface TerminatingSelect<T> {
+
+		/**
+		 * Get exactly zero or one result.
+		 *
+		 * @return {@link Optional#empty()} if no match found.
+		 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one match found.
+		 */
+		default Optional<T> one() {
+			return Optional.ofNullable(oneValue());
+		}
+
+		/**
+		 * Get exactly zero or one result.
+		 *
+		 * @return {@literal null} if no match found.
+		 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one match found.
+		 */
+		@Nullable
+		T oneValue();
+
+		/**
+		 * Get the first or no result.
+		 *
+		 * @return {@link Optional#empty()} if no match found.
+		 */
+		default Optional<T> first() {
+			return Optional.ofNullable(firstValue());
+		}
+
+		/**
+		 * Get the first or no result.
+		 *
+		 * @return {@literal null} if no match found.
+		 */
+		@Nullable
+		T firstValue();
+
+		/**
+		 * Get all matching elements.
+		 *
+		 * @return never {@literal null}.
+		 */
+		List<T> all();
+
+		/**
+		 * Stream all matching elements.
+		 *
+		 * @return a {@link Stream} that wraps the a Cassandra {@link com.datastax.driver.core.ResultSet} that needs to be
+		 *         closed. Never {@literal null}.
+		 */
+		Stream<T> stream();
+
+		/**
+		 * Get the number of matching elements.
+		 *
+		 * @return total number of matching elements.
+		 */
+		long count();
+
+		/**
+		 * Check for the presence of matching elements.
+		 *
+		 * @return {@literal true} if at least one matching element exists.
+		 */
+		boolean exists();
+	}
+
+	/**
+	 * Terminating operations invoking the actual query execution.
+	 */
+	interface SelectWithQuery<T> extends TerminatingSelect<T> {
+
+		/**
+		 * Set the filter query to be used.
+		 *
+		 * @param query must not be {@literal null}.
+		 * @return new instance of {@link TerminatingSelect}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 */
+		TerminatingSelect<T> matching(Query query);
+	}
+
+	/**
+	 * Table override (Optional).
+	 */
+	interface SelectWithTable<T> extends SelectWithQuery<T> {
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null} or empty.
+		 * @return new instance of {@link SelectWithProjection}.
+		 * @throws IllegalArgumentException if {@code table} is {@literal null} or empty.
+		 */
+		SelectWithProjection<T> inTable(String table);
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null}.
+		 * @return new instance of {@link SelectWithProjection}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier} is {@literal null}.
+		 */
+		SelectWithProjection<T> inTable(CqlIdentifier table);
+	}
+
+	/**
+	 * Result type override (Optional).
+	 */
+	interface SelectWithProjection<T> extends SelectWithQuery<T> {
+
+		/**
+		 * Define the target type fields should be mapped to. <br />
+		 * Skip this step if you are anyway only interested in the original domain type.
+		 *
+		 * @param resultType must not be {@literal null}.
+		 * @param <R> result type.
+		 * @return new instance of {@link SelectWithProjection}.
+		 * @throws IllegalArgumentException if resultType is {@literal null}.
+		 */
+		<R> SelectWithQuery<R> as(Class<R> resultType);
+	}
+
+	/**
+	 * {@link ExecutableSelect} provides methods for constructing {@code SELECT} operations in a fluent way.
+	 */
+	interface ExecutableSelect<T> extends SelectWithTable<T>, SelectWithProjection<T> {}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperationSupport.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+/**
+ * Implementation of {@link ExecutableSelectOperation}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@RequiredArgsConstructor
+class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
+
+	private final @NonNull CassandraTemplate template;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation#query(java.lang.Class)
+	 */
+	@Override
+	public <T> ExecutableSelect<T> query(Class<T> domainType) {
+
+		Assert.notNull(domainType, "DomainType must not be null!");
+
+		return new ExecutableSelectSupport<>(template, domainType, domainType, Query.empty(), null);
+	}
+
+	@RequiredArgsConstructor
+	@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+	static class ExecutableSelectSupport<T>
+			implements ExecutableSelect<T>, SelectWithTable<T>, SelectWithProjection<T>, SelectWithQuery<T> {
+
+		@NonNull CassandraTemplate template;
+
+		@NonNull Class<?> domainType;
+
+		@NonNull Class<T> returnType;
+
+		@NonNull Query query;
+
+		@Nullable CqlIdentifier tableName;
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation.SelectWithTable#inTable(java.lang.String)
+		 */
+		@Override
+		public SelectWithProjection<T> inTable(String tableName) {
+
+			Assert.hasText(tableName, "Table name must not be null or empty!");
+
+			return new ExecutableSelectSupport<>(template, domainType, returnType, query, CqlIdentifier.of(tableName));
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation.SelectWithTable#inTable(org.springframework.data.cassandra.core.cql.CqlIdentifier)
+		 */
+		@Override
+		public SelectWithProjection<T> inTable(CqlIdentifier tableName) {
+
+			Assert.notNull(tableName, "Table name must not be null!");
+
+			return new ExecutableSelectSupport<>(template, domainType, returnType, query, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation.SelectWithProjection#as(java.lang.Class)
+		 */
+		@Override
+		public <R> SelectWithQuery<R> as(Class<R> returnType) {
+
+			Assert.notNull(returnType, "ReturnType must not be null!");
+
+			return new ExecutableSelectSupport<>(template, domainType, returnType, query, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation.SelectWithQuery#matching(org.springframework.data.cassandra.core.query.Query)
+		 */
+		@Override
+		public TerminatingSelect<T> matching(Query query) {
+
+			Assert.notNull(query, "Query must not be null!");
+
+			return new ExecutableSelectSupport<>(template, domainType, returnType, query, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation.TerminatingSelect#oneValue()
+		 */
+		@Override
+		public T oneValue() {
+
+			List<T> result = template.doSelect(query.limit(2), domainType, getTableName(), returnType);
+
+			if (ObjectUtils.isEmpty(result)) {
+				return null;
+			}
+
+			if (result.size() > 1) {
+				throw new IncorrectResultSizeDataAccessException("Query " + query + " returned non unique result.", 1);
+			}
+
+			return result.iterator().next();
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation.TerminatingSelect#firstValue()
+		 */
+		@Override
+		public T firstValue() {
+
+			List<T> result = template.doSelect(query.limit(1), domainType, getTableName(), returnType);
+
+			return ObjectUtils.isEmpty(result) ? null : result.iterator().next();
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation.TerminatingSelect#all()
+		 */
+		@Override
+		public List<T> all() {
+			return template.doSelect(query, domainType, getTableName(), returnType);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation.TerminatingSelect#stream()
+		 */
+		@Override
+		public Stream<T> stream() {
+			return template.doStream(query, domainType, getTableName(), returnType);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation.TerminatingSelect#count()
+		 */
+		@Override
+		public long count() {
+			return template.doCount(query, domainType, getTableName());
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation.TerminatingSelect#exists()
+		 */
+		@Override
+		public boolean exists() {
+			return template.doExists(query, domainType, getTableName());
+		}
+
+		private CqlIdentifier getTableName() {
+			return tableName != null ? tableName : template.getTableName(domainType);
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableUpdateOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableUpdateOperation.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.core.query.Update;
+
+/**
+ * {@link ExecutableUpdateOperation} allows creation and execution of Cassandra {@code UPDATE} operation in a fluent API
+ * style.
+ * <p>
+ * The starting {@literal domainType} is used for mapping the {@link Query} provided via {@code matching}, as well as
+ * the {@link Update} via {@code apply} into the Cassandra specific representations. The table to operate on is by
+ * default derived from the initial {@literal domainType} and can be defined there via
+ * {@link org.springframework.data.cassandra.core.mapping.Table}. Using {@code inTable} allows to override the table
+ * name for the execution.
+ *
+ * <pre>
+ *     <code>
+ *         update(Jedi.class)
+ *             .inTable("star_wars")
+ *             .matching(query(where("firstname").is("luke")))
+ *             .apply(update("lastname", "skywalker"))
+ *             .all();
+ *     </code>
+ * </pre>
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface ExecutableUpdateOperation {
+
+	/**
+	 * Start creating an {@code UPDATE} operation for the given {@literal domainType}.
+	 *
+	 * @param domainType must not be {@literal null}.
+	 * @return new instance of {@link ExecutableUpdate}.
+	 * @throws IllegalArgumentException if domainType is {@literal null}.
+	 */
+	<T> ExecutableUpdate<T> update(Class<T> domainType);
+
+	/**
+	 * Declare the {@link Update} to apply.
+	 */
+	interface UpdateWithUpdate<T> {
+
+		/**
+		 * Set the {@link Update} to be applied.
+		 *
+		 * @param update must not be {@literal null}.
+		 * @return new instance of {@link TerminatingUpdate}.
+		 * @throws IllegalArgumentException if update is {@literal null}.
+		 */
+		TerminatingUpdate<T> apply(Update update);
+	}
+
+	/**
+	 * Explicitly define the name of the table to perform operation in.
+	 */
+	interface UpdateWithTable<T> {
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null} or empty.
+		 * @return new instance of {@link UpdateWithTable}.
+		 * @throws IllegalArgumentException if {@code table} is {@literal null} or empty.
+		 */
+		UpdateWithQuery<T> inTable(String table);
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null}.
+		 * @return new instance of {@link UpdateWithTable}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier} is {@literal null}.
+		 */
+		UpdateWithQuery<T> inTable(CqlIdentifier table);
+	}
+
+	/**
+	 * Define a filter query for the {@link Update}.
+	 */
+	interface UpdateWithQuery<T> {
+
+		/**
+		 * Filter documents by given {@literal query}.
+		 *
+		 * @param query must not be {@literal null}.
+		 * @return new instance of {@link UpdateWithQuery}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 */
+		UpdateWithUpdate<T> matching(Query query);
+	}
+
+	/**
+	 * Trigger update execution by calling one of the terminating methods.
+	 */
+	interface TerminatingUpdate<T> {
+
+		/**
+		 * Update all matching rows in the table.
+		 *
+		 * @return never {@literal null}.
+		 */
+		WriteResult all();
+	}
+
+	/**
+	 * {@link ExecutableUpdate} provides methods for constructing {@code UPDATE} operations in a fluent way.
+	 */
+	interface ExecutableUpdate<T> extends UpdateWithTable<T>, UpdateWithQuery<T> {}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableUpdateOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableUpdateOperationSupport.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.core.query.Update;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Implementation of {@link ExecutableUpdateOperation}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@RequiredArgsConstructor
+class ExecutableUpdateOperationSupport implements ExecutableUpdateOperation {
+
+	private final @NonNull CassandraTemplate template;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.ExecutableUpdateOperation#update(java.lang.Class)
+	 */
+	@Override
+	public <T> ExecutableUpdate<T> update(Class<T> domainType) {
+
+		Assert.notNull(domainType, "DomainType must not be null!");
+
+		return new ExecutableUpdateSupport<>(template, domainType, Query.empty(), null, null);
+	}
+
+	@RequiredArgsConstructor
+	@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+	static class ExecutableUpdateSupport<T> implements ExecutableUpdate<T>, UpdateWithTable<T>, UpdateWithQuery<T>,
+			UpdateWithUpdate<T>, TerminatingUpdate<T> {
+
+		@NonNull CassandraTemplate template;
+
+		@NonNull Class<T> domainType;
+
+		@NonNull Query query;
+
+		@Nullable Update update;
+
+		@Nullable CqlIdentifier tableName;
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableUpdateOperation.UpdateWithUpdate#apply(org.springframework.data.cassandra.core.query.Update)
+		 */
+		@Override
+		public TerminatingUpdate<T> apply(Update update) {
+
+			Assert.notNull(update, "Update must not be null!");
+
+			return new ExecutableUpdateSupport<>(template, domainType, query, update, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableUpdateOperation.UpdateWithTable#inTable(java.lang.String)
+		 */
+		@Override
+		public UpdateWithQuery<T> inTable(String tableName) {
+
+			Assert.hasText(tableName, "Table name must not be null or empty!");
+
+			return new ExecutableUpdateSupport<>(template, domainType, query, update, CqlIdentifier.of(tableName));
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableUpdateOperation.UpdateWithTable#inTable(org.springframework.data.cassandra.core.cql.CqlIdentifier)
+		 */
+		@Override
+		public UpdateWithQuery<T> inTable(CqlIdentifier tableName) {
+
+			Assert.notNull(tableName, "Table name must not be null!");
+
+			return new ExecutableUpdateSupport<>(template, domainType, query, update, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableUpdateOperation.UpdateWithQuery#matching(org.springframework.data.cassandra.core.query.Query)
+		 */
+		@Override
+		public UpdateWithUpdate<T> matching(Query query) {
+
+			Assert.notNull(query, "Query must not be null!");
+
+			return new ExecutableUpdateSupport<>(template, domainType, query, update, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableUpdateOperation.TerminatingUpdate#all()
+		 */
+		@Override
+		public WriteResult all() {
+			return template.doUpdate(query, update, domainType, getTableName());
+		}
+
+		private CqlIdentifier getTableName() {
+			return tableName != null ? tableName : template.getTableName(domainType);
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/FluentCassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/FluentCassandraOperations.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+/**
+ * Stripped down interface providing access to a fluent API that specifies a basic set of Cassandra operations.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ * @see CassandraOperations
+ */
+public interface FluentCassandraOperations extends ExecutableSelectOperation, ExecutableInsertOperation,
+		ExecutableUpdateOperation, ExecutableDeleteOperation {}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraOperations.java
@@ -42,7 +42,7 @@ import com.datastax.driver.core.Statement;
  * @see Flux
  * @see Mono
  */
-public interface ReactiveCassandraOperations {
+public interface ReactiveCassandraOperations extends ReactiveFluentCassandraOperations {
 
 	/**
 	 * Returns the underlying {@link CassandraConverter}.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveDeleteOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveDeleteOperation.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+
+/**
+ * {@link ReactiveDeleteOperation} allows creation and execution of Cassandra {@code DELETE} operations in a fluent API
+ * style.
+ * <p>
+ * The starting {@literal domainType} is used for mapping the {@link Query} provided via {@code matching} into the
+ * Cassandra specific representation. The table to operate on is by default derived from the initial
+ * {@literal domainType} and can be defined there via {@link org.springframework.data.cassandra.core.mapping.Table}.
+ * Using {@code inTable} allows to override the table name for the execution.
+ *
+ * <pre>
+ *     <code>
+ *         delete(Jedi.class)
+ *             .inTable("star_wars")
+ *             .matching(query(where("firstname").is("luke")))
+ *             .all();
+ *     </code>
+ * </pre>
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface ReactiveDeleteOperation {
+
+	/**
+	 * Start creating a {@code DELETE} operation for the given {@literal domainType}.
+	 *
+	 * @param domainType must not be {@literal null}.
+	 * @return new instance of {@link ReactiveDelete}.
+	 * @throws IllegalArgumentException if domainType is {@literal null}.
+	 */
+	ReactiveDelete delete(Class<?> domainType);
+
+	/**
+	 * Table override (optional).
+	 */
+	interface DeleteWithTable {
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null} or empty.
+		 * @return new instance of {@link DeleteWithTable}.
+		 * @throws IllegalArgumentException if {@code table} is {@literal null} or empty.
+		 */
+		DeleteWithQuery inTable(String table);
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null}.
+		 * @return new instance of {@link DeleteWithTable}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier} is {@literal null}.
+		 */
+		DeleteWithQuery inTable(CqlIdentifier table);
+	}
+
+	interface TerminatingDelete {
+
+		/**
+		 * Remove all matching rows.
+		 *
+		 * @return the {@link WriteResult}. Never {@literal null}.
+		 */
+		Mono<WriteResult> all();
+	}
+
+	interface DeleteWithQuery {
+
+		/**
+		 * Define the query filtering elements.
+		 *
+		 * @param query must not be {@literal null}.
+		 * @return new instance of {@link TerminatingDelete}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 */
+		TerminatingDelete matching(Query query);
+	}
+
+	/**
+	 * {@link ReactiveDelete} provides methods for constructing {@code DELETE} operations in a fluent way.
+	 */
+	interface ReactiveDelete extends DeleteWithTable, DeleteWithQuery {}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveDeleteOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveDeleteOperationSupport.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import reactor.core.publisher.Mono;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Implementation of {@link ReactiveDeleteOperation}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@RequiredArgsConstructor
+class ReactiveDeleteOperationSupport implements ReactiveDeleteOperation {
+
+	private final @NonNull ReactiveCassandraTemplate template;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.ReactiveDeleteOperation#remove(java.lang.Class)
+	 */
+	@Override
+	public ReactiveDelete delete(Class<?> domainType) {
+
+		Assert.notNull(domainType, "DomainType must not be null!");
+
+		return new ReactiveDeleteSupport(template, domainType, Query.empty(), null);
+	}
+
+	@RequiredArgsConstructor
+	@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+	static class ReactiveDeleteSupport implements ReactiveDelete, DeleteWithTable, TerminatingDelete {
+
+		@NonNull ReactiveCassandraTemplate template;
+
+		@NonNull Class<?> domainType;
+
+		@NonNull Query query;
+
+		@Nullable CqlIdentifier tableName;
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveDeleteOperation.DeleteWithTable#inTable(java.lang.String)
+		 */
+		@Override
+		public DeleteWithQuery inTable(String tableName) {
+
+			Assert.hasText(tableName, "Table name must not be null or empty");
+
+			return new ReactiveDeleteSupport(template, domainType, query, CqlIdentifier.of(tableName));
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveDeleteOperation.DeleteWithTable#inTable(org.springframework.data.cassandra.core.cql.CqlIdentifier)
+		 */
+		@Override
+		public DeleteWithQuery inTable(CqlIdentifier tableName) {
+
+			Assert.notNull(tableName, "Table name must not be null");
+
+			return new ReactiveDeleteSupport(template, domainType, query, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveDeleteOperation.DeleteWithQuery#matching(org.springframework.data.cassandra.core.query.Query)
+		 */
+		@Override
+		public TerminatingDelete matching(Query query) {
+
+			Assert.notNull(query, "Query must not be null!");
+
+			return new ReactiveDeleteSupport(template, domainType, query, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveDeleteOperation.TerminatingDelete#all()
+		 */
+		public Mono<WriteResult> all() {
+			return template.doDelete(query, domainType, getTableName());
+		}
+
+		private CqlIdentifier getTableName() {
+			return tableName != null ? tableName : template.getTableName(domainType);
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveFluentCassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveFluentCassandraOperations.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+/**
+ * Stripped down interface providing access to a fluent API that specifies a basic set of reactive Cassandra operations.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ * @see ReactiveCassandraOperations
+ */
+public interface ReactiveFluentCassandraOperations
+		extends ReactiveSelectOperation, ReactiveInsertOperation, ReactiveUpdateOperation, ReactiveDeleteOperation {}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveInsertOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveInsertOperation.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+
+/**
+ * {@link ReactiveInsertOperation} allows creation and execution of Cassandra {@code INSERT} insert operations in a
+ * fluent API style.
+ * <p>
+ * The table to operate on is by default derived from the initial {@literal domainType} and can be defined there via
+ * {@link org.springframework.data.cassandra.core.mapping.Table}. Using {@code inTable} allows to override the
+ * collection name for the execution.
+ *
+ * <pre>
+ *     <code>
+ *         insert(Jedi.class)
+ *             .inTable("star_wars")
+ *             .one(luke);
+ *     </code>
+ * </pre>
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface ReactiveInsertOperation {
+
+	/**
+	 * Start creating an {@code INSERT} operation for given {@literal domainType}.
+	 *
+	 * @param domainType must not be {@literal null}.
+	 * @return new instance of {@link ReactiveInsert}.
+	 * @throws IllegalArgumentException if domainType is {@literal null}.
+	 */
+	<T> ReactiveInsert<T> insert(Class<T> domainType);
+
+	/**
+	 * Trigger insert execution by calling one of the terminating methods.
+	 */
+	interface TerminatingInsert<T> {
+
+		/**
+		 * Insert exactly one object.
+		 *
+		 * @param object must not be {@literal null}.
+		 * @throws IllegalArgumentException if object is {@literal null}.
+		 */
+		Mono<WriteResult> one(T object);
+	}
+
+	/**
+	 * Collection override (optional).
+	 */
+	interface InsertWithTable<T> extends InsertWithOptions<T> {
+
+		/**
+		 * Explicitly set the name of the table.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null} or empty.
+		 * @return new instance of {@link TerminatingInsert}.
+		 * @throws IllegalArgumentException if {@code table} is {@literal null} or empty.
+		 */
+		InsertWithOptions<T> inTable(String table);
+
+		/**
+		 * Explicitly set the name of the table.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null}.
+		 * @return new instance of {@link TerminatingInsert}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier} is {@literal null}.
+		 */
+		InsertWithOptions<T> inTable(CqlIdentifier table);
+	}
+
+	/**
+	 * Apply {@link InsertOptions} (optional).
+	 */
+	interface InsertWithOptions<T> extends TerminatingInsert<T> {
+
+		/**
+		 * Set insert options.
+		 *
+		 * @param insertOptions insertOptions not be {@literal null}.
+		 * @return new instance of {@link TerminatingInsert}.
+		 * @throws IllegalArgumentException if {@link InsertOptions} is {@literal null}.
+		 */
+		TerminatingInsert<T> withOptions(InsertOptions insertOptions);
+	}
+
+	/**
+	 * {@link ReactiveInsert} provides methods for constructing {@code INSERT} operations in a fluent way.
+	 */
+	interface ReactiveInsert<T> extends TerminatingInsert<T>, InsertWithTable<T>, InsertWithOptions<T> {}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveInsertOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveInsertOperationSupport.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import reactor.core.publisher.Mono;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Implementation of {@link ReactiveInsertOperation}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@RequiredArgsConstructor
+class ReactiveInsertOperationSupport implements ReactiveInsertOperation {
+
+	private final @NonNull ReactiveCassandraTemplate template;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.ReactiveInsertOperation#insert(java.lang.Class)
+	 */
+	@Override
+	public <T> ReactiveInsert<T> insert(Class<T> domainType) {
+
+		Assert.notNull(domainType, "DomainType must not be null!");
+
+		return new ReactiveInsertSupport<>(template, domainType, null, InsertOptions.empty());
+	}
+
+	@RequiredArgsConstructor
+	@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+	static class ReactiveInsertSupport<T> implements ReactiveInsert<T> {
+
+		@NonNull ReactiveCassandraTemplate template;
+
+		@NonNull Class<T> domainType;
+
+		@Nullable CqlIdentifier tableName;
+
+		@NonNull InsertOptions insertOptions;
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveInsertOperation.InsertWithTable#inTable(java.lang.String)
+		 */
+		@Override
+		public InsertWithOptions<T> inTable(String tableName) {
+
+			Assert.hasText(tableName, "Table name must not be null or empty");
+
+			return new ReactiveInsertSupport<>(template, domainType, CqlIdentifier.of(tableName), insertOptions);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveInsertOperation.InsertWithTable#inTable(org.springframework.data.cassandra.core.cql.CqlIdentifier)
+		 */
+		@Override
+		public InsertWithOptions<T> inTable(CqlIdentifier tableName) {
+
+			Assert.notNull(tableName, "Table name must not be null");
+
+			return new ReactiveInsertSupport<>(template, domainType, tableName, insertOptions);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveInsertOperation.InsertWithOptions#withOptions(org.springframework.data.cassandra.core.InsertOptions)
+		 */
+		@Override
+		public TerminatingInsert<T> withOptions(InsertOptions insertOptions) {
+
+			Assert.notNull(insertOptions, "InsertOptions must not be null");
+
+			return new ReactiveInsertSupport<>(template, domainType, tableName, insertOptions);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveInsertOperation.TerminatingInsert#one(java.lang.Object)
+		 */
+		@Override
+		public Mono<WriteResult> one(T object) {
+
+			Assert.notNull(object, "Object must not be null!");
+
+			return template.doInsert(object, insertOptions, getTableName());
+		}
+
+		private CqlIdentifier getTableName() {
+			return tableName != null ? tableName : template.getTableName(domainType);
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveSelectOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveSelectOperation.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+
+/**
+ * {@link ReactiveSelectOperation} allows creation and execution of Cassandra {@code SELECT} operations in a fluent API
+ * style.
+ * <p>
+ * The starting {@literal domainType} is used for mapping the {@link Query} provided via {@code matching} into the
+ * Cassandra specific representation. By default, the originating {@literal domainType} is also used for mapping back
+ * the result from the {@link com.datastax.driver.core.Row}. However, it is possible to define an different
+ * {@literal returnType} via {@code as} to mapping the result.
+ * <p>
+ * The table to operate on is by default derived from the initial {@literal domainType} and can be defined there via
+ * {@link org.springframework.data.cassandra.core.mapping.Table}. Using {@code inTable} allows to override the table
+ * name for the execution.
+ *
+ * <pre>
+ *     <code>
+ *         query(Human.class)
+ *             .inTable("star_wars")
+ *             .as(Jedi.class)
+ *             .matching(query(where("firstname").is("luke")))
+ *             .all();
+ *     </code>
+ * </pre>
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface ReactiveSelectOperation {
+
+	/**
+	 * Start creating a {@code SELECT} operation for the given {@literal domainType}.
+	 *
+	 * @param domainType must not be {@literal null}.
+	 * @return new instance of {@link ReactiveSelect}.
+	 * @throws IllegalArgumentException if domainType is {@literal null}.
+	 */
+	<T> ReactiveSelect<T> query(Class<T> domainType);
+
+	/**
+	 * Trigger {@code SELECT} execution by calling one of the terminating methods.
+	 */
+	interface TerminatingSelect<T> {
+
+		/**
+		 * Get exactly zero or one result.
+		 *
+		 * @return {@link Mono#empty()} if no match found. Never {@literal null}.
+		 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one match found.
+		 */
+		Mono<T> one();
+
+		/**
+		 * Get the first or no result.
+		 *
+		 * @return {@link Mono#empty()} if no match found. Never {@literal null}.
+		 */
+		Mono<T> first();
+
+		/**
+		 * Get all matching elements.
+		 *
+		 * @return never {@literal null}.
+		 */
+		Flux<T> all();
+
+		/**
+		 * Get the number of matching elements.
+		 *
+		 * @return {@link Mono} emitting total number of matching elements. Never {@literal null}.
+		 */
+		Mono<Long> count();
+
+		/**
+		 * Check for the presence of matching elements.
+		 *
+		 * @return {@link Mono} emitting {@literal true} if at least one matching element exists. Never {@literal null}.
+		 */
+		Mono<Boolean> exists();
+	}
+
+	/**
+	 * Terminating operations invoking the actual query execution.
+	 */
+	interface SelectWithQuery<T> extends TerminatingSelect<T> {
+
+		/**
+		 * Set the filter query to be used.
+		 *
+		 * @param query must not be {@literal null}.
+		 * @return new instance of {@link TerminatingSelect}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 */
+		TerminatingSelect<T> matching(Query query);
+	}
+
+	/**
+	 * Table override (Optional).
+	 */
+	interface SelectWithTable<T> extends SelectWithQuery<T> {
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null} or empty.
+		 * @return new instance of {@link SelectWithProjection}.
+		 * @throws IllegalArgumentException if {@code table} is {@literal null} or empty.
+		 */
+		SelectWithProjection<T> inTable(String table);
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null}.
+		 * @return new instance of {@link SelectWithProjection}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier} is {@literal null}.
+		 */
+		SelectWithProjection<T> inTable(CqlIdentifier table);
+	}
+
+	/**
+	 * Result type override (Optional).
+	 */
+	interface SelectWithProjection<T> extends SelectWithQuery<T> {
+
+		/**
+		 * Define the target type fields should be mapped to. <br />
+		 * Skip this step if you are anyway only interested in the original domain type.
+		 *
+		 * @param resultType must not be {@literal null}.
+		 * @param <R> result type.
+		 * @return new instance of {@link SelectWithProjection}.
+		 * @throws IllegalArgumentException if resultType is {@literal null}.
+		 */
+		<R> SelectWithQuery<R> as(Class<R> resultType);
+	}
+
+	/**
+	 * {@link ReactiveSelect} provides methods for constructing {@code SELECT} operations in a fluent way.
+	 */
+	interface ReactiveSelect<T> extends SelectWithTable<T>, SelectWithProjection<T> {}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveSelectOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveSelectOperationSupport.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Implementation of {@link ReactiveSelectOperation}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@RequiredArgsConstructor
+class ReactiveSelectOperationSupport implements ReactiveSelectOperation {
+
+	private final @NonNull ReactiveCassandraTemplate template;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.ReactiveSelectOperation#query(java.lang.Class)
+	 */
+	@Override
+	public <T> ReactiveSelect<T> query(Class<T> domainType) {
+
+		Assert.notNull(domainType, "DomainType must not be null!");
+
+		return new ReactiveSelectSupport<>(template, domainType, domainType, Query.empty(), null);
+	}
+
+	@RequiredArgsConstructor
+	@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+	static class ReactiveSelectSupport<T>
+			implements ReactiveSelect<T>, SelectWithTable<T>, SelectWithProjection<T>, SelectWithQuery<T> {
+
+		@NonNull ReactiveCassandraTemplate template;
+
+		@NonNull Class<?> domainType;
+
+		@NonNull Class<T> returnType;
+
+		@NonNull Query query;
+
+		@Nullable CqlIdentifier tableName;
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveSelectOperation.SelectWithTable#inTable(java.lang.String)
+		 */
+		@Override
+		public SelectWithProjection<T> inTable(String tableName) {
+
+			Assert.hasText(tableName, "Table name must not be null or empty!");
+
+			return new ReactiveSelectSupport<>(template, domainType, returnType, query, CqlIdentifier.of(tableName));
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveSelectOperation.SelectWithTable#inTable(org.springframework.data.cassandra.core.cql.CqlIdentifier)
+		 */
+		@Override
+		public SelectWithProjection<T> inTable(CqlIdentifier tableName) {
+
+			Assert.notNull(tableName, "Table name must not be null!");
+
+			return new ReactiveSelectSupport<>(template, domainType, returnType, query, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveSelectOperation.SelectWithProjection#as(java.lang.Class)
+		 */
+		@Override
+		public <R> SelectWithQuery<R> as(Class<R> returnType) {
+
+			Assert.notNull(returnType, "ReturnType must not be null!");
+
+			return new ReactiveSelectSupport<>(template, domainType, returnType, query, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveSelectOperation.SelectWithQuery#matching(org.springframework.data.cassandra.core.query.Query)
+		 */
+		@Override
+		public TerminatingSelect<T> matching(Query query) {
+
+			Assert.notNull(query, "Query must not be null!");
+
+			return new ReactiveSelectSupport<>(template, domainType, returnType, query, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveSelectOperation.TerminatingSelect#first()
+		 */
+		@Override
+		public Mono<T> first() {
+			return template.doSelect(query.limit(1), domainType, getTableName(), returnType).next();
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveSelectOperation.TerminatingSelect#one()
+		 */
+		@Override
+		public Mono<T> one() {
+
+			Flux<T> result = template.doSelect(query.limit(2), domainType, getTableName(), returnType);
+
+			return result.collectList() //
+					.flatMap(it -> {
+
+						if (it.isEmpty()) {
+							return Mono.empty();
+						}
+
+						if (it.size() > 1) {
+							return Mono.error(
+									new IncorrectResultSizeDataAccessException("Query " + query + " returned non unique result.", 1));
+						}
+
+						return Mono.just(it.get(0));
+					});
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveSelectOperation.TerminatingSelect#all()
+		 */
+		@Override
+		public Flux<T> all() {
+			return template.doSelect(query, domainType, getTableName(), returnType);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveSelectOperation.TerminatingSelect#count()
+		 */
+		@Override
+		public Mono<Long> count() {
+			return template.doCount(query, domainType, getTableName());
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveSelectOperation.TerminatingSelect#exists()
+		 */
+		@Override
+		public Mono<Boolean> exists() {
+			return template.doExists(query, domainType, getTableName());
+		}
+
+		private CqlIdentifier getTableName() {
+			return tableName != null ? tableName : template.getTableName(domainType);
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveUpdateOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveUpdateOperation.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.core.query.Update;
+
+/**
+ * {@link ReactiveUpdateOperation} allows creation and execution of Cassandra {@code UPDATE} operation in a fluent API
+ * style.
+ * <p>
+ * The starting {@literal domainType} is used for mapping the {@link Query} provided via {@code matching}, as well as
+ * the {@link Update} via {@code apply} into the Cassandra specific representations. The table to operate on is by
+ * default derived from the initial {@literal domainType} and can be defined there via
+ * {@link org.springframework.data.cassandra.core.mapping.Table}. Using {@code inTable} allows to override the table
+ * name for the execution.
+ *
+ * <pre>
+ *     <code>
+ *         update(Jedi.class)
+ *             .inTable("star_wars")
+ *             .matching(query(where("firstname").is("luke")))
+ *             .apply(update("lastname", "skywalker"))
+ *             .all();
+ *     </code>
+ * </pre>
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface ReactiveUpdateOperation {
+
+	/**
+	 * Start creating an {@code UPDATE} operation for the given {@literal domainType}.
+	 *
+	 * @param domainType must not be {@literal null}.
+	 * @return new instance of {@link ReactiveUpdate}.
+	 * @throws IllegalArgumentException if domainType is {@literal null}.
+	 */
+	<T> ReactiveUpdate<T> update(Class<T> domainType);
+
+	/**
+	 * Declare the {@link Update} to apply.
+	 */
+	interface UpdateWithUpdate<T> {
+
+		/**
+		 * Set the {@link Update} to be applied.
+		 *
+		 * @param update must not be {@literal null}.
+		 * @return new instance of {@link TerminatingUpdate}.
+		 * @throws IllegalArgumentException if update is {@literal null}.
+		 */
+		TerminatingUpdate<T> apply(Update update);
+	}
+
+	/**
+	 * Explicitly define the name of the table to perform operation in.
+	 */
+	interface UpdateWithTable<T> {
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null} or empty.
+		 * @return new instance of {@link UpdateWithTable}.
+		 * @throws IllegalArgumentException if {@code table} is {@literal null} or empty.
+		 */
+		UpdateWithQuery<T> inTable(String table);
+
+		/**
+		 * Explicitly set the name of the table to perform the query on.
+		 * <p>
+		 * Skip this step to use the default table derived from the domain type.
+		 *
+		 * @param table must not be {@literal null}.
+		 * @return new instance of {@link UpdateWithTable}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier} is {@literal null}.
+		 */
+		UpdateWithQuery<T> inTable(CqlIdentifier table);
+	}
+
+	/**
+	 * Define a filter query for the {@link Update}.
+	 */
+	interface UpdateWithQuery<T> {
+
+		/**
+		 * Filter documents by given {@literal query}.
+		 *
+		 * @param query must not be {@literal null}.
+		 * @return new instance of {@link UpdateWithQuery}.
+		 * @throws IllegalArgumentException if query is {@literal null}.
+		 */
+		UpdateWithUpdate<T> matching(Query query);
+	}
+
+	/**
+	 * Trigger update execution by calling one of the terminating methods.
+	 */
+	interface TerminatingUpdate<T> {
+
+		/**
+		 * Update all matching rows in the table.
+		 *
+		 * @return never {@literal null}.
+		 */
+		Mono<WriteResult> all();
+	}
+
+	/**
+	 * {@link ReactiveUpdate} provides methods for constructing {@code UPDATE} operations in a fluent way.
+	 */
+	interface ReactiveUpdate<T> extends UpdateWithTable<T>, UpdateWithQuery<T> {}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveUpdateOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveUpdateOperationSupport.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import reactor.core.publisher.Mono;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.core.query.Update;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Implementation of {@link ReactiveUpdateOperation}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@RequiredArgsConstructor
+class ReactiveUpdateOperationSupport implements ReactiveUpdateOperation {
+
+	private final @NonNull ReactiveCassandraTemplate template;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.ReactiveUpdateOperation#update(java.lang.Class)
+	 */
+	@Override
+	public <T> ReactiveUpdate<T> update(Class<T> domainType) {
+
+		Assert.notNull(domainType, "DomainType must not be null!");
+
+		return new ReactiveUpdateSupport<>(template, domainType, Query.empty(), null, null);
+	}
+
+	@RequiredArgsConstructor
+	@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+	static class ReactiveUpdateSupport<T>
+			implements ReactiveUpdate<T>, UpdateWithTable<T>, UpdateWithQuery<T>, UpdateWithUpdate<T>, TerminatingUpdate<T> {
+
+		@NonNull ReactiveCassandraTemplate template;
+
+		@NonNull Class<T> domainType;
+
+		@NonNull Query query;
+
+		@Nullable Update update;
+
+		@Nullable CqlIdentifier tableName;
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveUpdateOperation.UpdateWithUpdate#apply(org.springframework.data.cassandra.core.query.Update)
+		 */
+		@Override
+		public TerminatingUpdate<T> apply(Update update) {
+
+			Assert.notNull(update, "Update must not be null!");
+
+			return new ReactiveUpdateSupport<>(template, domainType, query, update, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveUpdateOperation.UpdateWithTable#inTable(java.lang.String)
+		 */
+		@Override
+		public UpdateWithQuery<T> inTable(String tableName) {
+
+			Assert.hasText(tableName, "Table name must not be null or empty!");
+
+			return new ReactiveUpdateSupport<>(template, domainType, query, update, CqlIdentifier.of(tableName));
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveUpdateOperation.UpdateWithTable#inTable(org.springframework.data.cassandra.core.cql.CqlIdentifier)
+		 */
+		@Override
+		public UpdateWithQuery<T> inTable(CqlIdentifier tableName) {
+
+			Assert.notNull(tableName, "Table name must not be null!");
+
+			return new ReactiveUpdateSupport<>(template, domainType, query, update, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveUpdateOperation.UpdateWithQuery#matching(org.springframework.data.cassandra.core.query.Query)
+		 */
+		@Override
+		public UpdateWithUpdate<T> matching(Query query) {
+
+			Assert.notNull(query, "Query must not be null!");
+
+			return new ReactiveUpdateSupport<>(template, domainType, query, update, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveUpdateOperation.TerminatingUpdate#all()
+		 */
+		@Override
+		public Mono<WriteResult> all() {
+			return template.doUpdate(query, update, domainType, getTableName());
+		}
+
+		private CqlIdentifier getTableName() {
+			return tableName != null ? tableName : template.getTableName(domainType);
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/generator/DropTableCqlGenerator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/generator/DropTableCqlGenerator.java
@@ -21,6 +21,7 @@ import org.springframework.data.cassandra.core.cql.keyspace.DropTableSpecificati
  * CQL generator for generating a {@code DROP TABLE} statement.
  *
  * @author Matthew T. Adams
+ * @author Mark Paluch
  */
 public class DropTableCqlGenerator extends TableNameCqlGenerator<DropTableSpecification> {
 
@@ -35,7 +36,7 @@ public class DropTableCqlGenerator extends TableNameCqlGenerator<DropTableSpecif
 	@Override
 	public StringBuilder toCql(StringBuilder cql) {
 		return cql.append("DROP TABLE ")
-				// .append(spec().getIfExists() ? "IF EXISTS " : "")
+				.append(spec().getIfExists() ? "IF EXISTS " : "")
 				.append(spec().getName()).append(";");
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/keyspace/DropTableSpecification.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/keyspace/DropTableSpecification.java
@@ -25,6 +25,8 @@ import org.springframework.data.cassandra.core.cql.CqlIdentifier;
  */
 public class DropTableSpecification extends TableNameSpecification {
 
+	private boolean ifExists = false;
+
 	private DropTableSpecification(CqlIdentifier name) {
 		super(name);
 	}
@@ -49,5 +51,32 @@ public class DropTableSpecification extends TableNameSpecification {
 	 */
 	public static DropTableSpecification dropTable(CqlIdentifier tableName) {
 		return new DropTableSpecification(tableName);
+	}
+
+	/**
+	 * Causes the inclusion of an {@code IF EXISTS} clause.
+	 *
+	 * @return this
+	 * @since 2.1
+	 */
+	public DropTableSpecification ifExists() {
+		return ifExists(true);
+	}
+
+	/**
+	 * Toggles the inclusion of an {@code IF EXISTS} clause.
+	 *
+	 * @return this
+	 * @since 2.1
+	 */
+	public DropTableSpecification ifExists(boolean ifExists) {
+
+		this.ifExists = ifExists;
+
+		return this;
+	}
+
+	public boolean getIfExists() {
+		return ifExists;
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ExecutableDeleteOperationSupportTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ExecutableDeleteOperationSupportTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.cassandra.core.query.Criteria.*;
+import static org.springframework.data.cassandra.core.query.Query.*;
+
+import lombok.Data;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.Indexed;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+
+/**
+ * Integration tests for {@link ExecutableDeleteOperationSupport}.
+ *
+ * @author Mark Paluch
+ */
+public class ExecutableDeleteOperationSupportTests extends AbstractKeyspaceCreatingIntegrationTest {
+
+	CassandraAdminTemplate template;
+
+	Person han;
+	Person luke;
+
+	@Before
+	public void setUp() {
+
+		template = new CassandraAdminTemplate(session, new MappingCassandraConverter());
+		template.dropTable(true, CqlIdentifier.of("person"));
+		template.createTable(true, CqlIdentifier.of("person"), ExecutableInsertOperationSupportTests.Person.class,
+				Collections.emptyMap());
+
+		han = new Person();
+		han.firstname = "han";
+		han.id = "id-1";
+
+		luke = new Person();
+		luke.firstname = "luke";
+		luke.id = "id-2";
+
+		template.insert(han);
+		template.insert(luke);
+	}
+
+	@Test // DATACASS-485
+	public void removeAllMatching() {
+
+		WriteResult writeResult = template.delete(Person.class).matching(query(where("id").is(han.id))).all();
+
+		assertThat(writeResult.wasApplied()).isTrue();
+	}
+
+	@Test // DATACASS-485
+	public void removeAllMatchingWithAlternateDomainTypeAndCollection() {
+
+		WriteResult writeResult = template.delete(Jedi.class).inTable("person")
+				.matching(query(where("id").in(han.id, luke.id)))
+				.all();
+
+		assertThat(writeResult.wasApplied()).isTrue();
+		assertThat(template.select(Query.empty(), Person.class)).isEmpty();
+	}
+
+	@Data
+	@Table
+	static class Person {
+		@Id String id;
+		@Indexed String firstname;
+	}
+
+	@Data
+	static class Jedi {
+
+		@Column("firstname") String name;
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ExecutableInsertOperationSupportTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ExecutableInsertOperationSupportTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.Data;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.mapping.Indexed;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+
+/**
+ * Integration tests for {@link ExecutableInsertOperationSupport}.
+ *
+ * @author Mark Paluch
+ */
+public class ExecutableInsertOperationSupportTests extends AbstractKeyspaceCreatingIntegrationTest {
+
+	CassandraAdminTemplate template;
+
+	Person han;
+	Person luke;
+
+	@Before
+	public void setUp() {
+
+		template = new CassandraAdminTemplate(session, new MappingCassandraConverter());
+		template.dropTable(true, CqlIdentifier.of("person"));
+		template.createTable(true, CqlIdentifier.of("person"), Person.class, Collections.emptyMap());
+
+		initPersons();
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void domainTypeIsRequired() {
+		template.insert((Class) null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void tableIsRequiredOnSet() {
+		template.insert(Person.class).inTable((String) null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void optionsIsRequiredOnSet() {
+		template.insert(Person.class).withOptions(null);
+	}
+
+	@Test // DATACASS-485
+	public void insertOne() {
+
+		WriteResult writeResult = template.insert(Person.class).inTable("person").one(han);
+
+		assertThat(writeResult.wasApplied()).isTrue();
+		assertThat(template.selectOneById(han.id, Person.class)).isEqualTo(han);
+	}
+
+	@Test // DATACASS-485
+	public void insertOneWithOptions() {
+
+		template.insert(Person.class).inTable("person").one(han);
+
+		WriteResult writeResult = template.insert(Person.class).inTable("person")
+				.withOptions(InsertOptions.builder().withIfNotExists().build()).one(han);
+
+		assertThat(writeResult.wasApplied()).isFalse();
+		assertThat(template.selectOneById(han.id, Person.class)).isEqualTo(han);
+	}
+
+	@Data
+	@Table
+	static class Person {
+
+		@Id String id;
+		@Indexed String firstname;
+		@Indexed String lastname;
+	}
+
+	private void initPersons() {
+
+		han = new Person();
+		han.firstname = "han";
+		han.lastname = "solo";
+		han.id = "id-1";
+
+		luke = new Person();
+		luke.firstname = "luke";
+		luke.lastname = "skywalker";
+		luke.id = "id-2";
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ExecutableSelectOperationSupportTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ExecutableSelectOperationSupportTests.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.cassandra.core.query.Criteria.*;
+import static org.springframework.data.cassandra.core.query.Query.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.core.ExecutableSelectOperation.TerminatingSelect;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.Indexed;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+
+/**
+ * Integration tests for {@link ExecutableSelectOperationSupport}.
+ *
+ * @author Mark Paluch
+ */
+public class ExecutableSelectOperationSupportTests extends AbstractKeyspaceCreatingIntegrationTest {
+
+	CassandraAdminTemplate template;
+
+	Person han;
+	Person luke;
+
+	@Before
+	public void setUp() {
+
+		template = new CassandraAdminTemplate(session, new MappingCassandraConverter());
+		template.dropTable(true, CqlIdentifier.of("person"));
+		template.createTable(true, CqlIdentifier.of("person"), Person.class, Collections.emptyMap());
+
+		initPersons();
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void domainTypeIsRequired() {
+		template.query(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void returnTypeIsRequiredOnSet() {
+		template.query(Person.class).as(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void tableIsRequiredOnSet() {
+		template.query(Person.class).inTable((String) null);
+	}
+
+	@Test // DATACASS-485
+	public void findAll() {
+		assertThat(template.query(Person.class).all()).containsExactlyInAnyOrder(han, luke);
+	}
+
+	@Test // DATACASS-485
+	public void findAllWithCollection() {
+		assertThat(template.query(Human.class).inTable("person").all()).hasSize(2);
+	}
+
+	@Test // DATACASS-485
+	public void findAllWithProjection() {
+		assertThat(template.query(Person.class).as(Jedi.class).all()).hasOnlyElementsOfType(Jedi.class).hasSize(2);
+	}
+
+	@Test // DATACASS-485
+	public void findByReturningAllValuesAsClosedInterfaceProjection() {
+
+		assertThat(template.query(Person.class).as(PersonProjection.class).all())
+				.hasOnlyElementsOfTypes(PersonProjection.class);
+	}
+
+	@Test // DATACASS-485
+	public void findAllBy() {
+		assertThat(template.query(Person.class).matching(queryLuke()).all()).containsExactlyInAnyOrder(luke);
+	}
+
+	@Test // DATACASS-485
+	public void findAllByWithCollectionUsingMappingInformation() {
+		assertThat(template.query(Jedi.class).inTable("person").all()).isNotEmpty().hasOnlyElementsOfType(Jedi.class);
+	}
+
+	@Test // DATACASS-485
+	public void findAllByWithCollection() {
+		assertThat(template.query(Human.class).inTable("person").matching(queryLuke()).all()).hasSize(1);
+	}
+
+	@Test // DATACASS-485
+	public void findAllByWithProjection() {
+		assertThat(template.query(Person.class).as(Jedi.class).all()).hasOnlyElementsOfType(Jedi.class).isNotEmpty();
+	}
+
+	@Test // DATACASS-485
+	public void findBy() {
+		assertThat(template.query(Person.class).matching(queryLuke()).one()).contains(luke);
+	}
+
+	@Test // DATACASS-485
+	public void findByNoMatch() {
+		assertThat(template.query(Person.class).matching(querySpock()).one()).isEmpty();
+	}
+
+	@Test(expected = IncorrectResultSizeDataAccessException.class) // DATACASS-485
+	public void findByTooManyResults() {
+		template.query(Person.class).one();
+	}
+
+	@Test // DATACASS-485
+	public void findByReturningOneValue() {
+		assertThat(template.query(Person.class).matching(queryLuke()).oneValue()).isEqualTo(luke);
+	}
+
+	@Test(expected = IncorrectResultSizeDataAccessException.class) // DATACASS-485
+	public void findByReturningOneValueButTooManyResults() {
+		template.query(Person.class).oneValue();
+	}
+
+	@Test // DATACASS-485
+	public void findByReturningFirstValue() {
+
+		assertThat(template.query(Person.class).matching(queryLuke()).firstValue()).isEqualTo(luke);
+	}
+
+	@Test // DATACASS-485
+	public void findByReturningFirstValueForManyResults() {
+		assertThat(template.query(Person.class).firstValue()).isIn(han, luke);
+	}
+
+	@Test // DATACASS-485
+	public void findByReturningFirstValueAsClosedInterfaceProjection() {
+
+		PersonProjection result = template.query(Person.class).as(PersonProjection.class)
+				.matching(query(where("firstname").is("han")).withAllowFiltering()).firstValue();
+
+		assertThat(result).isInstanceOf(PersonProjection.class);
+		assertThat(result.getFirstname()).isEqualTo("han");
+	}
+
+	@Test // DATACASS-485
+	public void findByReturningFirstValueAsOpenInterfaceProjection() {
+
+		PersonSpELProjection result = template.query(Person.class).as(PersonSpELProjection.class)
+				.matching(query(where("firstname").is("han")).withAllowFiltering()).firstValue();
+
+		assertThat(result).isInstanceOf(PersonSpELProjection.class);
+		assertThat(result.getName()).isEqualTo("han");
+	}
+
+	@Test // DATACASS-485
+	public void streamAll() {
+
+		try (Stream<Person> stream = template.query(Person.class).stream()) {
+			assertThat(stream).containsExactlyInAnyOrder(han, luke);
+		}
+	}
+
+	@Test // DATACASS-485
+	public void streamAllWithCollection() {
+
+		Stream<Human> stream = template.query(Human.class).inTable("person").stream();
+		assertThat(stream).hasSize(2);
+	}
+
+	@Test // DATACASS-485
+	public void streamAllWithProjection() {
+
+		try (Stream<Jedi> stream = template.query(Person.class).as(Jedi.class).stream()) {
+			assertThat(stream).hasOnlyElementsOfType(Jedi.class).hasSize(2);
+		}
+	}
+
+	@Test // DATACASS-485
+	public void streamAllReturningResultsAsClosedInterfaceProjection() {
+
+		TerminatingSelect<PersonProjection> operation = template.query(Person.class).as(PersonProjection.class);
+
+		assertThat(operation.stream()) //
+				.hasSize(2) //
+				.allSatisfy(it -> {
+					assertThat(it).isInstanceOf(PersonProjection.class);
+					assertThat(it.getFirstname()).isNotBlank();
+				});
+	}
+
+	@Test // DATACASS-485
+	public void streamAllReturningResultsAsOpenInterfaceProjection() {
+
+		TerminatingSelect<PersonSpELProjection> operation = template.query(Person.class).as(PersonSpELProjection.class);
+
+		assertThat(operation.stream()) //
+				.hasSize(2) //
+				.allSatisfy(it -> {
+					assertThat(it).isInstanceOf(PersonSpELProjection.class);
+					assertThat(it.getName()).isNotBlank();
+				});
+	}
+
+	@Test // DATACASS-485
+	public void streamAllBy() {
+
+		Stream<Person> stream = template.query(Person.class).matching(queryLuke()).stream();
+		assertThat(stream).containsExactlyInAnyOrder(luke);
+	}
+
+	@Test // DATACASS-485
+	public void firstShouldReturnFirstEntryInCollection() {
+		assertThat(template.query(Person.class).first()).isNotEmpty();
+	}
+
+	@Test // DATACASS-485
+	public void countShouldReturnNrOfElementsInCollectionWhenNoQueryPresent() {
+		assertThat(template.query(Person.class).count()).isEqualTo(2);
+	}
+
+	@Test // DATACASS-485
+	public void countShouldReturnNrOfElementsMatchingQuery() {
+
+		assertThat(template.query(Person.class)
+				.matching(query(where("firstname").is(luke.getFirstname())).withAllowFiltering()).count()).isEqualTo(1);
+	}
+
+	@Test // DATACASS-485
+	public void existsShouldReturnTrueIfAtLeastOneElementExistsInCollection() {
+		assertThat(template.query(Person.class).exists()).isTrue();
+	}
+
+	@Test // DATACASS-485
+	public void existsShouldReturnFalseIfNoElementExistsInCollection() {
+
+		template.truncate(Person.class);
+
+		assertThat(template.query(Person.class).exists()).isFalse();
+	}
+
+	@Test // DATACASS-485
+	public void existsShouldReturnTrueIfAtLeastOneElementMatchesQuery() {
+
+		assertThat(template.query(Person.class).matching(queryLuke()).exists()).isTrue();
+	}
+
+	@Test // DATACASS-485
+	public void existsShouldReturnFalseWhenNoElementMatchesQuery() {
+		assertThat(template.query(Person.class).matching(querySpock()).exists()).isFalse();
+	}
+
+	@Test // DATACASS-485
+	public void returnsTargetObjectDirectlyIfProjectionInterfaceIsImplemented() {
+		assertThat(template.query(Person.class).as(Contact.class).all()).allMatch(it -> it instanceof Person);
+	}
+
+	private static Query queryLuke() {
+		return query(where("firstname").is("luke")).withAllowFiltering();
+	}
+
+	private static Query querySpock() {
+		return query(where("firstname").is("spock")).withAllowFiltering();
+	}
+
+	interface Contact {}
+
+	@Data
+	@Table
+	static class Person implements Contact {
+
+		@Id String id;
+		@Indexed String firstname;
+		@Indexed String lastname;
+	}
+
+	interface PersonProjection {
+		String getFirstname();
+	}
+
+	public interface PersonSpELProjection {
+
+		@Value("#{target.firstname}")
+		String getName();
+	}
+
+	@Data
+	static class Human {
+		@Id String id;
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	static class Jedi {
+
+		@Column("firstname") String name;
+	}
+
+	private void initPersons() {
+
+		han = new Person();
+		han.firstname = "han";
+		han.lastname = "solo";
+		han.id = "id-1";
+
+		luke = new Person();
+		luke.firstname = "luke";
+		luke.lastname = "skywalker";
+		luke.id = "id-2";
+
+		template.insert(han);
+		template.insert(luke);
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ExecutableUpdateOperationSupportTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ExecutableUpdateOperationSupportTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.cassandra.core.query.Criteria.*;
+import static org.springframework.data.cassandra.core.query.Query.*;
+import static org.springframework.data.cassandra.core.query.Update.*;
+
+import lombok.Data;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.Indexed;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+
+/**
+ * Integration tests for {@link ExecutableUpdateOperationSupport}.
+ *
+ * @author Mark Paluch
+ */
+public class ExecutableUpdateOperationSupportTests extends AbstractKeyspaceCreatingIntegrationTest {
+
+	CassandraAdminTemplate template;
+
+	Person han;
+	Person luke;
+
+	@Before
+	public void setUp() {
+
+		template = new CassandraAdminTemplate(session, new MappingCassandraConverter());
+		template.dropTable(true, CqlIdentifier.of("person"));
+		template.createTable(false, CqlIdentifier.of("person"), Person.class, Collections.emptyMap());
+
+		han = new Person();
+		han.firstname = "han";
+		han.id = "id-1";
+
+		luke = new Person();
+		luke.firstname = "luke";
+		luke.id = "id-2";
+
+		template.insert(han);
+		template.insert(luke);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void domainTypeIsRequired() {
+		template.update(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void queryIsRequired() {
+		template.update(Person.class).matching(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void tableIsRequiredOnSet() {
+		template.update(Person.class).inTable((CqlIdentifier) null);
+	}
+
+	@Test // DATACASS-485
+	public void updateAllMatching() {
+
+		WriteResult writeResult = template.update(Person.class).matching(queryHan()).apply(update("firstname", "Han"))
+				.all();
+
+		assertThat(writeResult.wasApplied()).isTrue();
+	}
+
+	@Test // DATACASS-485
+	public void updateWithDifferentDomainClassAndCollection() {
+
+		WriteResult writeResult = template.update(Jedi.class).inTable("person").matching(query(where("id").is(han.getId())))
+				.apply(update("name", "Han")).all();
+
+		assertThat(writeResult.wasApplied()).isTrue();
+		assertThat(template.selectOne(queryHan(), Person.class)).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname",
+				"Han");
+	}
+
+	private Query queryHan() {
+		return query(where("id").is(han.getId()));
+	}
+
+	@Data
+	@Table
+	static class Person {
+
+		@Id String id;
+		@Indexed String firstname;
+	}
+
+	@Data
+	static class Jedi {
+
+		@Column("firstname") String name;
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveDeleteOperationSupportTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveDeleteOperationSupportTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.springframework.data.cassandra.core.query.Criteria.*;
+import static org.springframework.data.cassandra.core.query.Query.*;
+
+import lombok.Data;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.cql.session.DefaultBridgedReactiveSession;
+import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.Indexed;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+
+/**
+ * Integration tests for {@link ExecutableDeleteOperationSupport}.
+ *
+ * @author Mark Paluch
+ */
+public class ReactiveDeleteOperationSupportTests extends AbstractKeyspaceCreatingIntegrationTest {
+
+	CassandraAdminTemplate admin;
+	ReactiveCassandraTemplate template;
+
+	Person han;
+	Person luke;
+
+	@Before
+	public void setUp() {
+
+		admin = new CassandraAdminTemplate(session, new MappingCassandraConverter());
+		template = new ReactiveCassandraTemplate(new DefaultBridgedReactiveSession(session));
+
+		admin.dropTable(true, CqlIdentifier.of("person"));
+		admin.createTable(true, CqlIdentifier.of("person"), ExecutableInsertOperationSupportTests.Person.class,
+				Collections.emptyMap());
+
+		han = new Person();
+		han.firstname = "han";
+		han.id = "id-1";
+
+		luke = new Person();
+		luke.firstname = "luke";
+		luke.id = "id-2";
+
+		admin.insert(han);
+		admin.insert(luke);
+	}
+
+	@Test // DATACASS-485
+	public void removeAllMatching() {
+
+		Mono<WriteResult> writeResult = template.delete(Person.class).matching(query(where("id").is(han.id))).all();
+
+		StepVerifier.create(writeResult.map(WriteResult::wasApplied)).expectNext(true).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void removeAllMatchingWithAlternateDomainTypeAndCollection() {
+
+		Mono<WriteResult> writeResult = template.delete(Jedi.class).inTable("person")
+				.matching(query(where("id").in(han.id, luke.id))).all();
+
+		StepVerifier.create(writeResult.map(WriteResult::wasApplied)).expectNext(true).verifyComplete();
+		StepVerifier.create(template.select(Query.empty(), Person.class)).verifyComplete();
+	}
+
+	@Data
+	@Table
+	static class Person {
+		@Id String id;
+		@Indexed String firstname;
+	}
+
+	@Data
+	static class Jedi {
+
+		@Column("firstname") String name;
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveInsertOperationSupportTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveInsertOperationSupportTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.Data;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.cql.session.DefaultBridgedReactiveSession;
+import org.springframework.data.cassandra.core.mapping.Indexed;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+
+/**
+ * Integration tests for {@link ReactiveInsertOperationSupport}.
+ *
+ * @author Mark Paluch
+ */
+public class ReactiveInsertOperationSupportTests extends AbstractKeyspaceCreatingIntegrationTest {
+
+	CassandraAdminTemplate admin;
+	ReactiveCassandraTemplate template;
+
+	Person han;
+	Person luke;
+
+	@Before
+	public void setUp() {
+
+		admin = new CassandraAdminTemplate(session, new MappingCassandraConverter());
+		template = new ReactiveCassandraTemplate(new DefaultBridgedReactiveSession(session));
+
+		admin.dropTable(true, CqlIdentifier.of("person"));
+		admin.createTable(true, CqlIdentifier.of("person"), Person.class, Collections.emptyMap());
+
+		initPersons();
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void domainTypeIsRequired() {
+		template.insert((Class) null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void tableIsRequiredOnSet() {
+		template.insert(Person.class).inTable((String) null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void optionsIsRequiredOnSet() {
+		template.insert(Person.class).withOptions(null);
+	}
+
+	@Test // DATACASS-485
+	public void insertOne() {
+
+		Mono<WriteResult> writeResult = template.insert(Person.class).inTable("person").one(han);
+
+		StepVerifier.create(writeResult.map(WriteResult::wasApplied)).expectNext(true).verifyComplete();
+		StepVerifier.create(template.selectOneById(han.id, Person.class)).expectNext(han).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void insertOneWithOptions() {
+
+		template.insert(Person.class).inTable("person").one(han);
+
+		Mono<WriteResult> writeResult = template.insert(Person.class).inTable("person")
+				.withOptions(InsertOptions.builder().withIfNotExists().build()).one(han);
+
+		StepVerifier.create(writeResult).assertNext(it -> assertThat(it.wasApplied()).isTrue()).verifyComplete();
+		StepVerifier.create(template.selectOneById(han.id, Person.class)).expectNext(han).verifyComplete();
+	}
+
+	@Data
+	@Table
+	static class Person {
+
+		@Id String id;
+		@Indexed String firstname;
+		@Indexed String lastname;
+	}
+
+	private void initPersons() {
+
+		han = new Person();
+		han.firstname = "han";
+		han.lastname = "solo";
+		han.id = "id-1";
+
+		luke = new Person();
+		luke.firstname = "luke";
+		luke.lastname = "skywalker";
+		luke.id = "id-2";
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveSelectOperationSupportTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveSelectOperationSupportTests.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.cassandra.core.query.Criteria.*;
+import static org.springframework.data.cassandra.core.query.Query.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.cql.session.DefaultBridgedReactiveSession;
+import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.Indexed;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+
+/**
+ * Integration tests for {@link ExecutableSelectOperationSupport}.
+ *
+ * @author Mark Paluch
+ */
+public class ReactiveSelectOperationSupportTests extends AbstractKeyspaceCreatingIntegrationTest {
+
+	CassandraAdminTemplate admin;
+	ReactiveCassandraTemplate template;
+
+	Person han;
+	Person luke;
+
+	@Before
+	public void setUp() {
+
+		admin = new CassandraAdminTemplate(session, new MappingCassandraConverter());
+		template = new ReactiveCassandraTemplate(new DefaultBridgedReactiveSession(session));
+
+		admin.dropTable(true, CqlIdentifier.of("person"));
+		admin.createTable(true, CqlIdentifier.of("person"), Person.class, Collections.emptyMap());
+
+		initPersons();
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void domainTypeIsRequired() {
+		template.query(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void returnTypeIsRequiredOnSet() {
+		template.query(Person.class).as(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void tableIsRequiredOnSet() {
+		template.query(Person.class).inTable((String) null);
+	}
+
+	@Test // DATACASS-485
+	public void findAll() {
+
+		Flux<Person> result = template.query(Person.class).all();
+
+		StepVerifier.create(result.collectList()).assertNext(actual -> {
+			assertThat(actual).containsExactlyInAnyOrder(han, luke);
+		}).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findAllWithCollection() {
+
+		Flux<Human> result = template.query(Human.class).inTable("person").all();
+
+		StepVerifier.create(result).expectNextCount(2).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findAllWithProjection() {
+
+		Flux<Jedi> result = template.query(Person.class).as(Jedi.class).all();
+
+		StepVerifier.create(result.collectList()).assertNext(actual -> {
+			assertThat(actual).hasOnlyElementsOfType(Jedi.class).hasSize(2);
+		}).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findByReturningAllValuesAsClosedInterfaceProjection() {
+
+		Flux<PersonProjection> result = template.query(Person.class).as(PersonProjection.class).all();
+
+		StepVerifier.create(result.collectList()).assertNext(actual -> {
+			assertThat(actual).hasOnlyElementsOfType(PersonProjection.class).hasSize(2);
+		}).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findAllBy() {
+
+		Flux<Person> result = template.query(Person.class).matching(queryLuke()).all();
+
+		StepVerifier.create(result).expectNext(luke).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findAllByWithCollectionUsingMappingInformation() {
+
+		Flux<Jedi> result = template.query(Jedi.class).inTable("person").all();
+
+		StepVerifier.create(result.collectList()).assertNext(actual -> {
+			assertThat(actual).isNotEmpty().hasOnlyElementsOfType(Jedi.class);
+		}).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findAllByWithCollection() {
+
+		Flux<Human> result = template.query(Human.class).inTable("person").matching(queryLuke()).all();
+
+		StepVerifier.create(result.collectList()).expectNextCount(1).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findAllByWithProjection() {
+
+		Flux<Jedi> result = template.query(Person.class).as(Jedi.class).all();
+
+		StepVerifier.create(result.collectList()).assertNext(actual -> {
+			assertThat(actual).isNotEmpty().hasOnlyElementsOfType(Jedi.class);
+		}).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findBy() {
+
+		Mono<Person> result = template.query(Person.class).matching(queryLuke()).one();
+
+		StepVerifier.create(result).expectNext(luke).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findByNoMatch() {
+
+		Mono<Person> result = template.query(Person.class).matching(querySpock()).one();
+
+		StepVerifier.create(result).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findByTooManyResults() {
+
+		Mono<Person> result = template.query(Person.class).one();
+
+		StepVerifier.create(result).expectError(IncorrectResultSizeDataAccessException.class).verify();
+	}
+
+	@Test // DATACASS-485
+	public void findByReturningFirstValue() {
+
+		Mono<Person> result = template.query(Person.class).matching(queryLuke()).first();
+
+		StepVerifier.create(result).expectNext(luke).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findByReturningFirstValueForManyResults() {
+
+		Mono<Person> result = template.query(Person.class).first();
+
+		StepVerifier.create(result).assertNext(actual -> {
+
+			assertThat(actual).isIn(han, luke);
+		}).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findByReturningFirstValueAsClosedInterfaceProjection() {
+
+		Mono<PersonProjection> result = template.query(Person.class).as(PersonProjection.class)
+				.matching(query(where("firstname").is("han")).withAllowFiltering()).first();
+
+		StepVerifier.create(result).assertNext(actual -> {
+
+			assertThat(actual).isInstanceOf(PersonProjection.class);
+			assertThat(actual.getFirstname()).isEqualTo("han");
+		}).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void findByReturningFirstValueAsOpenInterfaceProjection() {
+
+		Mono<PersonSpELProjection> result = template.query(Person.class).as(PersonSpELProjection.class)
+				.matching(query(where("firstname").is("han")).withAllowFiltering()).first();
+
+		StepVerifier.create(result).assertNext(actual -> {
+
+			assertThat(actual).isInstanceOf(PersonSpELProjection.class);
+			assertThat(actual.getName()).isEqualTo("han");
+		}).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void countShouldReturnNrOfElementsInCollectionWhenNoQueryPresent() {
+
+		Mono<Long> count = template.query(Person.class).count();
+
+		StepVerifier.create(count).expectNext(2L).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void countShouldReturnNrOfElementsMatchingQuery() {
+
+		Mono<Long> count = template.query(Person.class)
+				.matching(query(where("firstname").is(luke.getFirstname())).withAllowFiltering()).count();
+
+		StepVerifier.create(count).expectNext(1L).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void existsShouldReturnTrueIfAtLeastOneElementExistsInCollection() {
+
+		Mono<Boolean> exists = template.query(Person.class).exists();
+
+		StepVerifier.create(exists).expectNext(true).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void existsShouldReturnFalseIfNoElementExistsInCollection() {
+
+		StepVerifier.create(template.truncate(Person.class)).verifyComplete();
+
+		Mono<Boolean> exists = template.query(Person.class).exists();
+
+		StepVerifier.create(exists).expectNext(false).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void existsShouldReturnTrueIfAtLeastOneElementMatchesQuery() {
+
+		Mono<Boolean> exists = template.query(Person.class).matching(queryLuke()).exists();
+
+		StepVerifier.create(exists).expectNext(true).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void existsShouldReturnFalseWhenNoElementMatchesQuery() {
+
+		Mono<Boolean> exists = template.query(Person.class).matching(querySpock()).exists();
+
+		StepVerifier.create(exists).expectNext(false).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void returnsTargetObjectDirectlyIfProjectionInterfaceIsImplemented() {
+
+		Flux<Contact> result = template.query(Person.class).as(Contact.class).all();
+
+		StepVerifier.create(result.collectList()).assertNext(actual -> {
+
+			assertThat(actual).allMatch(it -> it instanceof Person);
+		}).verifyComplete();
+	}
+
+	private static Query queryLuke() {
+		return query(where("firstname").is("luke")).withAllowFiltering();
+	}
+
+	private static Query querySpock() {
+		return query(where("firstname").is("spock")).withAllowFiltering();
+	}
+
+	interface Contact {}
+
+	@Data
+	@Table
+	static class Person implements Contact {
+
+		@Id String id;
+		@Indexed String firstname;
+		@Indexed String lastname;
+	}
+
+	interface PersonProjection {
+		String getFirstname();
+	}
+
+	public interface PersonSpELProjection {
+
+		@Value("#{target.firstname}")
+		String getName();
+	}
+
+	@Data
+	static class Human {
+		@Id String id;
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	static class Jedi {
+
+		@Column("firstname") String name;
+	}
+
+	@Data
+	static class Sith {
+
+		String rank;
+	}
+
+	interface PlanetProjection {
+		String getName();
+	}
+
+	interface PlanetSpELProjection {
+
+		@Value("#{target.name}")
+		String getId();
+	}
+
+	private void initPersons() {
+
+		han = new Person();
+		han.firstname = "han";
+		han.lastname = "solo";
+		han.id = "id-1";
+
+		luke = new Person();
+		luke.firstname = "luke";
+		luke.lastname = "skywalker";
+		luke.id = "id-2";
+
+		admin.insert(han);
+		admin.insert(luke);
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveUpdateOperationSupportTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveUpdateOperationSupportTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.cassandra.core.query.Criteria.*;
+import static org.springframework.data.cassandra.core.query.Query.*;
+import static org.springframework.data.cassandra.core.query.Update.*;
+
+import lombok.Data;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.cql.session.DefaultBridgedReactiveSession;
+import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.Indexed;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+
+/**
+ * Integration tests for {@link ReactiveUpdateOperationSupport}.
+ *
+ * @author Mark Paluch
+ */
+public class ReactiveUpdateOperationSupportTests extends AbstractKeyspaceCreatingIntegrationTest {
+
+	CassandraAdminTemplate admin;
+	ReactiveCassandraTemplate template;
+
+	Person han;
+	Person luke;
+
+	@Before
+	public void setUp() {
+
+		admin = new CassandraAdminTemplate(session, new MappingCassandraConverter());
+		template = new ReactiveCassandraTemplate(new DefaultBridgedReactiveSession(session));
+
+		admin.dropTable(true, CqlIdentifier.of("person"));
+		admin.createTable(false, CqlIdentifier.of("person"), Person.class, Collections.emptyMap());
+
+		han = new Person();
+		han.firstname = "han";
+		han.id = "id-1";
+
+		luke = new Person();
+		luke.firstname = "luke";
+		luke.id = "id-2";
+
+		admin.insert(han);
+		admin.insert(luke);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void domainTypeIsRequired() {
+		template.update(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void queryIsRequired() {
+		template.update(Person.class).matching(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATACASS-485
+	public void tableIsRequiredOnSet() {
+		template.update(Person.class).inTable((CqlIdentifier) null);
+	}
+
+	@Test // DATACASS-485
+	public void updateAllMatching() {
+
+		Mono<WriteResult> writeResult = template.update(Person.class).matching(queryHan()).apply(update("firstname", "Han"))
+				.all();
+
+		StepVerifier.create(writeResult.map(WriteResult::wasApplied)).expectNext(true).verifyComplete();
+	}
+
+	@Test // DATACASS-485
+	public void updateWithDifferentDomainClassAndCollection() {
+
+		Mono<WriteResult> writeResult = template.update(Jedi.class).inTable("person")
+				.matching(query(where("id").is(han.getId()))).apply(update("name", "Han")).all();
+
+		StepVerifier.create(writeResult.map(WriteResult::wasApplied)).expectNext(true).verifyComplete();
+		assertThat(admin.selectOne(queryHan(), Person.class)).isNotEqualTo(han).hasFieldOrPropertyWithValue("firstname",
+				"Han");
+	}
+
+	private Query queryHan() {
+		return query(where("id").is(han.getId()));
+	}
+
+	@Data
+	@Table
+	static class Person {
+
+		@Id String id;
+		@Indexed String firstname;
+	}
+
+	@Data
+	static class Jedi {
+
+		@Column("firstname") String name;
+	}
+}

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -7,6 +7,7 @@ This chapter summarizes changes and new features for each release.
 == What's new in Spring Data for Apache Cassandra 2.1
 * New annotations for `@CountQuery` and `@ExistsQuery`.
 * Template API extended with `count(…)` and `exists(…)` methods accepting `Query`.
+* <<cassandra.template.query.fluent-template-api,Fluent API>> for CRUD operations.
 
 [[new-features.2-0-0]]
 == What's new in Spring Data for Apache Cassandra 2.0

--- a/src/main/asciidoc/reference/cassandra.adoc
+++ b/src/main/asciidoc/reference/cassandra.adoc
@@ -1188,3 +1188,39 @@ The query methods need to specify the target type T that will be returned.
 * `T` *selectOneById* `(String cql, Class<T> entityClass)` Ad-hoc query for a single object of type T from the table providing a CQL statement.
 * `Stream<T>` *stream* `(String cql, Class<T> entityClass)` Ad-hoc query for a stream of objects of type T from the table providing a CQL statement.
 
+[[cassandra.template.query.fluent-template-api]]
+=== Fluent Template API
+
+The `CassandraOperations` interface is one of the central components when it comes to more low level interaction with Apache Cassandra. It offers a wide range of methods.
+One can find multiple overloads for each and every method. Most of them just cover optional (nullable) parts of the API.
+
+`FluentCassandraOperations` provide a more narrow interface for common methods of `CassandraOperations` providing a more readable, fluent API.
+The entry points `query(…)`, `insert(…)`, `update(…)`, and `delete(…)` follow a natural naming schema based on the operation to execute. Moving on from the entry point the API is designed to only offer context dependent methods guiding towards a terminating method that invokes the actual `CassandraOperations` counterpart.
+
+====
+[source,java]
+----
+List<SWCharacter> all = ops.query(SWCharacter.class)
+  .inTable("star_wars")                        <1>
+  .all();
+----
+<1> Skip this step if `SWCharacter` defines the table name via `@Table` or if using the class name as table name is just fine.
+====
+
+If a table in Cassandra holds entities of different types, like a `Jedi` within a Table of `SWCharacters`, you can use different types to map the query and to map result. Use `as(Class<?> targetType)` to map results to a different target type while `query(Class<?> entityType)` still applies to the query and table name.
+
+====
+[source,java]
+----
+List<Jedi> all = ops.query(SWCharacter.class)    <1>
+  .as(Jedi.class)                                <2>
+  .matching(query(where("jedi").is(true)))
+  .all();
+----
+<1> The query fields are mapped against the `SWCharacter` type.
+<2> Resulting rows are mapped into `Jedi`.
+====
+
+TIP: It is possible to directly apply <<projections>> to resulting documents by providing just the `interface` type via `as(Class<?>)`.
+
+Switching between retrieving a single entity, multiple ones as `List` or `Stream` like is done via the terminating methods `first()`, `one()`, `all()` or `stream()`.


### PR DESCRIPTION
We now provide an alternative API for `CassandraOperations` and `ReactiveCassandraOperations` that allows defining operations in a fluent way. `FluentCassandraOperations` reduces the number of methods and strips down the interface to a minimum while offering a more readable API.

```java
// find all with filter query and projecting return type
template.select(Person.class)
    .as(Jedi.class)
    .matching(query(where("firstname").is("luke")))
    .all();

// insert
template.insert(Person.class)
    .inTable(STAR_WARS)
    .one(luke);

// update
template.update(Person.class)
    .apply(update("firstname", "Han"))
    .matching(query(where("id").is("han-solo")))
    .all();

// remove all matching
template.delete(Jedi.class)
    .inTable(STAR_WARS)
    .matching(query(where("name").is("luke")))
    .all();
```

---

Related ticket: [DATACASS-485](https://jira.spring.io/browse/DATACASS-485).