### PR TITLE
DATACASS-487 - Support map columns with mapped and converted key/value types.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACASS-487-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-487-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-487-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/ColumnReader.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/ColumnReader.java
@@ -113,14 +113,8 @@ public class ColumnReader {
 		}
 
 		// Map
-		if (collectionTypes.size() == 2) {
-
-			DataType keyType = collectionTypes.get(0);
-			TypeCodec<Object> keyTypeCodec = codecRegistry.codecFor(keyType);
-
-			DataType valueType = collectionTypes.get(1);
-			TypeCodec<Object> valueTypeCodec = codecRegistry.codecFor(valueType);
-			return row.getMap(i, keyTypeCodec.getJavaType().getRawType(), valueTypeCodec.getJavaType().getRawType());
+		if (type.getName() == Name.MAP) {
+			return row.getObject(i);
 		}
 
 		throw new IllegalStateException("Unknown Collection type encountered. Valid collections are Set, List and Map.");

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/UpdateMapper.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/UpdateMapper.java
@@ -130,7 +130,7 @@ public class UpdateMapper extends QueryMapper {
 			Optional<? extends TypeInformation<?>> typeInformation = field.getProperty()
 					.map(PersistentProperty::getTypeInformation);
 
-			Optional<TypeInformation<?>> keyType = typeInformation.map(TypeInformation::getActualType);
+			Optional<TypeInformation<?>> keyType = typeInformation.map(TypeInformation::getComponentType);
 			Optional<TypeInformation<?>> valueType = typeInformation.map(TypeInformation::getMapValueType);
 
 			Object mappedKey = keyType.map(typeInfo -> getConverter().convertToColumnType(op.getKey(), typeInfo))
@@ -219,7 +219,7 @@ public class UpdateMapper extends QueryMapper {
 		Optional<? extends TypeInformation<?>> typeInformation = field.getProperty()
 				.map(PersistentProperty::getTypeInformation);
 
-		Optional<TypeInformation<?>> keyType = typeInformation.map(TypeInformation::getActualType);
+		Optional<TypeInformation<?>> keyType = typeInformation.map(TypeInformation::getComponentType);
 		Optional<TypeInformation<?>> valueType = typeInformation.map(TypeInformation::getMapValueType);
 
 		Map<Object, Object> result = new LinkedHashMap<>(updateOp.getValue().size(), 1);

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverterUDTUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverterUDTUnitTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.convert;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.data.cassandra.test.util.RowMockUtil.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.core.mapping.UserDefinedType;
+import org.springframework.data.cassandra.core.mapping.UserTypeResolver;
+import org.springframework.data.cassandra.support.UserTypeBuilder;
+import org.springframework.data.cassandra.test.util.RowMockUtil;
+
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.UDTValue;
+import com.datastax.driver.core.UserType;
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+
+/**
+ * Unit tests for UDT through {@link MappingCassandraConverter}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.Silent.class) // there are some unused stubbings in RowMockUtil but they're used in other
+																					// tests
+public class MappingCassandraConverterUDTUnitTests {
+
+	@Rule public final ExpectedException expectedException = ExpectedException.none();
+	@Mock UserTypeResolver userTypeResolver;
+
+	UserType manufacturer = UserTypeBuilder.forName("manufacturer").withField("name", DataType.varchar()).build();
+	UserType currency = UserTypeBuilder.forName("mycurrency").withField("currency", DataType.varchar()).build();
+
+	Row rowMock;
+
+	CassandraMappingContext mappingContext;
+	MappingCassandraConverter mappingCassandraConverter;
+
+	@Before
+	public void setUp() {
+
+		mappingContext = new CassandraMappingContext();
+		mappingContext.setUserTypeResolver(userTypeResolver);
+
+		mappingCassandraConverter = new MappingCassandraConverter(mappingContext);
+		mappingCassandraConverter.afterPropertiesSet();
+
+		when(userTypeResolver.resolveType(CqlIdentifier.of("manufacturer"))).thenReturn(manufacturer);
+		when(userTypeResolver.resolveType(CqlIdentifier.of("currency"))).thenReturn(currency);
+	}
+
+	@Test // DATACASS-487
+	public void shouldReadMappedUdtInMap() {
+
+		UDTValue key = manufacturer.newValue().setString("name", "a good one");
+		UDTValue value1 = currency.newValue().setString("currency", "EUR");
+		UDTValue value2 = currency.newValue().setString("currency", "USD");
+
+		Map<UDTValue, List<UDTValue>> map = new HashMap<>();
+		map.put(key, Arrays.asList(value1, value2));
+
+		rowMock = RowMockUtil
+				.newRowMock(column("acceptedCurrencies", map, DataType.map(manufacturer, DataType.list(currency))));
+
+		Supplier supplier = mappingCassandraConverter.read(Supplier.class, rowMock);
+
+		assertThat(supplier.getAcceptedCurrencies()).isNotEmpty();
+
+		List<Currency> currencies = supplier.getAcceptedCurrencies().get(new Manufacturer("a good one"));
+		assertThat(currencies).contains(new Currency("EUR"), new Currency("USD"));
+	}
+
+	@Test // DATACASS-487
+	public void shouldWriteMappedUdtInMap() {
+
+		Map<Manufacturer, List<Currency>> currencies = Collections.singletonMap(new Manufacturer("a good one"),
+				Arrays.asList(new Currency("EUR"), new Currency("USD")));
+
+		Supplier supplier = new Supplier(currencies);
+		Insert insert = QueryBuilder.insertInto("table");
+		mappingCassandraConverter.write(supplier, insert);
+
+		assertThat(insert.toString()).contains("VALUES ({{name:'a good one'}:[{currency:'EUR'},{currency:'USD'}]}");
+	}
+
+	@UserDefinedType
+	@Data
+	@AllArgsConstructor
+	private static class Manufacturer {
+		String name;
+	}
+
+	@UserDefinedType
+	@Data
+	@AllArgsConstructor
+	private static class Currency {
+		String currency;
+	}
+
+	@Data
+	@AllArgsConstructor
+	private static class Supplier {
+		Map<Manufacturer, List<Currency>> acceptedCurrencies;
+	}
+}

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -7,6 +7,7 @@ This chapter summarizes changes and new features for each release.
 == What's new in Spring Data for Apache Cassandra 2.1
 * New annotations for `@CountQuery` and `@ExistsQuery`.
 * Template API extended with `count(…)` and `exists(…)` methods accepting `Query`.
+* Support for `map` columns using User-defined/converted types.
 
 [[new-features.2-0-0]]
 == What's new in Spring Data for Apache Cassandra 2.0


### PR DESCRIPTION
We now support map columns that use mapped user-defined types and converted, non-primitive types in their keys and values. `Map` columns can be used for schema generation, column and key/value types are derived from the declared types by inspecting whether they are either UDTs or they can be converted by a custom registered converter.

```java
class Supplier {

  @Id String id;

  Map<Manufacturer, List<Currency>> currencies;
}

@UserDefinedType
class Manufacturer {
  String name;
}

class UDTToCurrencyConverter implements Converter<UDTValue, Currency> {
 // …
}

class CurrencyToUDTConverter implements Converter<Currency, UDTValue> {
  // …
}
```

---

Related ticket: [DATACASS-487](https://jira.spring.io/browse/DATACASS-487).