### PR TITLE
DATACASS-556 - Support for SimplePreparedStatementCreator with RegularStatement in CqlTemplate

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
@@ -15,6 +15,19 @@
  */
 package org.springframework.data.cassandra.core.cql;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.support.DataAccessUtils;
+import org.springframework.data.cassandra.SessionFactory;
+import org.springframework.data.cassandra.core.cql.support.PreparedStatementCache;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.Host;
 import com.datastax.driver.core.PreparedStatement;
@@ -24,18 +37,6 @@ import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.DriverException;
-import org.springframework.dao.DataAccessException;
-import org.springframework.dao.support.DataAccessUtils;
-import org.springframework.data.cassandra.SessionFactory;
-import org.springframework.data.cassandra.core.cql.support.PreparedStatementCache;
-import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
 
 /**
  * <b>This is the central class in the CQL core package.</b> It simplifies the use of CQL and helps to avoid common
@@ -69,6 +70,7 @@ import java.util.function.Function;
  * @author Antoine Toulme
  * @author John Blum
  * @author Mark Paluch
+ * @author Mike Barlotta (CodeSmell)
  * @see PreparedStatementCreator
  * @see PreparedStatementBinder
  * @see PreparedStatementCallback

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
@@ -408,7 +408,7 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 	@Override
 	public boolean execute(String cql, @Nullable PreparedStatementBinder psb) throws DataAccessException {
 		// noinspection ConstantConditions
-		return query(new SimplePreparedStatementCreator(cql), psb, ResultSet::wasApplied);
+		return query(newPreparedStatementCreator(cql), psb, ResultSet::wasApplied);
 	}
 
 	/*

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateUnitTests.java
@@ -286,7 +286,6 @@ public class CqlTemplateUnitTests {
         when(mockCache.getPreparedStatement(Mockito.any(Session.class), Mockito.any(RegularStatement.class)))
             .thenReturn(preparedStatement);
 
-        when(session.prepare("SELECT * FROM user WHERE username = ?")).thenReturn(preparedStatement);
         when(preparedStatement.bind("Walter")).thenReturn(boundStatement);
         when(session.execute(boundStatement)).thenReturn(resultSet);
         when(resultSet.iterator()).thenReturn(Collections.singleton(row).iterator());
@@ -654,7 +653,6 @@ public class CqlTemplateUnitTests {
         when(mockCache.getPreparedStatement(Mockito.any(Session.class), Mockito.any(RegularStatement.class)))
             .thenReturn(preparedStatement);
 
-        when(session.prepare("SELECT * FROM user WHERE username = ?")).thenReturn(preparedStatement);
         when(preparedStatement.bind("Walter")).thenReturn(boundStatement);
         when(session.execute(boundStatement)).thenReturn(resultSet);
         when(resultSet.iterator()).thenReturn(Collections.singleton(row).iterator());
@@ -721,7 +719,6 @@ public class CqlTemplateUnitTests {
         when(mockCache.getPreparedStatement(Mockito.any(Session.class), Mockito.any(RegularStatement.class)))
             .thenReturn(preparedStatement);
 
-        when(session.prepare("SELECT * FROM user WHERE username = ?")).thenReturn(preparedStatement);
         when(preparedStatement.bind("Walter")).thenReturn(boundStatement);
         when(session.execute(boundStatement)).thenReturn(resultSet);
         when(resultSet.iterator()).thenReturn(Arrays.asList(row, row).iterator());

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateUnitTests.java
@@ -15,6 +15,25 @@
  */
 package org.springframework.data.cassandra.core.cql;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -40,23 +59,6 @@ import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.policies.DowngradingConsistencyRetryPolicy;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link CqlTemplate}.

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateUnitTests.java
@@ -15,6 +15,18 @@
  */
 package org.springframework.data.cassandra.core.cql;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.data.cassandra.CassandraConnectionFailureException;
+import org.springframework.data.cassandra.CassandraInvalidQueryException;
+import org.springframework.data.cassandra.core.cql.support.PreparedStatementCache;
+
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.ColumnDefinitions;
 import com.datastax.driver.core.ConsistencyLevel;
@@ -35,17 +47,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.dao.IncorrectResultSizeDataAccessException;
-import org.springframework.data.cassandra.CassandraConnectionFailureException;
-import org.springframework.data.cassandra.CassandraInvalidQueryException;
-import org.springframework.data.cassandra.core.cql.support.PreparedStatementCache;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -61,6 +62,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link CqlTemplate}.
  *
  * @author Mark Paluch
+ * @author Mike Barlotta (CodeSmell)
  */
 @RunWith(MockitoJUnitRunner.class)
 public class CqlTemplateUnitTests {

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateUnitTests.java
@@ -15,32 +15,11 @@
  */
 package org.springframework.data.cassandra.core.cql;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Consumer;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.dao.IncorrectResultSizeDataAccessException;
-import org.springframework.data.cassandra.CassandraConnectionFailureException;
-import org.springframework.data.cassandra.CassandraInvalidQueryException;
-
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.ColumnDefinitions;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
@@ -49,6 +28,34 @@ import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.policies.DowngradingConsistencyRetryPolicy;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.data.cassandra.CassandraConnectionFailureException;
+import org.springframework.data.cassandra.CassandraInvalidQueryException;
+import org.springframework.data.cassandra.core.cql.support.PreparedStatementCache;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link CqlTemplate}.
@@ -64,6 +71,7 @@ public class CqlTemplateUnitTests {
 	@Mock PreparedStatement preparedStatement;
 	@Mock BoundStatement boundStatement;
 	@Mock ColumnDefinitions columnDefinitions;
+	@Mock PreparedStatementCache mockCache;
 
 	CqlTemplate template;
 
@@ -266,6 +274,26 @@ public class CqlTemplateUnitTests {
 
 		assertThat(applied).isTrue();
 	}
+
+    @Test // DATACASS-555
+    public void queryWithArgsAndWithCache() {
+
+        template.setPreparedStatementCache(mockCache);
+        when(mockCache.getPreparedStatement(Mockito.any(Session.class), Mockito.any(RegularStatement.class)))
+            .thenReturn(preparedStatement);
+
+        when(session.prepare("SELECT * FROM user WHERE username = ?")).thenReturn(preparedStatement);
+        when(preparedStatement.bind("Walter")).thenReturn(boundStatement);
+        when(session.execute(boundStatement)).thenReturn(resultSet);
+        when(resultSet.iterator()).thenReturn(Collections.singleton(row).iterator());
+
+        List<Object> resultList = template.query("SELECT * FROM user WHERE username = ?", (row, rowNum) -> "OK", "Walter");
+        assertNotNull(resultList);
+        assertEquals(1, resultList.size());
+        assertThat((String) resultList.get(0)).isEqualTo("OK");
+
+        verify(mockCache, times(1)).getPreparedStatement(Mockito.any(Session.class), Mockito.any(RegularStatement.class));
+    }
 
 	// -------------------------------------------------------------------------
 	// Tests dealing with com.datastax.driver.core.Statement
@@ -615,6 +643,24 @@ public class CqlTemplateUnitTests {
 		assertThat(result).isEqualTo("OK");
 	}
 
+    @Test // DATACASS-555
+    public void queryForObjectPreparedStatementShouldReturnRecordWithCache() {
+
+        template.setPreparedStatementCache(mockCache);
+        when(mockCache.getPreparedStatement(Mockito.any(Session.class), Mockito.any(RegularStatement.class)))
+            .thenReturn(preparedStatement);
+
+        when(session.prepare("SELECT * FROM user WHERE username = ?")).thenReturn(preparedStatement);
+        when(preparedStatement.bind("Walter")).thenReturn(boundStatement);
+        when(session.execute(boundStatement)).thenReturn(resultSet);
+        when(resultSet.iterator()).thenReturn(Collections.singleton(row).iterator());
+
+        String result = template.queryForObject("SELECT * FROM user WHERE username = ?", (row, rowNum) -> "OK", "Walter");
+        assertThat(result).isEqualTo("OK");
+
+        verify(mockCache, times(1)).getPreparedStatement(Mockito.any(Session.class), Mockito.any(RegularStatement.class));
+    }
+
 	@Test // DATACASS-292
 	public void queryForObjectPreparedStatementShouldFailReturningManyRecords() {
 
@@ -663,6 +709,28 @@ public class CqlTemplateUnitTests {
 
 		assertThat(result).contains("OK", "NOT OK");
 	}
+
+    @Test // DATACASS-555
+    public void queryForListPreparedStatementWithTypeShouldReturnRecordWithCache() {
+
+        template.setPreparedStatementCache(mockCache);
+        when(mockCache.getPreparedStatement(Mockito.any(Session.class), Mockito.any(RegularStatement.class)))
+            .thenReturn(preparedStatement);
+
+        when(session.prepare("SELECT * FROM user WHERE username = ?")).thenReturn(preparedStatement);
+        when(preparedStatement.bind("Walter")).thenReturn(boundStatement);
+        when(session.execute(boundStatement)).thenReturn(resultSet);
+        when(resultSet.iterator()).thenReturn(Arrays.asList(row, row).iterator());
+        when(row.getColumnDefinitions()).thenReturn(columnDefinitions);
+        when(columnDefinitions.size()).thenReturn(1);
+        when(row.getString(0)).thenReturn("OK", "NOT OK");
+
+        List<String> result = template.queryForList("SELECT * FROM user WHERE username = ?", String.class, "Walter");
+
+        assertThat(result).contains("OK", "NOT OK");
+
+        verify(mockCache, times(1)).getPreparedStatement(Mockito.any(Session.class), Mockito.any(RegularStatement.class));
+    }
 
 	@Test // DATACASS-292
 	public void updatePreparedStatementShouldReturnApplied() {


### PR DESCRIPTION
This is a partial PR showing how Spring Data Cassandra `CqlTemplate` could use `PreparedStatement` when users are building queries with DataStax `RegularStatement`

Will add rest of implementation and unit tests if this is approved

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACASS).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
