### PR TITLE
DATACASS-529 - Allow slice queries using reactive repositories.

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraOperations.java
@@ -25,6 +25,8 @@ import org.springframework.data.cassandra.core.cql.ReactiveCqlOperations;
 import org.springframework.data.cassandra.core.cql.WriteOptions;
 import org.springframework.data.cassandra.core.query.Query;
 import org.springframework.data.cassandra.core.query.Update;
+import org.springframework.data.domain.Slice;
+
 
 import com.datastax.driver.core.Statement;
 
@@ -96,6 +98,19 @@ public interface ReactiveCassandraOperations {
 	 * @throws DataAccessException if there is any problem issuing the execution.
 	 */
 	<T> Flux<T> select(Statement statement, Class<T> entityClass) throws DataAccessException;
+
+	/**
+	 * Execute a {@code SELECT} query with paging and convert the result set to a {@link Slice} of entities.
+	 *
+	 * A sliced query translates the effective {@link Statement#getFetchSize() fetch size} to the page size.
+	 *
+	 * @param statement the CQL statement, must not be {@literal null}.
+	 * @param entityClass The entity type must not be {@literal null}.
+	 * @return the result object returned by the action or {@link Mono#empty()}
+	 * @throws DataAccessException if there is any problem executing the query.
+	 * @since 2.0
+	 */
+	<T> Mono<Slice<T>> slice(Statement statement, Class<T> entityClass) throws DataAccessException;
 
 	/**
 	 * Execute a {@code SELECT} query and convert the resulting item to an entity.

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/ReactiveCassandraRepositoryIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/ReactiveCassandraRepositoryIntegrationTests.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.cassandra.core.ReactiveCassandraOperations;
+import org.springframework.data.cassandra.core.query.CassandraPageRequest;
 import org.springframework.data.cassandra.domain.Group;
 import org.springframework.data.cassandra.domain.GroupKey;
 import org.springframework.data.cassandra.domain.User;
@@ -42,6 +43,8 @@ import org.springframework.data.cassandra.repository.support.IntegrationTestConf
 import org.springframework.data.cassandra.repository.support.ReactiveCassandraRepositoryFactory;
 import org.springframework.data.cassandra.repository.support.SimpleReactiveCassandraRepository;
 import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.repository.query.DefaultEvaluationContextProvider;
@@ -128,6 +131,13 @@ public class ReactiveCassandraRepositoryIntegrationTests extends AbstractKeyspac
 		StepVerifier.create(repository.findByLastname(dave.getLastname())).expectNextCount(2).verifyComplete();
 	}
 
+	@Test //DATACASS-529
+	public void shouldFindSliceByLastName() {
+		StepVerifier.create(repository.findByLastname(carter.getLastname(), CassandraPageRequest.first(1)))
+				.expectNextMatches(users -> users.getSize() == 1 && users.hasNext())
+				.verifyComplete();
+	}
+
 	@Test // DATACASS-525
 	public void findOneWithManyResultsShouldFail() {
 		StepVerifier.create(repository.findOneByLastname(dave.getLastname()))
@@ -184,6 +194,8 @@ public class ReactiveCassandraRepositoryIntegrationTests extends AbstractKeyspac
 	interface UserRepository extends ReactiveCassandraRepository<User, String> {
 
 		Flux<User> findByLastname(String lastname);
+
+		Mono<Slice<User>> findByLastname(String firstname, Pageable pageable);
 
 		Mono<User> findFirstByLastname(String lastname);
 


### PR DESCRIPTION
Reactive repositories now support methods returning `Mono<Slice<T>>`.
```
Mono<Slice<User>> findByLastname(String firstname, Pageable pageable);
```

Related ticket: DATACASS-529.