### PR TITLE
DATACASS-555 - minor fix to CqlTemplate

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
@@ -69,6 +69,8 @@ import com.datastax.driver.core.exceptions.DriverException;
  * @author Antoine Toulme
  * @author John Blum
  * @author Mark Paluch
+ * @author Mike Barlotta (CodeSmell)
+ *
  * @see PreparedStatementCreator
  * @see PreparedStatementBinder
  * @see PreparedStatementCallback
@@ -404,7 +406,7 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 	@Override
 	public boolean execute(String cql, @Nullable PreparedStatementBinder psb) throws DataAccessException {
 		// noinspection ConstantConditions
-		return query(new SimplePreparedStatementCreator(cql), psb, ResultSet::wasApplied);
+	    return query(newPreparedStatementCreator(cql), psb, ResultSet::wasApplied);
 	}
 
 	/*
@@ -734,25 +736,4 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 		return sessionFactory.getSession();
 	}
 
-	private class SimplePreparedStatementCreator implements PreparedStatementCreator, CqlProvider {
-
-		private final String cql;
-
-		SimplePreparedStatementCreator(String cql) {
-
-			Assert.notNull(cql, "CQL must not be null");
-
-			this.cql = cql;
-		}
-
-		@Override
-		public PreparedStatement createPreparedStatement(Session session) throws DriverException {
-			return session.prepare(cql);
-		}
-
-		@Override
-		public String getCql() {
-			return cql;
-		}
-	}
 }


### PR DESCRIPTION
Allow for caching the prepared statements in the CqlTemplate if a PreparedStatementCache implementation is provided
https://jira.spring.io/browse/DATACASS-555

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACASS).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
