### PR TITLE
DATACASS-556 - Support for SimplePreparedStatementCreator with RegularStatement in CqlTemplate

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
@@ -406,6 +406,10 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
     public <T> List<T> query(RegularStatement regStatement, RowMapper<T> rowMapper, Object... args) throws DataAccessException {
         return query(newPreparedStatementCreator(regStatement), newPreparedStatementBinder(args), newResultSetExtractor(rowMapper));
     }
+
+    public ResultSet queryForResultSet(RegularStatement regStatement, Object... args) throws DataAccessException {
+        return query(newPreparedStatementCreator(regStatement), newPreparedStatementBinder(args), rs -> rs);
+    }
     // - mike (end)
 
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.Host;
 import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
@@ -69,6 +70,7 @@ import com.datastax.driver.core.exceptions.DriverException;
  * @author Antoine Toulme
  * @author John Blum
  * @author Mark Paluch
+ * @author Mike Barlotta (CodeSmell)
  * @see PreparedStatementCreator
  * @see PreparedStatementBinder
  * @see PreparedStatementCallback
@@ -385,17 +387,41 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 	}
 
 	// -------------------------------------------------------------------------
-	// Methods dealing with com.datastax.driver.core.PreparedStatement
+	// Methods dealing with com.datastax.driver.core.PreparedStatement and com.datastax.driver.core.RegularStatement
 	// -------------------------------------------------------------------------
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.cassandra.core.cqlOperations#execute(java.lang.String, java.lang.Object[])
-	 */
-	@Override
-	public boolean execute(String cql, Object... args) throws DataAccessException {
-		return execute(cql, newPreparedStatementBinder(args));
-	}
+	// - mike
+    public boolean execute(RegularStatement regStatement, Object... args) throws DataAccessException {
+        return execute(regStatement, newPreparedStatementBinder(args));
+    }
+
+    public boolean execute(RegularStatement regStatement, @Nullable PreparedStatementBinder psb) throws DataAccessException {
+        return query(newPreparedStatementCreator(regStatement), psb, ResultSet::wasApplied);
+    }
+
+    public <T> T query(RegularStatement regStatement, ResultSetExtractor<T> resultSetExtractor, Object... args) throws DataAccessException {
+        return query(newPreparedStatementCreator(regStatement), newPreparedStatementBinder(args), resultSetExtractor);
+    }
+
+    public <T> List<T> query(RegularStatement regStatement, RowMapper<T> rowMapper, Object... args) throws DataAccessException {
+        return query(newPreparedStatementCreator(regStatement), newPreparedStatementBinder(args), newResultSetExtractor(rowMapper));
+    }
+    // - mike (end)
+
+
+    // -------------------------------------------------------------------------
+    // Methods dealing with com.datastax.driver.core.PreparedStatement
+    // -------------------------------------------------------------------------
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.springframework.data.cassandra.core.cqlOperations#execute(java.lang.String, java.lang.Object[])
+     */
+    @Override
+    public boolean execute(String cql, Object... args) throws DataAccessException {
+        return execute(cql, newPreparedStatementBinder(args));
+    }
 
 	/*
 	 * (non-Javadoc)
@@ -404,7 +430,7 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 	@Override
 	public boolean execute(String cql, @Nullable PreparedStatementBinder psb) throws DataAccessException {
 		// noinspection ConstantConditions
-		return query(new SimplePreparedStatementCreator(cql), psb, ResultSet::wasApplied);
+		return query(newPreparedStatementCreator(cql), psb, ResultSet::wasApplied);
 	}
 
 	/*
@@ -704,9 +730,13 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 	}
 
 	/* (non-Javadoc) */
-	protected PreparedStatementCreator newPreparedStatementCreator(String cql) {
-		return new SimplePreparedStatementCreator(cql);
-	}
+    protected PreparedStatementCreator newPreparedStatementCreator(String cql) {
+        return new SimplePreparedStatementCreator(cql);
+    }
+
+    protected PreparedStatementCreator newPreparedStatementCreator(RegularStatement regStatement) {
+        return new SimplePreparedStatementCreator(regStatement.getQueryString());
+    }
 
 	// -------------------------------------------------------------------------
 	// Implementation hooks and helper methods
@@ -734,25 +764,4 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 		return sessionFactory.getSession();
 	}
 
-	private class SimplePreparedStatementCreator implements PreparedStatementCreator, CqlProvider {
-
-		private final String cql;
-
-		SimplePreparedStatementCreator(String cql) {
-
-			Assert.notNull(cql, "CQL must not be null");
-
-			this.cql = cql;
-		}
-
-		@Override
-		public PreparedStatement createPreparedStatement(Session session) throws DriverException {
-			return session.prepare(cql);
-		}
-
-		@Override
-		public String getCql() {
-			return cql;
-		}
-	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateIntegrationTests.java
@@ -34,6 +34,7 @@ import com.datastax.driver.core.querybuilder.Select;
  * Integration tests for {@link CqlTemplate}.
  *
  * @author Mark Paluch
+ * @author Mike Barlotta (CodeSmell)
  */
 public class CqlTemplateIntegrationTests extends AbstractKeyspaceCreatingIntegrationTest {
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateIntegrationTests.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
 
 import com.datastax.driver.core.querybuilder.QueryBuilder;
@@ -38,140 +37,140 @@ import com.datastax.driver.core.querybuilder.Select;
  */
 public class CqlTemplateIntegrationTests extends AbstractKeyspaceCreatingIntegrationTest {
 
-    static final AtomicBoolean initialized = new AtomicBoolean();
-    CqlTemplate template;
+	static final AtomicBoolean initialized = new AtomicBoolean();
+	CqlTemplate template;
 
-    @Before
-    public void before() throws Exception {
+	@Before
+	public void before() throws Exception {
 
-        if (initialized.compareAndSet(false, true)) {
-            getSession().execute("CREATE TABLE IF NOT EXISTS user (id text PRIMARY KEY, username text);");
-        } else {
-            session.execute("TRUNCATE user;");
-        }
+		if (initialized.compareAndSet(false, true)) {
+			getSession().execute("CREATE TABLE IF NOT EXISTS user (id text PRIMARY KEY, username text);");
+		} else {
+			session.execute("TRUNCATE user;");
+		}
 
-        session.execute("INSERT INTO user (id, username) VALUES ('WHITE', 'Walter');");
+		session.execute("INSERT INTO user (id, username) VALUES ('WHITE', 'Walter');");
 
-        template = new CqlTemplate();
-        template.setSession(getSession());
-    }
+		template = new CqlTemplate();
+		template.setSession(getSession());
+	}
 
-    @Test // DATACASS-292
-    public void executeShouldRemoveRecords() throws Exception {
+	@Test // DATACASS-292
+	public void executeShouldRemoveRecords() throws Exception {
 
-        template.execute("DELETE FROM user WHERE id = 'WHITE'");
+		template.execute("DELETE FROM user WHERE id = 'WHITE'");
 
-        assertThat(session.execute("SELECT * FROM user").one()).isNull();
-    }
+		assertThat(session.execute("SELECT * FROM user").one()).isNull();
+	}
 
-    @Test // DATACASS-292
-    public void queryShouldInvokeCallback() throws Exception {
+	@Test // DATACASS-292
+	public void queryShouldInvokeCallback() throws Exception {
 
-        List<String> result = new ArrayList<>();
-        template.query("SELECT id FROM user;", row -> {
-            result.add(row.getString(0));
-        });
+		List<String> result = new ArrayList<>();
+		template.query("SELECT id FROM user;", row -> {
+			result.add(row.getString(0));
+		});
 
-        assertThat(result).contains("WHITE");
-    }
+		assertThat(result).contains("WHITE");
+	}
 
-    @Test // DATACASS-292
-    public void queryForObjectShouldReturnFirstColumn() throws Exception {
+	@Test // DATACASS-292
+	public void queryForObjectShouldReturnFirstColumn() throws Exception {
 
-        String id = template.queryForObject("SELECT id FROM user;", String.class);
+		String id = template.queryForObject("SELECT id FROM user;", String.class);
 
-        assertThat(id).isEqualTo("WHITE");
-    }
+		assertThat(id).isEqualTo("WHITE");
+	}
 
-    @Test // DATACASS-292
-    public void queryForObjectShouldReturnMap() throws Exception {
+	@Test // DATACASS-292
+	public void queryForObjectShouldReturnMap() throws Exception {
 
-        Map<String, Object> map = template.queryForMap("SELECT * FROM user;");
+		Map<String, Object> map = template.queryForMap("SELECT * FROM user;");
 
-        assertThat(map).containsEntry("id", "WHITE").containsEntry("username", "Walter");
-    }
+		assertThat(map).containsEntry("id", "WHITE").containsEntry("username", "Walter");
+	}
 
-    @Test // DATACASS-292
-    public void executeStatementShouldRemoveRecords() throws Exception {
+	@Test // DATACASS-292
+	public void executeStatementShouldRemoveRecords() throws Exception {
 
-        template.execute(QueryBuilder.delete().from("user").where(QueryBuilder.eq("id", "WHITE")));
+		template.execute(QueryBuilder.delete().from("user").where(QueryBuilder.eq("id", "WHITE")));
 
-        assertThat(session.execute("SELECT * FROM user").one()).isNull();
-    }
+		assertThat(session.execute("SELECT * FROM user").one()).isNull();
+	}
 
-    @Test // DATACASS-292
-    public void queryStatementShouldInvokeCallback() throws Exception {
+	@Test // DATACASS-292
+	public void queryStatementShouldInvokeCallback() throws Exception {
 
-        List<String> result = new ArrayList<>();
-        template.query(QueryBuilder.select("id").from("user"), row -> {
-            result.add(row.getString(0));
-        });
+		List<String> result = new ArrayList<>();
+		template.query(QueryBuilder.select("id").from("user"), row -> {
+			result.add(row.getString(0));
+		});
 
-        assertThat(result).contains("WHITE");
-    }
+		assertThat(result).contains("WHITE");
+	}
 
-    @Test // DATACASS-292
-    public void queryForObjectStatementShouldReturnFirstColumn() throws Exception {
+	@Test // DATACASS-292
+	public void queryForObjectStatementShouldReturnFirstColumn() throws Exception {
 
-        String id = template.queryForObject(QueryBuilder.select("id").from("user"), String.class);
+		String id = template.queryForObject(QueryBuilder.select("id").from("user"), String.class);
 
-        assertThat(id).isEqualTo("WHITE");
-    }
+		assertThat(id).isEqualTo("WHITE");
+	}
 
-    @Test // DATACASS-292
-    public void queryForObjectStatementShouldReturnMap() throws Exception {
+	@Test // DATACASS-292
+	public void queryForObjectStatementShouldReturnMap() throws Exception {
 
-        Map<String, Object> map = template.queryForMap(QueryBuilder.select().from("user"));
+		Map<String, Object> map = template.queryForMap(QueryBuilder.select().from("user"));
 
-        assertThat(map).containsEntry("id", "WHITE").containsEntry("username", "Walter");
-    }
+		assertThat(map).containsEntry("id", "WHITE").containsEntry("username", "Walter");
+	}
 
-    @Test // DATACASS-292
-    public void executeWithArgsShouldRemoveRecords() throws Exception {
+	@Test // DATACASS-292
+	public void executeWithArgsShouldRemoveRecords() throws Exception {
 
-        template.execute("DELETE FROM user WHERE id = ?", "WHITE");
+		template.execute("DELETE FROM user WHERE id = ?", "WHITE");
 
-        assertThat(session.execute("SELECT * FROM user").one()).isNull();
-    }
+		assertThat(session.execute("SELECT * FROM user").one()).isNull();
+	}
 
-    @Test // DATACASS-292
-    public void queryPreparedStatementShouldInvokeCallback() throws Exception {
+	@Test // DATACASS-292
+	public void queryPreparedStatementShouldInvokeCallback() throws Exception {
 
-        List<String> result = new ArrayList<>();
-        template.query("SELECT id FROM user WHERE id = ?;", row -> {
-            result.add(row.getString(0));
-        }, "WHITE");
+		List<String> result = new ArrayList<>();
+		template.query("SELECT id FROM user WHERE id = ?;", row -> {
+			result.add(row.getString(0));
+		}, "WHITE");
 
-        assertThat(result).contains("WHITE");
-    }
+		assertThat(result).contains("WHITE");
+	}
 
-    @Test // DATACASS-292
-    public void queryPreparedStatementCreatorShouldInvokeCallback() throws Exception {
+	@Test // DATACASS-292
+	public void queryPreparedStatementCreatorShouldInvokeCallback() throws Exception {
 
-        List<String> result = new ArrayList<>();
-        template.query(session -> session.prepare("SELECT id FROM user WHERE id = ?;"), ps -> ps.bind("WHITE"), row -> {
-            result.add(row.getString(0));
-        });
+		List<String> result = new ArrayList<>();
+		template.query(session -> session.prepare("SELECT id FROM user WHERE id = ?;"), ps -> ps.bind("WHITE"), row -> {
+			result.add(row.getString(0));
+		});
 
-        assertThat(result).contains("WHITE");
-    }
+		assertThat(result).contains("WHITE");
+	}
 
-    @Test // DATACASS-292
-    public void queryForObjectWithArgsShouldReturnFirstColumn() throws Exception {
+	@Test // DATACASS-292
+	public void queryForObjectWithArgsShouldReturnFirstColumn() throws Exception {
 
-        String id = template.queryForObject("SELECT id FROM user WHERE id = ?;", String.class, "WHITE");
+		String id = template.queryForObject("SELECT id FROM user WHERE id = ?;", String.class, "WHITE");
 
-        assertThat(id).isEqualTo("WHITE");
-    }
+		assertThat(id).isEqualTo("WHITE");
+	}
 
-    @Test // DATACASS-292
-    public void queryForObjectWithArgsShouldReturnMap() throws Exception {
+	@Test // DATACASS-292
+	public void queryForObjectWithArgsShouldReturnMap() throws Exception {
 
-        Map<String, Object> map = template.queryForMap("SELECT * FROM user WHERE id = ?;", "WHITE");
+		Map<String, Object> map = template.queryForMap("SELECT * FROM user WHERE id = ?;", "WHITE");
 
-        assertThat(map).containsEntry("id", "WHITE").containsEntry("username", "Walter");
-    }
-
+		assertThat(map).containsEntry("id", "WHITE").containsEntry("username", "Walter");
+	}
+	
     @Test // DATACASS-556
     public void queryRegularStatementShouldUsePreparedStatement() throws Exception {
 


### PR DESCRIPTION
This is a partial PR showing how Spring Data Cassandra CqlTemplate could use PreparedStatement when users are building queries with DataStax RegularStatement

Will add rest of implementation and unit tests if this is approved
https://jira.spring.io/browse/DATACASS-556

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACASS).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
