### PR TITLE
DATACASS-302 - Support Cassandra time columns.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACASS-302-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-302-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.DATACASS-302-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/CassandraJodaTimeConverters.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/CassandraJodaTimeConverters.java
@@ -21,8 +21,13 @@ import java.util.Collections;
 import java.util.List;
 
 import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.cassandra.core.mapping.CassandraType;
+import org.springframework.data.convert.WritingConverter;
 import org.springframework.util.ClassUtils;
+
+import com.datastax.driver.core.DataType.Name;
 
 /**
  * Helper class to register JSR-310 specific {@link Converter} implementations to convert between Cassandra types in
@@ -53,6 +58,8 @@ public abstract class CassandraJodaTimeConverters {
 
 		converters.add(CassandraLocalDateToLocalDateConverter.INSTANCE);
 		converters.add(LocalDateToCassandraLocalDateConverter.INSTANCE);
+		converters.add(MillisOfDayToLocalTimeConverter.INSTANCE);
+		converters.add(LocalTimeToMillisOfDayConverter.INSTANCE);
 
 		return converters;
 	}
@@ -87,6 +94,38 @@ public abstract class CassandraJodaTimeConverters {
 		public com.datastax.driver.core.LocalDate convert(LocalDate source) {
 			return com.datastax.driver.core.LocalDate.fromYearMonthDay(source.getYear(), source.getMonthOfYear(),
 					source.getDayOfMonth());
+		}
+	}
+
+	/**
+	 * Simple singleton to convert {@link Long}s to their {@link LocalTime} representation.
+	 *
+	 * @author Mark Paluch
+	 */
+	public enum MillisOfDayToLocalTimeConverter implements Converter<Long, LocalTime> {
+
+		INSTANCE;
+
+		@Override
+		public LocalTime convert(Long source) {
+			return LocalTime.fromMillisOfDay(source);
+		}
+	}
+
+	/**
+	 * Simple singleton to convert {@link LocalTime}s to their {@link Long} representation.
+	 *
+	 * @author Mark Paluch
+	 */
+	@WritingConverter
+	@CassandraType(type = Name.TIME)
+	public enum LocalTimeToMillisOfDayConverter implements Converter<LocalTime, Long> {
+
+		INSTANCE;
+
+		@Override
+		public Long convert(LocalTime source) {
+			return (long) source.getMillisOfDay();
 		}
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraSimpleTypeHolder.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraSimpleTypeHolder.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.cassandra.core.mapping;
 
+import java.time.LocalTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -120,6 +121,9 @@ public class CassandraSimpleTypeHolder extends SimpleTypeHolder {
 
 		// override UUID to timeuuid as regular uuid as the favored default
 		classToDataType.put(UUID.class, DataType.uuid());
+
+		// override LocalTime to time as time columns are mapped to long by default
+		classToDataType.put(LocalTime.class, DataType.time());
 
 		return classToDataType;
 	}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/CassandraTemplateIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/CassandraTemplateIntegrationTests.java
@@ -19,8 +19,11 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assume.*;
 import static org.springframework.data.cassandra.core.query.Criteria.*;
 
+import lombok.Data;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,6 +36,7 @@ import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
 import org.springframework.data.cassandra.core.cql.CqlTemplate;
 import org.springframework.data.cassandra.core.mapping.BasicMapId;
@@ -78,6 +82,7 @@ public class CassandraTemplateIntegrationTests extends AbstractKeyspaceCreatingI
 		SchemaTestUtils.potentiallyCreateTableFor(User.class, template);
 		SchemaTestUtils.potentiallyCreateTableFor(UserToken.class, template);
 		SchemaTestUtils.potentiallyCreateTableFor(BookReference.class, template);
+		SchemaTestUtils.potentiallyCreateTableFor(TimeClass.class, template);
 		SchemaTestUtils.truncate(User.class, template);
 		SchemaTestUtils.truncate(UserToken.class, template);
 		SchemaTestUtils.truncate(BookReference.class, template);
@@ -477,5 +482,12 @@ public class CassandraTemplateIntegrationTests extends AbstractKeyspaceCreatingI
 
 		assertThat(ids).containsAll(expectedIds);
 		assertThat(iterations).isEqualTo(10);
+	}
+
+	@Data
+	static class TimeClass {
+
+		@Id LocalTime id;
+		LocalTime bar;
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/CassandraJodaTimeConvertersUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/CassandraJodaTimeConvertersUnitTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.convert;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.joda.time.LocalTime;
+import org.junit.Test;
+import org.springframework.data.cassandra.core.convert.CassandraJodaTimeConverters.LocalTimeToMillisOfDayConverter;
+import org.springframework.data.cassandra.core.convert.CassandraJodaTimeConverters.MillisOfDayToLocalTimeConverter;
+
+/**
+ * Unit tests for {@link CassandraJodaTimeConverters}.
+ *
+ * @author Mark Paluch
+ */
+public class CassandraJodaTimeConvertersUnitTests {
+
+	@Test // DATACASS-302
+	public void shouldConvertLocalTimeToLong() {
+
+		assertThat(MillisOfDayToLocalTimeConverter.INSTANCE.convert(3723000L))
+				.isEqualTo(LocalTime.fromMillisOfDay(3723000L));
+	}
+
+	@Test // DATACASS-302
+	public void shouldConvertLongToLocalTime() {
+
+		assertThat(LocalTimeToMillisOfDayConverter.INSTANCE.convert(LocalTime.MIDNIGHT)).isZero();
+		assertThat(LocalTimeToMillisOfDayConverter.INSTANCE.convert(LocalTime.fromMillisOfDay(3723000L)))
+				.isEqualTo(3723000L);
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/CassandraJsr310ConvertersUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/CassandraJsr310ConvertersUnitTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.convert;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalTime;
+
+import org.junit.Test;
+import org.springframework.data.cassandra.core.convert.CassandraJsr310Converters.LocalTimeToMillisOfDayConverter;
+import org.springframework.data.cassandra.core.convert.CassandraJsr310Converters.MillisOfDayToLocalTimeConverter;
+
+/**
+ * Unit tests for {@link CassandraJsr310Converters}.
+ *
+ * @author Mark Paluch
+ */
+public class CassandraJsr310ConvertersUnitTests {
+
+	@Test // DATACASS-302
+	public void shouldConvertLocalTimeToLong() {
+
+		assertThat(MillisOfDayToLocalTimeConverter.INSTANCE.convert(3723000L)).isEqualTo(LocalTime.of(1, 2, 3));
+	}
+
+	@Test // DATACASS-302
+	public void shouldConvertLongToLocalTime() {
+
+		assertThat(LocalTimeToMillisOfDayConverter.INSTANCE.convert(LocalTime.MIDNIGHT)).isZero();
+		assertThat(LocalTimeToMillisOfDayConverter.INSTANCE.convert(LocalTime.of(1, 2, 3))).isEqualTo(3723000L);
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/CassandraThreeTenBackPortConvertersUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/CassandraThreeTenBackPortConvertersUnitTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.convert;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.springframework.data.cassandra.core.convert.CassandraThreeTenBackPortConverters.LocalTimeToMillisOfDayConverter;
+import org.springframework.data.cassandra.core.convert.CassandraThreeTenBackPortConverters.MillisOfDayToLocalTimeConverter;
+import org.threeten.bp.LocalTime;
+
+/**
+ * Unit tests for {@link CassandraThreeTenBackPortConverters}.
+ *
+ * @author Mark Paluch
+ */
+public class CassandraThreeTenBackPortConvertersUnitTests {
+
+	@Test // DATACASS-302
+	public void shouldConvertLocalTimeToLong() {
+
+		assertThat(MillisOfDayToLocalTimeConverter.INSTANCE.convert(3723000L)).isEqualTo(LocalTime.of(1, 2, 3));
+	}
+
+	@Test // DATACASS-302
+	public void shouldConvertLongToLocalTime() {
+
+		assertThat(LocalTimeToMillisOfDayConverter.INSTANCE.convert(LocalTime.MIDNIGHT)).isZero();
+		assertThat(LocalTimeToMillisOfDayConverter.INSTANCE.convert(LocalTime.of(1, 2, 3))).isEqualTo(3723000L);
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/CassandraTypeMappingIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/CassandraTypeMappingIntegrationTests.java
@@ -35,10 +35,10 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-
 import org.springframework.data.annotation.Id;
 import org.springframework.data.cassandra.core.CassandraOperations;
 import org.springframework.data.cassandra.core.CassandraTemplate;
@@ -47,8 +47,6 @@ import org.springframework.data.cassandra.repository.support.SchemaTestUtils;
 import org.springframework.data.cassandra.support.CassandraVersion;
 import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
 import org.springframework.data.util.Version;
-
-import org.assertj.core.api.Assertions;
 
 import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.Duration;
@@ -431,7 +429,7 @@ public class CassandraTypeMappingIntegrationTests extends AbstractKeyspaceCreati
 		operations.insert(entity);
 		AllPossibleTypes loaded = load(entity);
 
-		Assertions.assertThat(loaded.getAnEnum()).isEqualTo(entity.getAnEnum());
+		assertThat(loaded.getAnEnum()).isEqualTo(entity.getAnEnum());
 	}
 
 	@Test // DATACASS-280
@@ -543,6 +541,18 @@ public class CassandraTypeMappingIntegrationTests extends AbstractKeyspaceCreati
 		AllPossibleTypes loaded = load(entity);
 
 		assertThat(loaded.getLocalTime()).isEqualTo(entity.getLocalTime());
+	}
+
+	@Test // DATACASS-296
+	public void shouldReadAndWriteJodaLocalTime() {
+
+		AllPossibleTypes entity = new AllPossibleTypes("1");
+		entity.setJodaLocalTime(org.joda.time.LocalTime.fromMillisOfDay(50000));
+
+		operations.insert(entity);
+		AllPossibleTypes loaded = load(entity);
+
+		assertThat(loaded.getJodaLocalTime()).isEqualTo(entity.getJodaLocalTime());
 	}
 
 	@Test // DATACASS-296

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/QueryMapperUnitTests.java
@@ -27,13 +27,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
-
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import org.springframework.data.annotation.Id;
 import org.springframework.data.cassandra.core.cql.CqlIdentifier;
 import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
@@ -348,6 +348,17 @@ public class QueryMapperUnitTests {
 		assertThat(mappedObject).contains(Criteria.where("tuple").is(tupleValue));
 	}
 
+	@Test // DATACASS-302
+	public void shouldMapTime() {
+
+		Filter filter = Filter.from(Criteria.where("localDate").gt(LocalTime.fromMillisOfDay(1000)));
+
+		Filter mappedObject = this.queryMapper.getMappedObject(filter,
+				this.mappingContext.getRequiredPersistentEntity(Person.class));
+
+		assertThat(mappedObject).contains(Criteria.where("localdate").gt(1000L));
+	}
+
 	@Test(expected = IllegalArgumentException.class) // DATACASS-523
 	public void referencingTupleElementsInQueryShouldFail() {
 
@@ -366,6 +377,8 @@ public class QueryMapperUnitTests {
 		State state;
 
 		Integer number;
+
+		LocalDate localDate;
 
 		MappedTuple tuple;
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/UpdateMapperUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/UpdateMapperUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.cassandra.core.convert;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalTime;
 import java.util.Collections;
 import java.util.Currency;
 import java.util.List;
@@ -238,6 +239,16 @@ public class UpdateMapperUnitTests {
 		assertThat(update.toString()).isEqualTo("tuple = ('foo')");
 	}
 
+	@Test // DATACASS-302
+	public void shouldMapTime() {
+
+		Update update = this.updateMapper.getMappedObject(Update.empty().set("localTime", LocalTime.of(1, 2, 3)),
+				this.persistentEntity);
+
+		assertThat(update.getUpdateOperations()).hasSize(1);
+		assertThat(update.toString()).isEqualTo("localtime = 3723000");
+	}
+
 	@Test(expected = IllegalArgumentException.class) // DATACASS-523
 	public void referencingTupleElementsInQueryShouldFail() {
 		this.updateMapper.getMappedObject(Update.empty().set("tuple.zip", "bar"), this.persistentEntity);
@@ -252,6 +263,7 @@ public class UpdateMapperUnitTests {
 		Map<String, Currency> map;
 		Map<Manufacturer, Currency> manufacturers;
 		Currency currency;
+		LocalTime localTime;
 
 		Integer number;
 		MappedTuple tuple;

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContextUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContextUnitTests.java
@@ -29,7 +29,6 @@ import java.util.NoSuchElementException;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.annotation.Id;
@@ -41,6 +40,7 @@ import org.springframework.data.cassandra.core.cql.keyspace.ColumnSpecification;
 import org.springframework.data.cassandra.core.cql.keyspace.CreateIndexSpecification;
 import org.springframework.data.cassandra.core.cql.keyspace.CreateIndexSpecification.ColumnFunction;
 import org.springframework.data.cassandra.core.cql.keyspace.CreateTableSpecification;
+import org.springframework.data.cassandra.domain.AllPossibleTypes;
 import org.springframework.data.cassandra.support.UserTypeBuilder;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.mapping.MappingException;
@@ -461,6 +461,17 @@ public class CassandraMappingContextUnitTests {
 
 		assertThat(mappingContext.getDataType(persistentEntity.getRequiredPersistentProperty("humans")))
 				.isEqualTo(DataType.list(DataType.varchar()));
+	}
+
+	@Test // DATACASS-302
+	public void propertyTypeShouldMapToTime() {
+
+		CassandraPersistentEntity<?> persistentEntity = mappingContext.getRequiredPersistentEntity(AllPossibleTypes.class);
+
+		assertThat(mappingContext.getDataType(persistentEntity.getRequiredPersistentProperty("localTime")))
+				.isEqualTo(DataType.time());
+		assertThat(mappingContext.getDataType(persistentEntity.getRequiredPersistentProperty("jodaLocalTime")))
+				.isEqualTo(DataType.time());
 	}
 
 	@Test // DATACASS-172, DATACASS-455

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/AllPossibleTypes.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/AllPossibleTypes.java
@@ -104,6 +104,7 @@ public class AllPossibleTypes {
 	org.joda.time.DateTime jodaDateTime;
 	org.joda.time.LocalDate jodaLocalDate;
 	org.joda.time.LocalDateTime jodaLocalDateTime;
+	org.joda.time.LocalTime jodaLocalTime;
 
 	org.threeten.bp.Instant bpInstant;
 	org.threeten.bp.LocalDate bpLocalDate;

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -9,6 +9,7 @@ This chapter summarizes changes and new features for each release.
 * Template API extended with `count(…)` and `exists(…)` methods accepting `Query`.
 * <<cassandra.template.query.fluent-template-api,Fluent API>> for CRUD operations.
 * Cassandra Mapped Tuple support via `@Tuple`.
+* Support for Cassandra `time` columns via `LocalTime`.
 * Support for `map` columns using User-defined/converted types.
 * <<cassandra.mapping-usage.events>>
 

--- a/src/main/asciidoc/reference/mapping.adoc
+++ b/src/main/asciidoc/reference/mapping.adoc
@@ -95,6 +95,10 @@ for further details.
 (Joda, Java 8, JSR310-BackPort)
 | `date`
 
+|  `LocalTime`+
+(Joda, Java 8, JSR310-BackPort)
+| `time`
+
 | `LocalDateTime`, `LocalTime`, `Instant` +
 (Joda, Java 8, JSR310-BackPort)
 | `timestamp`


### PR DESCRIPTION
We now support Cassandra time columns via LocalTime types (JSR-310, Joda and ThreeTenBackport) in domain classes, queries and updates.

```java
@Table
class Schedule {

  @Id String id;

  LocalTime scheduledAt;
}
```

---

Related ticket: [DATACASS-302](https://jira.spring.io/browse/DATACASS-302).