### PR TITLE
DATACASS-523 - Extend converter to map TupleValue to domain objects.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACASS-523-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-523-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-523-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/AbstractCassandraConfiguration.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/AbstractCassandraConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.data.cassandra.core.convert.CassandraCustomConversion
 import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
 import org.springframework.data.cassandra.core.cql.session.DefaultSessionFactory;
 import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.core.mapping.SimpleTupleTypeFactory;
 import org.springframework.data.cassandra.core.mapping.SimpleUserTypeResolver;
 import org.springframework.data.cassandra.core.mapping.Table;
 import org.springframework.data.convert.CustomConversions;
@@ -37,6 +38,7 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
+import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 
 /**
@@ -139,7 +141,10 @@ public abstract class AbstractCassandraConfiguration extends AbstractClusterConf
 	@Bean
 	public CassandraMappingContext cassandraMapping() throws ClassNotFoundException {
 
-		CassandraMappingContext mappingContext = new CassandraMappingContext();
+		Cluster cluster = getRequiredCluster();
+
+		CassandraMappingContext mappingContext = new CassandraMappingContext(
+				new SimpleUserTypeResolver(cluster, getKeyspaceName()), new SimpleTupleTypeFactory(cluster));
 
 		if (beanClassLoader != null) {
 			mappingContext.setBeanClassLoader(beanClassLoader);
@@ -151,7 +156,6 @@ public abstract class AbstractCassandraConfiguration extends AbstractClusterConf
 
 		mappingContext.setCustomConversions(customConversions);
 		mappingContext.setSimpleTypeHolder(customConversions.getSimpleTypeHolder());
-		mappingContext.setUserTypeResolver(new SimpleUserTypeResolver(getRequiredCluster(), getKeyspaceName()));
 
 		return mappingContext;
 	}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/BasicCassandraRowValueProvider.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/BasicCassandraRowValueProvider.java
@@ -38,19 +38,32 @@ public class BasicCassandraRowValueProvider implements CassandraRowValueProvider
 	private final SpELExpressionEvaluator evaluator;
 
 	/**
+	 * Create a new {@link BasicCassandraRowValueProvider} with the given {@link Row} and {@link SpELExpressionEvaluator}.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @param evaluator must not be {@literal null}.
+	 * @since 2.1
+	 */
+	public BasicCassandraRowValueProvider(Row source, SpELExpressionEvaluator evaluator) {
+
+		Assert.notNull(source, "Source Row must not be null");
+		Assert.notNull(evaluator, "SpELExpressionEvaluator must not be null");
+
+		this.reader = new ColumnReader(source);
+		this.evaluator = evaluator;
+	}
+
+	/**
 	 * Create a new {@link BasicCassandraRowValueProvider} with the given {@link Row} and
 	 * {@link DefaultSpELExpressionEvaluator}.
 	 *
 	 * @param source must not be {@literal null}.
 	 * @param evaluator must not be {@literal null}.
+	 * @deprecated since 2.1, use {@link #BasicCassandraRowValueProvider(Row, SpELExpressionEvaluator)}
 	 */
+	@Deprecated
 	public BasicCassandraRowValueProvider(Row source, DefaultSpELExpressionEvaluator evaluator) {
-
-		Assert.notNull(source, "Source Row must not be null");
-		Assert.notNull(evaluator, "DefaultSpELExpressionEvaluator must not be null");
-
-		this.reader = new ColumnReader(source);
-		this.evaluator = evaluator;
+		this(source, (SpELExpressionEvaluator) evaluator);
 	}
 
 	/* (non-Javadoc)
@@ -66,7 +79,7 @@ public class BasicCassandraRowValueProvider implements CassandraRowValueProvider
 			return evaluator.evaluate(spelExpression);
 		}
 
-		return (T) reader.get(property.getColumnName());
+		return (T) reader.get(property.getRequiredColumnName());
 	}
 
 	/* (non-Javadoc)
@@ -85,6 +98,6 @@ public class BasicCassandraRowValueProvider implements CassandraRowValueProvider
 
 		Assert.notNull(property, "CassandraPersistentProperty must not be null");
 
-		return getRow().getColumnDefinitions().contains(property.getColumnName().toCql());
+		return getRow().getColumnDefinitions().contains(property.getRequiredColumnName().toCql());
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/CassandraTupleValueProvider.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/CassandraTupleValueProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.convert;
+
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty;
+import org.springframework.data.mapping.model.SpELExpressionEvaluator;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+import com.datastax.driver.core.CodecRegistry;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.TupleValue;
+
+/**
+ * {@link CassandraValueProvider} to read property values from a {@link TupleValue}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public class CassandraTupleValueProvider implements CassandraValueProvider {
+
+	private final TupleValue tupleValue;
+
+	private final CodecRegistry codecRegistry;
+
+	private final SpELExpressionEvaluator evaluator;
+
+	/**
+	 * Create a new {@link CassandraTupleValueProvider} with the given {@link TupleValue} and
+	 * {@link SpELExpressionEvaluator}.
+	 *
+	 * @param tupleValue must not be {@literal null}.
+	 * @param codecRegistry must not be {@literal null}.
+	 * @param evaluator must not be {@literal null}.
+	 */
+	public CassandraTupleValueProvider(TupleValue tupleValue, CodecRegistry codecRegistry,
+			SpELExpressionEvaluator evaluator) {
+
+		Assert.notNull(tupleValue, "TupleValue must not be null");
+		Assert.notNull(codecRegistry, "CodecRegistry must not be null");
+		Assert.notNull(evaluator, "SpELExpressionEvaluator must not be null");
+
+		this.tupleValue = tupleValue;
+		this.codecRegistry = codecRegistry;
+		this.evaluator = evaluator;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.convert.CassandraValueProvider#hasProperty(org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty)
+	 */
+	@Override
+	public boolean hasProperty(CassandraPersistentProperty property) {
+		return tupleValue.getType().getComponentTypes().size() >= property.getRequiredOrdinal();
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.mapping.model.PropertyValueProvider#getPropertyValue(org.springframework.data.mapping.PersistentProperty)
+	 */
+	@Nullable
+	@Override
+	public <T> T getPropertyValue(CassandraPersistentProperty property) {
+
+		String spelExpression = property.getSpelExpression();
+		if (spelExpression != null) {
+			return evaluator.evaluate(spelExpression);
+		}
+
+		int ordinal = property.getRequiredOrdinal();
+		DataType elementType = tupleValue.getType().getComponentTypes().get(ordinal);
+
+		return tupleValue.get(ordinal, codecRegistry.codecFor(elementType));
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/CassandraUDTValueProvider.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/CassandraUDTValueProvider.java
@@ -40,15 +40,15 @@ public class CassandraUDTValueProvider implements CassandraValueProvider {
 	private final SpELExpressionEvaluator evaluator;
 
 	/**
-	 * Create a new {@link CassandraUDTValueProvider} with the given {@link UDTValue} and
-	 * {@link DefaultSpELExpressionEvaluator}.
+	 * Create a new {@link CassandraUDTValueProvider} with the given {@link UDTValue} and {@link SpELExpressionEvaluator}.
 	 *
 	 * @param udtValue must not be {@literal null}.
 	 * @param codecRegistry must not be {@literal null}.
 	 * @param evaluator must not be {@literal null}.
+	 * @since 2.1
 	 */
 	public CassandraUDTValueProvider(UDTValue udtValue, CodecRegistry codecRegistry,
-			DefaultSpELExpressionEvaluator evaluator) {
+			SpELExpressionEvaluator evaluator) {
 
 		Assert.notNull(udtValue, "UDTValue must not be null");
 		Assert.notNull(codecRegistry, "CodecRegistry must not be null");
@@ -57,6 +57,21 @@ public class CassandraUDTValueProvider implements CassandraValueProvider {
 		this.udtValue = udtValue;
 		this.codecRegistry = codecRegistry;
 		this.evaluator = evaluator;
+	}
+
+	/**
+	 * Create a new {@link CassandraUDTValueProvider} with the given {@link UDTValue} and
+	 * {@link DefaultSpELExpressionEvaluator}.
+	 *
+	 * @param udtValue must not be {@literal null}.
+	 * @param codecRegistry must not be {@literal null}.
+	 * @param evaluator must not be {@literal null}.
+	 * @deprecated since 2.1, use {@link #CassandraUDTValueProvider(UDTValue, CodecRegistry, SpELExpressionEvaluator)}
+	 */
+	@Deprecated
+	public CassandraUDTValueProvider(UDTValue udtValue, CodecRegistry codecRegistry,
+			DefaultSpELExpressionEvaluator evaluator) {
+		this(udtValue, codecRegistry, (SpELExpressionEvaluator) evaluator);
 	}
 
 	/* (non-Javadoc)
@@ -71,7 +86,7 @@ public class CassandraUDTValueProvider implements CassandraValueProvider {
 			return evaluator.evaluate(spelExpression);
 		}
 
-		String name = property.getColumnName().toCql();
+		String name = property.getRequiredColumnName().toCql();
 		DataType fieldType = udtValue.getType().getFieldType(name);
 
 		return udtValue.get(name, codecRegistry.codecFor(fieldType));
@@ -82,6 +97,6 @@ public class CassandraUDTValueProvider implements CassandraValueProvider {
 	 */
 	@Override
 	public boolean hasProperty(CassandraPersistentProperty property) {
-		return udtValue.getType().contains(property.getColumnName().toCql());
+		return udtValue.getType().contains(property.getRequiredColumnName().toCql());
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/QueryMapper.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/QueryMapper.java
@@ -125,6 +125,11 @@ public class QueryMapper {
 						"Cannot use composite primary key directly. Reference a property of the composite primary key");
 			});
 
+			field.getProperty().filter(it -> it.getOrdinal() != null).ifPresent(it -> {
+				throw new IllegalArgumentException(
+						String.format("Cannot reference tuple value elements, property [%s]", field.getMappedKey()));
+			});
+
 			Object value = predicate.getValue();
 			TypeInformation<?> typeInformation = getTypeInformation(field, value);
 			Object mappedValue = value != null ? getConverter().convertToColumnType(value, typeInformation) : null;
@@ -182,7 +187,7 @@ public class QueryMapper {
 				CassandraPersistentEntity<?> primaryKeyEntity = mappingContext.getRequiredPersistentEntity(property);
 				addColumns(primaryKeyEntity, selectors);
 			} else {
-				selectors.add(ColumnSelector.from(property.getColumnName().toCql()));
+				selectors.add(ColumnSelector.from(property.getRequiredColumnName().toCql()));
 			}
 		});
 	}
@@ -265,7 +270,7 @@ public class QueryMapper {
 				}
 
 				if (seen.add(property)) {
-					columnNames.add(property.getColumnName().toCql());
+					columnNames.add(property.getRequiredColumnName().toCql());
 				}
 			});
 		}
@@ -309,7 +314,7 @@ public class QueryMapper {
 						throw new IllegalArgumentException(
 								"Cannot use composite primary key directly. Reference a property of the composite primary key");
 					}
-					return cassandraPersistentProperty.getColumnName();
+					return cassandraPersistentProperty.getRequiredColumnName();
 				});
 			}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/UpdateMapper.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/UpdateMapper.java
@@ -85,6 +85,11 @@ public class UpdateMapper extends QueryMapper {
 
 			Field field = createPropertyField(entity, assignmentOp.getColumnName());
 
+			field.getProperty().filter(it -> it.getOrdinal() != null).ifPresent(it -> {
+				throw new IllegalArgumentException(
+						String.format("Cannot reference tuple value elements, property [%s]", field.getMappedKey()));
+			});
+
 			mapped.add(getMappedUpdateOperation(assignmentOp, field));
 		}
 
@@ -127,8 +132,8 @@ public class UpdateMapper extends QueryMapper {
 			Assert.state(op.getValue() != null,
 					() -> String.format("SetAtKeyOp for %s attempts to set null", field.getProperty()));
 
-			Optional<? extends TypeInformation<?>> typeInformation =
-					field.getProperty().map(PersistentProperty::getTypeInformation);
+			Optional<? extends TypeInformation<?>> typeInformation = field.getProperty()
+					.map(PersistentProperty::getTypeInformation);
 
 			Optional<TypeInformation<?>> keyType = typeInformation.map(TypeInformation::getComponentType);
 			Optional<TypeInformation<?>> valueType = typeInformation.map(TypeInformation::getMapValueType);
@@ -162,8 +167,8 @@ public class UpdateMapper extends QueryMapper {
 
 			if (collection.isEmpty()) {
 
-				DataType.Name dataType = field.getProperty().map(property ->
-						getMappingContext().getDataType(property)).map(DataType::getName).orElse(Name.LIST);
+				DataType.Name dataType = field.getProperty().map(property -> getMappingContext().getDataType(property))
+						.map(DataType::getName).orElse(Name.LIST);
 
 				if (dataType == Name.SET) {
 					return new SetOp(field.getMappedKey(), Collections.emptySet());

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
@@ -17,6 +17,7 @@ package org.springframework.data.cassandra.core.mapping;
 
 import static org.springframework.data.cassandra.core.cql.CqlIdentifier.*;
 
+import java.util.Comparator;
 import java.util.Optional;
 
 import org.springframework.beans.BeansException;
@@ -36,6 +37,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
+import com.datastax.driver.core.TupleType;
 import com.datastax.driver.core.UserType;
 
 /**
@@ -79,6 +81,23 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 			CassandraPersistentEntityMetadataVerifier verifier) {
 
 		super(typeInformation, CassandraPersistentPropertyComparator.INSTANCE);
+
+		setVerifier(verifier);
+	}
+
+	/**
+	 * Create a new {@link BasicCassandraPersistentEntity} with the given {@link TypeInformation}. Will default the table
+	 * name to the entity's simple type name.
+	 *
+	 * @param typeInformation must not be {@literal null}.
+	 * @param verifier must not be {@literal null}.
+	 * @param comparator must not be {@literal null}.
+	 * @since 2.1
+	 */
+	protected BasicCassandraPersistentEntity(TypeInformation<T> typeInformation,
+			CassandraPersistentEntityMetadataVerifier verifier, Comparator<CassandraPersistentProperty> comparator) {
+
+		super(typeInformation, comparator);
 
 		setVerifier(verifier);
 	}
@@ -221,6 +240,23 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 	@Override
 	@Nullable
 	public UserType getUserType() {
+		return null;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity#isTupleType()
+	 */
+	@Override
+	public boolean isTupleType() {
+		return false;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity#getTupleType()
+	 */
+	@Override
+	@Nullable
+	public TupleType getTupleType() {
 		return null;
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentProperty.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentProperty.java
@@ -147,6 +147,15 @@ public class BasicCassandraPersistentProperty extends AnnotationBasedPersistentP
 	}
 
 	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty#getOrdinal()
+	 */
+	@Nullable
+	@Override
+	public Integer getOrdinal() {
+		return null;
+	}
+
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty#getPrimaryKeyOrdering()
 	 */
 	@Nullable
@@ -397,7 +406,7 @@ public class BasicCassandraPersistentProperty extends AnnotationBasedPersistentP
 
 		if (changed) {
 
-			CqlIdentifier columnName = getColumnName();
+			CqlIdentifier columnName = getRequiredColumnName();
 			setColumnName(of(columnName.getUnquoted(), forceQuote));
 		}
 	}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentTupleEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentTupleEntity.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.springframework.data.mapping.MappingException;
+import org.springframework.data.util.Lazy;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.util.Assert;
+
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.TupleType;
+
+/**
+ * Cassandra Tuple-specific {@link org.springframework.data.mapping.PersistentEntity} for a mapped tuples. Mapped tuples
+ * are nested level entities that can be referred from a {@link CassandraPersistentEntity}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ * @see Tuple
+ * @see Element
+ */
+public class BasicCassandraPersistentTupleEntity<T> extends BasicCassandraPersistentEntity<T> {
+
+	private final Lazy<TupleType> tupleType;
+
+	/**
+	 * Creates a new {@link BasicCassandraPersistentTupleEntity} given {@link TypeInformation} and
+	 * {@link TupleTypeFactory}.
+	 *
+	 * @param information must not be {@literal null}.
+	 * @param tupleTypeFactory must not be {@literal null}.
+	 */
+	public BasicCassandraPersistentTupleEntity(TypeInformation<T> information, TupleTypeFactory tupleTypeFactory) {
+
+		super(information, CassandraPersistentTupleMetadataVerifier.INSTANCE, TuplePropertyComparator.INSTANCE);
+
+		Assert.notNull(tupleTypeFactory, "TupleTypeFactory must not be null");
+
+		this.tupleType = Lazy.of(() -> tupleTypeFactory.create(getTupleFieldTypes()));
+	}
+
+	private List<DataType> getTupleFieldTypes() {
+
+		return StreamSupport.stream(spliterator(), false) //
+				.sorted(TuplePropertyComparator.INSTANCE) //
+				.map(CassandraPersistentProperty::getDataType) //
+				.collect(Collectors.toList());
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.mapping.model.BasicPersistentEntity#verify()
+	 */
+	@Override
+	public void verify() throws MappingException {
+
+		super.verify();
+
+		CassandraPersistentTupleMetadataVerifier.INSTANCE.verify(this);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.BasicCassandraPersistentEntity#isTupleType()
+	 */
+	@Override
+	public boolean isTupleType() {
+		return true;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.BasicCassandraPersistentEntity#getTupleType()
+	 */
+	@Override
+	public TupleType getTupleType() {
+		return tupleType.get();
+	}
+
+	/**
+	 * {@link CassandraPersistentProperty} comparator using to sort properties by their
+	 * {@link CassandraPersistentProperty#getRequiredOrdinal()}.
+	 *
+	 * @see Element
+	 */
+	enum TuplePropertyComparator implements Comparator<CassandraPersistentProperty> {
+
+		INSTANCE;
+
+		/* (non-Javadoc)
+		 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
+		 */
+		@Override
+		public int compare(CassandraPersistentProperty o1, CassandraPersistentProperty o2) {
+			return Integer.compare(o1.getRequiredOrdinal(), o2.getRequiredOrdinal());
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentTupleProperty.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentTupleProperty.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.mapping.MappingException;
+import org.springframework.data.mapping.model.Property;
+import org.springframework.data.mapping.model.SimpleTypeHolder;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Cassandra Tuple specific {@link CassandraPersistentProperty} implementation.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ * @see Element
+ */
+public class BasicCassandraPersistentTupleProperty extends BasicCassandraPersistentProperty {
+
+	private final @Nullable Integer ordinal;
+
+	/**
+	 * Create a new {@link BasicCassandraPersistentTupleProperty}.
+	 *
+	 * @param property the actual {@link Property} in the domain entity corresponding to this persistent entity.
+	 * @param owner the containing object or {@link CassandraPersistentEntity} of this persistent property.
+	 * @param simpleTypeHolder mapping of Java [simple|wrapper] types to Cassandra data types.
+	 */
+	public BasicCassandraPersistentTupleProperty(Property property, CassandraPersistentEntity<?> owner,
+			SimpleTypeHolder simpleTypeHolder) {
+		this(property, owner, simpleTypeHolder, null);
+	}
+
+	/**
+	 * Create a new {@link BasicCassandraPersistentTupleProperty}.
+	 *
+	 * @param property the actual {@link Property} in the domain entity corresponding to this persistent entity.
+	 * @param owner the containing object or {@link CassandraPersistentEntity} of this persistent property.
+	 * @param simpleTypeHolder mapping of Java [simple|wrapper] types to Cassandra data types.
+	 * @param userTypeResolver resolver for user-defined types.
+	 */
+	public BasicCassandraPersistentTupleProperty(Property property, CassandraPersistentEntity<?> owner,
+			SimpleTypeHolder simpleTypeHolder, @Nullable UserTypeResolver userTypeResolver) {
+
+		super(property, owner, simpleTypeHolder, userTypeResolver);
+
+		this.ordinal = findOrdinal();
+	}
+
+	@Nullable
+	private Integer findOrdinal() {
+
+		if (isTransient()) {
+			return null;
+		}
+
+		int ordinal;
+
+		try {
+			ordinal = getRequiredAnnotation(Element.class).value();
+		} catch (IllegalStateException e) {
+			throw new MappingException(
+					String.format("Missing @Element annotation in mapped tuple type for property [%s] in entity [%s]", getName(),
+							getOwner().getName()),
+					e);
+		}
+
+		Assert.isTrue(ordinal >= 0,
+				String.format("Element ordinal must be greater or equal to zero for property [%s] in entity [%s]", getName(),
+						getOwner().getName()));
+
+		return ordinal;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty#getColumnName()
+	 */
+	@Override
+	public CqlIdentifier getColumnName() {
+		return null;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.BasicCassandraPersistentProperty#getOrdinal()
+	 */
+	@Nullable
+	@Override
+	public Integer getOrdinal() {
+		return ordinal;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty#isCompositePrimaryKey()
+	 */
+	@Override
+	public boolean isCompositePrimaryKey() {
+		return false;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty#isPrimaryKeyColumn()
+	 */
+	@Override
+	public boolean isPrimaryKeyColumn() {
+		return false;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty#isPartitionKeyColumn()
+	 */
+	@Override
+	public boolean isPartitionKeyColumn() {
+		return false;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty#isClusterKeyColumn()
+	 */
+	@Override
+	public boolean isClusterKeyColumn() {
+		return false;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty#setColumnName(org.springframework.data.cassandra.core.cql.CqlIdentifier)
+	 */
+	@Override
+	public void setColumnName(CqlIdentifier columnName) {
+		throw new UnsupportedOperationException("Cannot set a column name on a property representing a tuple element");
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
@@ -19,6 +19,7 @@ import org.springframework.data.cassandra.core.cql.CqlIdentifier;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.lang.Nullable;
 
+import com.datastax.driver.core.TupleType;
 import com.datastax.driver.core.UserType;
 
 /**
@@ -55,7 +56,7 @@ public interface CassandraPersistentEntity<T> extends PersistentEntity<T, Cassan
 	void setForceQuote(boolean forceQuote);
 
 	/**
-	 * @return {@literal true} if the type is a mapped user defined type
+	 * @return {@literal true} if the type is a mapped user defined type.
 	 * @since 1.5
 	 * @see UserDefinedType
 	 */
@@ -68,4 +69,19 @@ public interface CassandraPersistentEntity<T> extends PersistentEntity<T, Cassan
 	 */
 	@Nullable
 	UserType getUserType();
+
+	/**
+	 * @return {@literal true} if the type is a mapped tuple type.
+	 * @since 2.1
+	 * @see Tuple
+	 */
+	boolean isTupleType();
+
+	/**
+	 * @return the {@link TupleType} matching the data types from {@link BasicCassandraPersistentTupleProperty mapped
+	 *         tuple elements}.
+	 * @since 2.1
+	 */
+	@Nullable
+	TupleType getTupleType();
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentProperty.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentProperty.java
@@ -42,7 +42,48 @@ public interface CassandraPersistentProperty
 	/**
 	 * The name of the single column to which the property is persisted.
 	 */
+	@Nullable
 	CqlIdentifier getColumnName();
+
+	/**
+	 * The name of the single column to which the property is persisted.
+	 *
+	 * @throws IllegalStateException if the required column name is not available.
+	 * @since 2.1
+	 */
+	default CqlIdentifier getRequiredColumnName() {
+
+		CqlIdentifier columnName = getColumnName();
+
+		if (columnName == null) {
+			throw new IllegalStateException("No column name available for this persistent property");
+		}
+
+		return columnName;
+	}
+
+	/**
+	 * The name of the element ordinal to which the property is persisted when the owning type is a mapped tuple.
+	 */
+	@Nullable
+	Integer getOrdinal();
+
+	/**
+	 * The required element ordinal to which the property is persisted when the owning type is a mapped tuple.
+	 *
+	 * @throws IllegalStateException if the required ordinal is not available.
+	 * @since 2.1
+	 */
+	default int getRequiredOrdinal() {
+
+		Integer ordinal = getOrdinal();
+
+		if (ordinal == null) {
+			throw new IllegalStateException("No ordinal available for this persistent property");
+		}
+
+		return ordinal;
+	}
 
 	/**
 	 * The ordering (ascending or descending) for the column. Valid only for primary key columns; returns null for

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentPropertyComparator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentPropertyComparator.java
@@ -92,6 +92,6 @@ public enum CassandraPersistentPropertyComparator implements Comparator<Cassandr
 		}
 
 		// else, neither property is a composite primary key nor a primary key; compare @Column annotations
-		return left.getColumnName().compareTo(right.getColumnName());
+		return left.getRequiredColumnName().compareTo(right.getRequiredColumnName());
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentTupleMetadataVerifier.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentTupleMetadataVerifier.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.springframework.data.mapping.MappingException;
+import org.springframework.util.StringUtils;
+
+/**
+ * Verifier for {@link CassandraPersistentEntity tuple entities}. Validates for a proper annotated domain classes to
+ * ensure the meta-model is suitable for {@link com.datastax.driver.core.TupleValue} mapping.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+enum CassandraPersistentTupleMetadataVerifier implements CassandraPersistentEntityMetadataVerifier {
+
+	INSTANCE;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.CassandraPersistentEntityMetadataVerifier#verify(org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity)
+	 */
+	public void verify(CassandraPersistentEntity<?> entity) throws MappingException {
+
+		if (entity.getType().isInterface() || !entity.isAnnotationPresent(Tuple.class)) {
+			return;
+		}
+
+		Set<Integer> ordinals = new TreeSet<>();
+
+		for (CassandraPersistentProperty tupleProperty : entity) {
+
+			if (tupleProperty.isTransient()) {
+				continue;
+			}
+
+			if (!ordinals.add(tupleProperty.getOrdinal())) {
+				throw new MappingException(
+						String.format("Duplicate ordinal [%d] in entity [%s]", tupleProperty.getOrdinal(), entity.getName()));
+			}
+		}
+
+		if (ordinals.isEmpty()) {
+			throw new MappingException(String.format(
+					"Mapped tuple contains no persistent elements annotated with @Element in entity [%s]", entity.getName()));
+		}
+
+		List<Integer> missingMappings = IntStream.range(0, ordinals.size()).boxed().collect(Collectors.toList());
+
+		missingMappings.removeAll(ordinals);
+
+		if (!missingMappings.isEmpty()) {
+			throw new MappingException(String.format("Mapped tuple has no ordinal mapping in entity [%s] for ordinal(s): %s",
+					entity.getName(), StringUtils.collectionToDelimitedString(missingMappings, ", ")));
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CodecRegistryTupleTypeFactory.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CodecRegistryTupleTypeFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import java.util.List;
+
+import org.springframework.util.Assert;
+
+import com.datastax.driver.core.CodecRegistry;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.ProtocolVersion;
+import com.datastax.driver.core.TupleType;
+
+/**
+ * {@link CodecRegistry}-based {@link TupleTypeFactory} using
+ * {@link TupleType#of(ProtocolVersion, CodecRegistry, DataType...)} to create tuple types. {@link TupleType tuple
+ * types}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public class CodecRegistryTupleTypeFactory implements TupleTypeFactory {
+
+	/**
+	 * Default {@link CodecRegistryTupleTypeFactory} using newest protocol versions and the default {@link CodecRegistry}.
+	 */
+	public static final CodecRegistryTupleTypeFactory DEFAULT = new CodecRegistryTupleTypeFactory();
+
+	private final ProtocolVersion protocolVersion;
+
+	private final CodecRegistry codecRegistry;
+
+	/**
+	 * Creates a new {@link CodecRegistryTupleTypeFactory} using newest protocol version and the default
+	 * {@link CodecRegistry}.
+	 */
+	private CodecRegistryTupleTypeFactory() {
+		this(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE);
+	}
+
+	/**
+	 * Creates a new {@link CodecRegistryTupleTypeFactory} given {@link ProtocolVersion} and {@link CodecRegistry}.
+	 *
+	 * @param protocolVersion must not be {@literal null}.
+	 * @param codecRegistry must not be {@literal null}.
+	 */
+	public CodecRegistryTupleTypeFactory(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+
+		Assert.notNull(protocolVersion, "ProtocolVersion must not be null");
+		Assert.notNull(codecRegistry, "CodecRegistry must not be null");
+
+		this.protocolVersion = protocolVersion;
+		this.codecRegistry = codecRegistry;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.TupleTypeFactory#create(java.util.List)
+	 */
+	@Override
+	public TupleType create(List<DataType> types) {
+		return create(types.toArray(new DataType[0]));
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.TupleTypeFactory#create(com.datastax.driver.core.DataType[])
+	 */
+	@Override
+	public TupleType create(DataType... types) {
+		return TupleType.of(protocolVersion, codecRegistry, types);
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/Element.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/Element.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to define an ordinal element index within a tuple. Ordinals map to fields or property accessors within a
+ * domain class. Element indexes within a tuple must be unique and consecutive beginning with the first index at
+ * {@literal 0}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ * @see Tuple
+ */
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD })
+public @interface Element {
+
+	/**
+	 * @return ordinal index within a tuple. First index is {@literal 0}, must be greater or equal to zero.
+	 */
+	int value();
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/IndexSpecificationFactory.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/IndexSpecificationFactory.java
@@ -131,7 +131,7 @@ class IndexSpecificationFactory {
 			index = CreateIndexSpecification.createIndex();
 		}
 
-		return index.columnName(property.getColumnName());
+		return index.columnName(property.getRequiredColumnName());
 	}
 
 	private static CreateIndexSpecification createIndexSpecification(SASI annotation,
@@ -146,7 +146,7 @@ class IndexSpecificationFactory {
 		}
 
 		index.using("org.apache.cassandra.index.sasi.SASIIndex") //
-				.columnName(property.getColumnName()) //
+				.columnName(property.getRequiredColumnName()) //
 				.withOption("mode", annotation.indexMode().name());
 
 		long analyzerCount = INDEX_CONFIGURERS.keySet().stream().filter(property::isAnnotationPresent).count();

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/SimpleTupleTypeFactory.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/SimpleTupleTypeFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import java.util.List;
+
+import org.springframework.util.Assert;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.TupleType;
+
+/**
+ * Default {@link TupleTypeFactory} implementation using Cluster {@link com.datastax.driver.core.Metadata} to create
+ * {@link TupleType tuple types}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public class SimpleTupleTypeFactory implements TupleTypeFactory {
+
+	private final Cluster cluster;
+
+	/**
+	 * Creates a new {@link SimpleTupleTypeFactory} given {@link Cluster}.
+	 *
+	 * @param cluster must not be {@literal null}.
+	 */
+	public SimpleTupleTypeFactory(Cluster cluster) {
+
+		Assert.notNull(cluster, "Cluster must not be null");
+
+		this.cluster = cluster;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.core.mapping.TupleTypeFactory#create(java.util.List)
+	 */
+	@Override
+	public TupleType create(List<DataType> types) {
+		return cluster.getMetadata().newTupleType(types);
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/Tuple.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/Tuple.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Identifies a domain object as Cassandra Tuple. Tuples use ordered fields to map their value to the actual property.
+ * <p/>
+ * A mapped tuple type is typically annotated with {@code @Tuple} and its properties/accessors are annotated with
+ * {@code @Element(0), @Element(1), ..., @Element(n)}.
+ * <p/>
+ * Example usage:
+ *
+ * <pre class="code">
+ * &#64;Tuple
+ * class Address {
+ *
+ * 	&#64;Element(0) String street;
+ *
+ * 	&#64;Element(1) &#64;CassandraType(type = Name.ASCII) String city;
+ *
+ * 	&#64;Element(2) int sortOrder;
+ * }
+ * </pre>
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ * @see Element
+ */
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+public @interface Tuple {
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/TupleTypeFactory.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/TupleTypeFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.util.Assert;
+
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.TupleType;
+
+/**
+ * Factory to create {@link TupleType} given {@link DataType tuple element types}. Primarily internal use.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ * @see SimpleTupleTypeFactory
+ * @see CodecRegistryTupleTypeFactory
+ */
+@FunctionalInterface
+public interface TupleTypeFactory {
+
+	/**
+	 * Create a {@link TupleType} representing the given {@link DataType tuple element types}.
+	 *
+	 * @param types must not be {@literal null} and not contain {@literal null} elements.
+	 * @return the {@link TupleType} representing the given {@link DataType tuple element types}.
+	 */
+	default TupleType create(DataType... types) {
+
+		Assert.notNull(types, "DataType must not be null");
+		Assert.noNullElements(types, "DataType must not contain null elements");
+
+		return create(Arrays.asList(types));
+	}
+
+	/**
+	 * Create a {@link TupleType} representing the given {@link DataType tuple element types}.
+	 *
+	 * @param types must not be {@literal null}.
+	 * @return the {@link TupleType} representing the given {@link DataType tuple element types}.
+	 */
+	TupleType create(List<DataType> types);
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverterMappedTupleUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverterMappedTupleUnitTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.convert;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.cassandra.test.util.RowMockUtil.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.cassandra.core.mapping.BasicCassandraPersistentEntity;
+import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.core.mapping.Element;
+import org.springframework.data.cassandra.core.mapping.Tuple;
+import org.springframework.data.cassandra.test.util.RowMockUtil;
+
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.TupleValue;
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+
+/**
+ * Unit tests for mapped tuples through {@link MappingCassandraConverter}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class MappingCassandraConverterMappedTupleUnitTests {
+
+	@Rule public final ExpectedException expectedException = ExpectedException.none();
+
+	Row rowMock;
+
+	CassandraMappingContext mappingContext;
+	MappingCassandraConverter mappingCassandraConverter;
+
+	@Before
+	public void setUp() {
+
+		mappingContext = new CassandraMappingContext();
+
+		mappingCassandraConverter = new MappingCassandraConverter(mappingContext);
+		mappingCassandraConverter.afterPropertiesSet();
+	}
+
+	@Test // DATACASS-523
+	public void shouldReadMappedTupleValue() {
+
+		BasicCassandraPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(MappedTuple.class);
+
+		TupleValue value = entity.getTupleType().newValue("hello", 1);
+
+		rowMock = RowMockUtil.newRowMock(column("tuple", value, entity.getTupleType()));
+
+		Person person = mappingCassandraConverter.read(Person.class, rowMock);
+
+		MappedTuple tuple = person.getTuple();
+
+		assertThat(tuple.getName()).isEqualTo("hello");
+		assertThat(tuple.getPosition()).isEqualTo(1);
+	}
+
+	@Test // DATACASS-523
+	public void shouldWriteMappedTuple() {
+
+		MappedTuple tuple = new MappedTuple("hello", 1);
+		Person person = new Person(tuple);
+
+		Insert insert = QueryBuilder.insertInto("table");
+
+		mappingCassandraConverter.write(person, insert);
+
+		assertThat(insert.toString()).contains("VALUES (('hello',1))");
+	}
+
+	@Data
+	@AllArgsConstructor
+	private static class Person {
+		MappedTuple tuple;
+	}
+
+	@Tuple
+	@Data
+	@AllArgsConstructor
+	private static class MappedTuple {
+
+		@Element(0) String name;
+		@Element(1) int position;
+	}
+
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverterTupleIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverterTupleIntegrationTests.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.convert;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.Data;
+
+import java.util.Arrays;
+import java.util.Currency;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.config.SchemaAction;
+import org.springframework.data.cassandra.core.cql.generator.CreateTableCqlGenerator;
+import org.springframework.data.cassandra.core.cql.generator.CreateUserTypeCqlGenerator;
+import org.springframework.data.cassandra.core.cql.keyspace.CreateTableSpecification;
+import org.springframework.data.cassandra.core.cql.keyspace.CreateUserTypeSpecification;
+import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.core.mapping.Element;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.core.mapping.Tuple;
+import org.springframework.data.cassandra.core.mapping.UserDefinedType;
+import org.springframework.data.cassandra.domain.AllPossibleTypes;
+import org.springframework.data.cassandra.repository.support.AbstractSpringDataEmbeddedCassandraIntegrationTest;
+import org.springframework.data.cassandra.repository.support.IntegrationTestConfig;
+import org.springframework.data.convert.CustomConversions;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+
+/**
+ * Integration tests for mapped tuple values through {@link MappingCassandraConverter}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class MappingCassandraConverterTupleIntegrationTests extends AbstractSpringDataEmbeddedCassandraIntegrationTest {
+
+	private static AtomicBoolean initialized = new AtomicBoolean();
+
+	@Configuration
+	public static class Config extends IntegrationTestConfig {
+
+		@Override
+		public SchemaAction getSchemaAction() {
+			return SchemaAction.NONE;
+		}
+
+		@Override
+		public String[] getEntityBasePackages() {
+			return new String[] { AllPossibleTypes.class.getPackage().getName() };
+		}
+
+		@Override
+		public CustomConversions customConversions() {
+			return new CassandraCustomConversions(
+					Arrays.asList(new StringToCurrencyConverter(), new CurrencyToStringConverter()));
+		}
+	}
+
+	@Autowired Session session;
+	@Autowired MappingCassandraConverter converter;
+
+	@Before
+	public void setUp() {
+
+		if (initialized.compareAndSet(false, true)) {
+
+			session.execute("DROP TYPE IF EXISTS address;");
+			session.execute("DROP TABLE IF EXISTS person;");
+
+			CassandraMappingContext mappingContext = converter.getMappingContext();
+
+			CreateUserTypeSpecification createAddress = mappingContext
+					.getCreateUserTypeSpecificationFor(mappingContext.getRequiredPersistentEntity(AddressUserType.class));
+
+			session.execute(CreateUserTypeCqlGenerator.toCql(createAddress));
+
+			CreateTableSpecification createPerson = mappingContext
+					.getCreateTableSpecificationFor(mappingContext.getRequiredPersistentEntity(Person.class));
+
+			session.execute(CreateTableCqlGenerator.toCql(createPerson));
+		} else {
+			session.execute("TRUNCATE person;");
+		}
+	}
+
+	@Test // DATACASS-523
+	public void shouldInsertRowWithComplexTuple() {
+
+		Person person = new Person();
+		person.setId("foo");
+
+		MappedTuple tuple = new MappedTuple();
+		AddressUserType userType = new AddressUserType();
+		userType.setZip("myzip");
+		tuple.setAddressUserType(userType);
+		tuple.setCurrency(Arrays.asList(Currency.getInstance("EUR"), Currency.getInstance("USD")));
+		tuple.setName("bar");
+
+		person.setMappedTuple(tuple);
+		person.setMappedTuples(Arrays.asList(tuple));
+
+		Insert insert = QueryBuilder.insertInto("person");
+		converter.write(person, insert);
+
+		session.execute(insert);
+	}
+
+	@Test // DATACASS-523
+	public void shouldReadRowWithComplexTuple() {
+
+		session.execute("INSERT INTO person (id,mappedtuple,mappedtuples) VALUES (" + //
+				"'foo'," //
+				+ "({zip:'myzip'},['EUR','USD'],'bar')," //
+				+ "[({zip:'myzip'},['EUR','USD'],'bar')]);\n");
+
+		ResultSet resultSet = session.execute("SELECT * FROM person;");
+
+		Person person = converter.read(Person.class, resultSet.one());
+
+		assertThat(person.getMappedTuples()).hasSize(1);
+		assertThat(person.getMappedTuple()).isNotNull();
+
+		MappedTuple mappedTuple = person.getMappedTuple();
+
+		assertThat(mappedTuple.getAddressUserType()).isNotNull();
+		assertThat(mappedTuple.getAddressUserType().getZip()).isEqualTo("myzip");
+		assertThat(mappedTuple.getName()).isEqualTo("bar");
+		assertThat(mappedTuple.getCurrency()).containsSequence(Currency.getInstance("EUR"), Currency.getInstance("USD"));
+	}
+
+	@Data
+	@Table
+	static class Person {
+
+		@Id private String id;
+
+		MappedTuple mappedTuple;
+		List<MappedTuple> mappedTuples;
+	}
+
+	@Data
+	@Tuple
+	static class MappedTuple {
+
+		@Element(0) AddressUserType addressUserType;
+		@Element(1) List<Currency> currency;
+		@Element(2) String name;
+
+	}
+
+	@UserDefinedType("address")
+	@Data
+	static class AddressUserType {
+		String zip;
+	}
+
+	private static class StringToCurrencyConverter implements Converter<String, Currency> {
+
+		@Override
+		public Currency convert(String source) {
+			return Currency.getInstance(source);
+		}
+	}
+
+	private static class CurrencyToStringConverter implements Converter<Currency, String> {
+
+		@Override
+		public String convert(Currency source) {
+			return source.getCurrencyCode();
+		}
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentPropertyUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentPropertyUnitTests.java
@@ -42,7 +42,7 @@ public class BasicCassandraPersistentPropertyUnitTests {
 
 	@Test
 	public void usesAnnotatedColumnName() {
-		assertThat(getPropertyFor(Timeline.class, "text").getColumnName().toCql()).isEqualTo("message");
+		assertThat(getPropertyFor(Timeline.class, "text").getRequiredColumnName().toCql()).isEqualTo("message");
 	}
 
 	@Test
@@ -55,7 +55,7 @@ public class BasicCassandraPersistentPropertyUnitTests {
 
 	@Test
 	public void returnsPropertyNameForUnannotatedProperty() {
-		assertThat(getPropertyFor(Timeline.class, "time").getColumnName().toCql()).isEqualTo("time");
+		assertThat(getPropertyFor(Timeline.class, "time").getRequiredColumnName().toCql()).isEqualTo("time");
 	}
 
 	@Test // DATACASS-259
@@ -63,7 +63,7 @@ public class BasicCassandraPersistentPropertyUnitTests {
 
 		CassandraPersistentProperty persistentProperty = getPropertyFor(TypeWithComposedColumnAnnotation.class, "column");
 
-		assertThat(persistentProperty.getColumnName()).isEqualTo(CqlIdentifier.of("mycolumn", true));
+		assertThat(persistentProperty.getRequiredColumnName()).isEqualTo(CqlIdentifier.of("mycolumn", true));
 	}
 
 	@Test // DATACASS-259
@@ -72,7 +72,7 @@ public class BasicCassandraPersistentPropertyUnitTests {
 		CassandraPersistentProperty persistentProperty = getPropertyFor(TypeWithComposedPrimaryKeyAnnotation.class,
 				"column");
 
-		assertThat(persistentProperty.getColumnName()).isEqualTo(CqlIdentifier.of("primary-key", true));
+		assertThat(persistentProperty.getRequiredColumnName()).isEqualTo(CqlIdentifier.of("primary-key", true));
 		assertThat(persistentProperty.isIdProperty()).isTrue();
 	}
 
@@ -82,7 +82,7 @@ public class BasicCassandraPersistentPropertyUnitTests {
 		CassandraPersistentProperty persistentProperty = getPropertyFor(TypeWithComposedPrimaryKeyColumnAnnotation.class,
 				"column");
 
-		assertThat(persistentProperty.getColumnName()).isEqualTo(CqlIdentifier.of("mycolumn", true));
+		assertThat(persistentProperty.getRequiredColumnName()).isEqualTo(CqlIdentifier.of("mycolumn", true));
 		assertThat(persistentProperty.isPrimaryKeyColumn()).isTrue();
 	}
 
@@ -113,7 +113,6 @@ public class BasicCassandraPersistentPropertyUnitTests {
 		return new BasicCassandraPersistentProperty(Property.of(ClassTypeInformation.from(type), field), getEntity(type),
 				CassandraSimpleTypeHolder.HOLDER);
 	}
-
 	private <T> BasicCassandraPersistentEntity<T> getEntity(Class<T> type) {
 		return new BasicCassandraPersistentEntity<>(ClassTypeInformation.from(type));
 	}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentTuplePropertyUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentTuplePropertyUnitTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.util.Date;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.mapping.model.Property;
+import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Unit tests for {@link BasicCassandraPersistentTupleEntity}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BasicCassandraPersistentTuplePropertyUnitTests {
+
+	@Mock TupleTypeFactory tupleTypeFactory;
+
+	@Test // DATACASS-523
+	public void mappedTupleShouldNotReportColumnName() {
+
+		CassandraPersistentProperty property = getPropertyFor(MappedTuple.class, "date");
+
+		assertThat(property.getColumnName()).isNull();
+	}
+
+	@Test // DATACASS-523
+	public void mappedTupleShouldReportOrdinal() {
+
+		CassandraPersistentProperty property = getPropertyFor(MappedTuple.class, "time");
+
+		assertThat(property.getOrdinal()).isEqualTo(1);
+	}
+
+	private CassandraPersistentProperty getPropertyFor(Class<?> type, String fieldName) {
+
+		Field field = ReflectionUtils.findField(type, fieldName);
+
+		return new BasicCassandraPersistentTupleProperty(Property.of(ClassTypeInformation.from(type), field),
+				getEntity(type), CassandraSimpleTypeHolder.HOLDER);
+	}
+
+	private <T> BasicCassandraPersistentEntity<T> getEntity(Class<T> type) {
+		return new BasicCassandraPersistentTupleEntity<>(ClassTypeInformation.from(type), tupleTypeFactory);
+	}
+
+	@Tuple
+	static class MappedTuple {
+		@Element(0) Date date;
+		@Element(1) Date time;
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContextUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContextUnitTests.java
@@ -15,10 +15,8 @@
  */
 package org.springframework.data.cassandra.core.mapping;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -29,7 +27,6 @@ import java.util.NoSuchElementException;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.annotation.Id;
@@ -252,14 +249,13 @@ public class CassandraMappingContextUnitTests {
 		UserType mappedudt = UserTypeBuilder.forName("mappedudt").withField("foo", DataType.ascii()).build();
 
 		this.mappingContext.setUserTypeResolver(typeName -> mappedudt);
-		this.mappingContext.setCustomConversions(new CassandraCustomConversions(
-				Collections.singletonList(HumanToStringConverter.INSTANCE)));
+		this.mappingContext.setCustomConversions(
+				new CassandraCustomConversions(Collections.singletonList(HumanToStringConverter.INSTANCE)));
 
-		CassandraPersistentEntity<?> persistentEntity =
-				this.mappingContext.getRequiredPersistentEntity(WithMapOfMixedTypes.class);
+		CassandraPersistentEntity<?> persistentEntity = this.mappingContext
+				.getRequiredPersistentEntity(WithMapOfMixedTypes.class);
 
-		CreateTableSpecification tableSpecification =
-				this.mappingContext.getCreateTableSpecificationFor(persistentEntity);
+		CreateTableSpecification tableSpecification = this.mappingContext.getCreateTableSpecificationFor(persistentEntity);
 
 		assertThat(tableSpecification.getColumns()).hasSize(2);
 
@@ -369,16 +365,15 @@ public class CassandraMappingContextUnitTests {
 
 	@Test(expected = InvalidDataAccessApiUsageException.class) // DATACASS-284
 	public void shouldRejectUntypedTuples() {
-		this.mappingContext.getCreateTableSpecificationFor(
-				this.mappingContext.getRequiredPersistentEntity(UntypedTupleEntity.class));
+		this.mappingContext
+				.getCreateTableSpecificationFor(this.mappingContext.getRequiredPersistentEntity(UntypedTupleEntity.class));
 	}
 
 	@Test // DATACASS-284
 	public void shouldCreateTableForTypedTupleType() {
 
-		CreateTableSpecification tableSpecification =
-				this.mappingContext.getCreateTableSpecificationFor(
-					this.mappingContext.getRequiredPersistentEntity(TypedTupleEntity.class));
+		CreateTableSpecification tableSpecification = this.mappingContext
+				.getCreateTableSpecificationFor(this.mappingContext.getRequiredPersistentEntity(TypedTupleEntity.class));
 
 		assertThat(tableSpecification.getColumns()).hasSize(2);
 
@@ -475,6 +470,18 @@ public class CassandraMappingContextUnitTests {
 		assertThat(mappingContext.getUserDefinedTypeEntities()).hasSize(1);
 		assertThat(mappingContext.getPersistentEntities()).hasSize(1);
 		assertThat(mappingContext.getTableEntities()).hasSize(0);
+	}
+
+	@Test // DATACASS-523
+	public void shouldCreateMappedTupleType() {
+
+		CassandraPersistentEntity<?> persistentEntity = mappingContext.getRequiredPersistentEntity(MappedTuple.class);
+
+		assertThat(persistentEntity).isInstanceOf(BasicCassandraPersistentTupleEntity.class);
+
+		assertThat(mappingContext.getUserDefinedTypeEntities()).isEmpty();
+		assertThat(mappingContext.getPersistentEntities()).hasSize(1);
+		assertThat(mappingContext.getTableEntities()).isEmpty();
 	}
 
 	@Test // DATACASS-172
@@ -622,6 +629,11 @@ public class CassandraMappingContextUnitTests {
 	@Table
 	private static class Y {
 		@PrimaryKey String key;
+	}
+
+	@Tuple
+	private static class MappedTuple {
+		@Element(0) String name;
 	}
 
 	@UserDefinedType

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentPropertyComparatorUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentPropertyComparatorUnitTests.java
@@ -160,17 +160,17 @@ public class CassandraPersistentPropertyComparatorUnitTests {
 		when(left.isPrimaryKeyColumn()).thenReturn(true);
 		when(right.isCompositePrimaryKey()).thenReturn(true);
 		when(right.isPrimaryKeyColumn()).thenReturn(false);
-		when(left.getColumnName()).thenReturn(CqlIdentifier.of("left"));
-		when(right.getColumnName()).thenReturn(CqlIdentifier.of("right"));
+		when(left.getRequiredColumnName()).thenReturn(CqlIdentifier.of("left"));
+		when(right.getRequiredColumnName()).thenReturn(CqlIdentifier.of("right"));
 
 		assertThat(INSTANCE.compare(left, right)).isLessThan(0);
 
 		verify(left, times(1)).isCompositePrimaryKey();
 		verify(left, times(1)).isPrimaryKeyColumn();
-		verify(left, times(1)).getColumnName();
+		verify(left, times(1)).getRequiredColumnName();
 		verify(right, times(1)).isCompositePrimaryKey();
 		verify(right, times(1)).isPrimaryKeyColumn();
-		verify(right, times(1)).getColumnName();
+		verify(right, times(1)).getRequiredColumnName();
 	}
 
 	@Test // DATACASS-352

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/SimpleTupleTypeFactoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/SimpleTupleTypeFactoryUnitTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.Metadata;
+
+/**
+ * Unit tests for {@link SimpleTupleTypeFactory}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleTupleTypeFactoryUnitTests {
+
+	@Mock Cluster cluster;
+	@Mock Metadata metadata;
+
+	@Test // DATACASS-523
+	public void shouldCreateTupleTypes() {
+
+		when(cluster.getMetadata()).thenReturn(metadata);
+
+		new SimpleTupleTypeFactory(cluster).create(DataType.varchar());
+
+		verify(metadata).newTupleType(Collections.singletonList(DataType.varchar()));
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/util/RowMockUtil.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/util/RowMockUtil.java
@@ -77,6 +77,8 @@ public class RowMockUtil {
 		when(rowMock.getTimestamp(anyInt()))
 				.thenAnswer(invocation -> columns[(Integer) invocation.getArguments()[0]].value);
 		when(rowMock.getUUID(anyInt())).thenAnswer(invocation -> columns[(Integer) invocation.getArguments()[0]].value);
+		when(rowMock.getTupleValue(anyInt()))
+				.thenAnswer(invocation -> columns[(Integer) invocation.getArguments()[0]].value);
 
 		return rowMock;
 	}

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -8,7 +8,7 @@ This chapter summarizes changes and new features for each release.
 * New annotations for `@CountQuery` and `@ExistsQuery`.
 * Template API extended with `count(…)` and `exists(…)` methods accepting `Query`.
 * <<cassandra.template.query.fluent-template-api,Fluent API>> for CRUD operations.
-* Cassandra Tuple support via `TupleValue`.
+* Cassandra Mapped Tuple support via `@Tuple`.
 * Support for `map` columns using User-defined/converted types.
 * <<cassandra.mapping-usage.events>>
 

--- a/src/main/asciidoc/reference/mapping.adoc
+++ b/src/main/asciidoc/reference/mapping.adoc
@@ -73,7 +73,7 @@ for further details.
 | `java.util.UUID`
 | `timeuuid`
 
-| `TupleValue`
+| `TupleValue`,  mapped Tuple Types
 | `tuple<…>`
 
 | `UDTValue`, mapped User-Defined Types
@@ -412,9 +412,12 @@ thus allowing the name to be different than the field name of the class.
 * `@Indexed` - applied at the field level. Describes the index to be created at session initialization.
 * `@SASI` - applied at the field level. Allows SASI index creation during session initialization.
 * `@CassandraType` - applied at the field level to specify a Cassandra data type.
-Types are derived from the declaration by default.
+Types are derived from the property declaration by default.
 * `@UserDefinedType` - applied at the type level to specify a Cassandra User-defined Data Type (UDT).
 Types are derived from the declaration by default.
+* `@Tuple` - applied at the type level to use a type as mapped tuple.
+* `@Element` - applied at the field level to specify element/field ordinals within a mapped tuple.
+Types are derived from the property declaration by default.
 
 The mapping metadata infrastructure is defined in the separate, spring-data-commons project that is both
 technology and data store agnostic.
@@ -460,6 +463,8 @@ public class Person {
 
   @CassandraType(type = Name.UDT, userTypeName = "myusertype")
   private UDTValue usertype;
+
+  private Coordinates coordinates;
 
   @Transient
   private Integer accountTotal;
@@ -512,6 +517,28 @@ public class Address {
 
 NOTE: Working with User-Defined Types requires a `UserTypeResolver` configured with the mapping context.
 See the <<cassandra.connectors,configuration chapter>> for how to configure a `UserTypeResolver`.
+
+.Mapped Tuple
+====
+[source,java]
+----
+@Tuple
+public class Coordinates {
+
+  @Element(0)
+  @CassandraType(type = Name.VARCHAR)
+  private String description;
+
+  @Element(1)
+  private long longitude;
+
+  @Element(2)
+  private long latitude;
+
+  // other getters/setters ommitted
+}
+----
+====
 
 ==== Index creation
 


### PR DESCRIPTION
We now support mapped tuple values via `@Tuple` and `@Element(…)` annotations. Mapped tuple values can be embedded within table entities and user-defined. Mapped tuples can contain user-defined types, collection types and simple property types and are supported with schema generation.

```java
@Tuple
class Address {

	@Element(0) String city;

	@Element(1) String street;

	@Element(2) int sortOrder;
}
```

---

Related ticket: [DATACASS-523](https://jira.spring.io/browse/DATACASS-523).