### PR TITLE
DATACASS-575 - Support IF conditions in lightweight transactions with UPDATE and DELETE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACASS-575-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATACASS-575-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATACASS-575-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
@@ -312,8 +312,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return select(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)),
-				entityClass);
+		return select(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)), entityClass);
 	}
 
 	/* (non-Javadoc)
@@ -325,8 +324,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return slice(this.statementFactory.select(query, getRequiredPersistentEntity(entityClass)),
-				entityClass);
+		return slice(this.statementFactory.select(query, getRequiredPersistentEntity(entityClass)), entityClass);
 	}
 
 	/* (non-Javadoc)
@@ -340,8 +338,8 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(entityConsumer, "Entity Consumer must not be empty");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return select(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)),
-				entityConsumer, entityClass);
+		return select(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)), entityConsumer,
+				entityClass);
 	}
 
 	/* (non-Javadoc)
@@ -353,8 +351,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return selectOne(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)),
-				entityClass);
+		return selectOne(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)), entityClass);
 	}
 
 	/* (non-Javadoc)
@@ -368,8 +365,8 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(update, "Update must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return getAsyncCqlOperations().execute(
-				getStatementFactory().update(query, update, getRequiredPersistentEntity(entityClass)));
+		return getAsyncCqlOperations()
+				.execute(getStatementFactory().update(query, update, getRequiredPersistentEntity(entityClass)));
 	}
 
 	/* (non-Javadoc)
@@ -482,7 +479,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 
 		return new MappingListenableFutureAdapter<>(
 				getAsyncCqlOperations().query(select, (row, rowNum) -> mapper.apply(row)),
-						it -> it.isEmpty() ? null : (T) it.get(0));
+				it -> it.isEmpty() ? null : (T) it.get(0));
 	}
 
 	/* (non-Javadoc)
@@ -533,8 +530,9 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "UpdateOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-		Update update = EntityQueryUtils.createUpdateQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Update update = getStatementFactory().update(entity, options, getConverter(), persistentEntity, tableName);
 
 		maybeEmitEvent(new BeforeSaveEvent<>(entity, tableName, update));
 
@@ -562,8 +560,9 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "QueryOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-		Delete delete = EntityQueryUtils.createDeleteQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Delete delete = getStatementFactory().delete(entity, options, getConverter(), persistentEntity, tableName);
 
 		maybeEmitEvent(new BeforeDeleteEvent<>(delete, entity.getClass(), tableName));
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -589,8 +589,9 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "UpdateOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-		Update update = EntityQueryUtils.createUpdateQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Update update = getStatementFactory().update(entity, options, getConverter(), persistentEntity, tableName);
 
 		maybeEmitEvent(new BeforeSaveEvent<>(entity, tableName, update));
 
@@ -619,8 +620,9 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "QueryOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-		Delete delete = EntityQueryUtils.createDeleteQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Delete delete = getStatementFactory().delete(entity, options, getConverter(), persistentEntity, tableName);
 
 		maybeEmitEvent(new BeforeDeleteEvent<>(delete, entity.getClass(), tableName));
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
@@ -526,8 +526,9 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "UpdateOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-		Update update = EntityQueryUtils.createUpdateQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Update update = getStatementFactory().update(entity, options, getConverter(), persistentEntity, tableName);
 
 		Mono<EntityWriteResult<T>> result = getReactiveCqlOperations() //
 				.execute(new StatementCallback(update)) //
@@ -555,9 +556,9 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "QueryOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-
-		Delete delete = EntityQueryUtils.createDeleteQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Delete delete = getStatementFactory().delete(entity, options, getConverter(), persistentEntity, tableName);
 
 		Mono<WriteResult> result = getReactiveCqlOperations() //
 				.execute(new StatementCallback(delete)) //

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/DeleteOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/DeleteOptionsUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,45 +24,41 @@ import org.junit.Test;
 import org.springframework.data.cassandra.core.query.Query;
 
 /**
- * Unit tests for {@link UpdateOptions}.
+ * Unit tests for {@link DeleteOptions}.
  *
  * @author Mark Paluch
- * @author Lukasz Antoniak
  */
-public class UpdateOptionsUnitTests {
+public class DeleteOptionsUnitTests {
 
-	@Test // DATACASS-250, DATACASS-155
-	public void shouldConfigureUpdateOptions() {
+	@Test // DATACASS-575
+	public void shouldConfigureDeleteOptions() {
 
 		Instant now = Instant.ofEpochSecond(1234);
 
-		UpdateOptions updateOptions = UpdateOptions.builder() //
+		DeleteOptions deleteOptions = DeleteOptions.builder() //
 				.ttl(10) //
 				.timestamp(now) //
 				.withIfExists() //
 				.build();
 
-		assertThat(updateOptions.getTtl()).isEqualTo(Duration.ofSeconds(10));
-		assertThat(updateOptions.getTimestamp()).isEqualTo(now.toEpochMilli() * 1000);
-		assertThat(updateOptions.isIfExists()).isTrue();
+		assertThat(deleteOptions.getTtl()).isEqualTo(Duration.ofSeconds(10));
+		assertThat(deleteOptions.getTimestamp()).isEqualTo(now.toEpochMilli() * 1000);
+		assertThat(deleteOptions.isIfExists()).isTrue();
 	}
 
-	@Test // DATACASS-56, DATACASS-155
-	public void buildUpdateOptionsMutate() {
+	@Test // DATACASS-575
+	public void buildDeleteOptionsMutate() {
 
-		UpdateOptions updateOptions = UpdateOptions.builder() //
+		DeleteOptions deleteOptions = DeleteOptions.builder() //
 				.ttl(10) //
 				.timestamp(1519222753) //
 				.withIfExists() //
 				.build();
 
-		UpdateOptions mutated = updateOptions.mutate() //
-				.ttl(20) //
-				.timestamp(1519000753) //
-				.build();
+		DeleteOptions mutated = deleteOptions.mutate().ttl(20).timestamp(1519000753).build();
 
 		assertThat(mutated).isNotNull();
-		assertThat(mutated).isNotSameAs(updateOptions);
+		assertThat(mutated).isNotSameAs(deleteOptions);
 		assertThat(mutated.getTtl()).isEqualTo(Duration.ofSeconds(20));
 		assertThat(mutated.getTimestamp()).isEqualTo(1519000753);
 		assertThat(mutated.isIfExists()).isTrue();
@@ -71,12 +67,12 @@ public class UpdateOptionsUnitTests {
 	@Test // DATACASS-575
 	public void shouldApplyFilterCondition() {
 
-		UpdateOptions updateOptions = UpdateOptions.builder() //
+		DeleteOptions deleteOptions = DeleteOptions.builder() //
 				.withIfExists() //
 				.ifCondition(Query.empty()) //
 				.build();
 
-		assertThat(updateOptions.isIfExists()).isFalse();
-		assertThat(updateOptions.getIfCondition()).isEqualTo(Query.empty());
+		assertThat(deleteOptions.isIfExists()).isFalse();
+		assertThat(deleteOptions.getIfCondition()).isEqualTo(Query.empty());
 	}
 }

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -3,6 +3,11 @@
 
 This chapter summarizes changes and new features for each release.
 
+[[new-features.2-2-0]]
+== What's new in Spring Data for Apache Cassandra 2.2
+* Lightweight transaction support via `DeleteOptions` using the Template API.
+* Filter conditions for lightweight transaction update and delete (`UPDATE … IF <condition>`, `DELETE … IF <condition>`).
+
 [[new-features.2-1-0]]
 == What's new in Spring Data for Apache Cassandra 2.1
 * New annotations for `@CountQuery` and `@ExistsQuery`.


### PR DESCRIPTION
We now support conditions in lightweight transactions for `UPDATE` and `DELETE` statements. Conditions are `Filter` objects similar to the `WHERE` clause. Conditions are supported for entity and query-based update/delete methods.

```java
UpdateOptions options = UpdateOptions.builder().ifCondition(where("firstname").is("Walter")).build();
User user = new User("heisenberg", "Walter", "White");
template.update(user, options);

DeleteOptions options = DeleteOptions.builder().ifCondition(where("counter").is(42)).build();
Query query = Query.query(where("id").is("heisenberg")).queryOptions(options);
template.delete(query, User.class);
```

---

Related ticket: [DATACASS-575](https://jira.spring.io/browse/DATACASS-575).