### PR TITLE
DATACASS-576 - Add support for Optimistic Locking.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACASS-575-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.2.0.DATACASS-575-SNAPSHOT</version>
+	<version>2.2.0.DATACASS-576-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.2.0.DATACASS-575-SNAPSHOT</version>
+		<version>2.2.0.DATACASS-576-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATACASS-575-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATACASS-575-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.2.0.DATACASS-575-SNAPSHOT</version>
+		<version>2.2.0.DATACASS-576-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
@@ -777,7 +777,6 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		return session.getCluster().getConfiguration().getQueryOptions().getFetchSize();
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	private int getEffectiveFetchSize(Statement statement) {
 
 		if (statement.getFetchSize() > 0) {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
@@ -312,8 +312,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return select(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)),
-				entityClass);
+		return select(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)), entityClass);
 	}
 
 	/* (non-Javadoc)
@@ -325,8 +324,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return slice(this.statementFactory.select(query, getRequiredPersistentEntity(entityClass)),
-				entityClass);
+		return slice(this.statementFactory.select(query, getRequiredPersistentEntity(entityClass)), entityClass);
 	}
 
 	/* (non-Javadoc)
@@ -340,8 +338,8 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(entityConsumer, "Entity Consumer must not be empty");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return select(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)),
-				entityConsumer, entityClass);
+		return select(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)), entityConsumer,
+				entityClass);
 	}
 
 	/* (non-Javadoc)
@@ -353,8 +351,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return selectOne(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)),
-				entityClass);
+		return selectOne(getStatementFactory().select(query, getRequiredPersistentEntity(entityClass)), entityClass);
 	}
 
 	/* (non-Javadoc)
@@ -368,8 +365,8 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(update, "Update must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return getAsyncCqlOperations().execute(
-				getStatementFactory().update(query, update, getRequiredPersistentEntity(entityClass)));
+		return getAsyncCqlOperations()
+				.execute(getStatementFactory().update(query, update, getRequiredPersistentEntity(entityClass)));
 	}
 
 	/* (non-Javadoc)
@@ -482,7 +479,7 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 
 		return new MappingListenableFutureAdapter<>(
 				getAsyncCqlOperations().query(select, (row, rowNum) -> mapper.apply(row)),
-						it -> it.isEmpty() ? null : (T) it.get(0));
+				it -> it.isEmpty() ? null : (T) it.get(0));
 	}
 
 	/* (non-Javadoc)
@@ -533,8 +530,9 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "UpdateOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-		Update update = EntityQueryUtils.createUpdateQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Update update = getStatementFactory().update(entity, options, getConverter(), persistentEntity, tableName);
 
 		maybeEmitEvent(new BeforeSaveEvent<>(entity, tableName, update));
 
@@ -562,8 +560,9 @@ public class AsyncCassandraTemplate implements AsyncCassandraOperations, Applica
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "QueryOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-		Delete delete = EntityQueryUtils.createDeleteQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Delete delete = getStatementFactory().delete(entity, options, getConverter(), persistentEntity, tableName);
 
 		maybeEmitEvent(new BeforeDeleteEvent<>(delete, entity.getClass(), tableName));
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -589,8 +589,9 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "UpdateOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-		Update update = EntityQueryUtils.createUpdateQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Update update = getStatementFactory().update(entity, options, getConverter(), persistentEntity, tableName);
 
 		maybeEmitEvent(new BeforeSaveEvent<>(entity, tableName, update));
 
@@ -619,8 +620,9 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "QueryOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-		Delete delete = EntityQueryUtils.createDeleteQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Delete delete = getStatementFactory().delete(entity, options, getConverter(), persistentEntity, tableName);
 
 		maybeEmitEvent(new BeforeDeleteEvent<>(delete, entity.getClass(), tableName));
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/EntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/EntityOperations.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.core.convert.ConversionService;
+import org.springframework.data.cassandra.core.cql.CqlIdentifier;
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.querybuilder.Delete;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.querybuilder.Update;
+
+/**
+ * Common operations performed on an entity in the context of it's mapping metadata.
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ * @see CassandraTemplate
+ * @see AsyncCassandraTemplate
+ * @see ReactiveCassandraTemplate
+ */
+@RequiredArgsConstructor
+class EntityOperations {
+
+	private final @NonNull MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> context;
+
+	private CassandraPersistentEntity<?> getRequiredPersistentEntity(Class<?> entityType) {
+		return context.getRequiredPersistentEntity(ClassUtils.getUserClass(entityType));
+	}
+
+	/**
+	 * Creates a new {@link Entity} for the given bean.
+	 *
+	 * @param entity must not be {@literal null}.
+	 * @return
+	 */
+	public <T> Entity<T> forEntity(T entity) {
+
+		Assert.notNull(entity, "Bean must not be null!");
+
+		return MappedEntity.of(entity, context);
+	}
+
+	/**
+	 * Returns the table name to which the entity shall be persisted.
+	 *
+	 * @param entityClass entity class, must not be {@literal null}.
+	 * @return the table name to which the entity shall be persisted.
+	 */
+	public CqlIdentifier getTableName(Class<?> entityClass) {
+		return getRequiredPersistentEntity(entityClass).getTableName();
+	}
+
+	/**
+	 * Creates a new {@link AdaptibleEntity} for the given bean and {@link ConversionService}.
+	 *
+	 * @param entity must not be {@literal null}.
+	 * @param conversionService must not be {@literal null}.
+	 * @return
+	 */
+	public <T> AdaptibleEntity<T> forEntity(T entity, ConversionService conversionService) {
+
+		Assert.notNull(entity, "Bean must not be null!");
+		Assert.notNull(conversionService, "ConversionService must not be null!");
+
+		return AdaptibleMappedEntity.of(entity, context, conversionService);
+	}
+
+	/**
+	 * A representation of information about an entity.
+	 */
+	interface Entity<T> {
+
+		/**
+		 * Returns whether the entity is versioned, i.e. if it contains a version property.
+		 *
+		 * @return
+		 */
+		default boolean isVersionedEntity() {
+			return false;
+		}
+
+		/**
+		 * Returns the value of the version if the entity has a version property, {@literal null} otherwise.
+		 *
+		 * @return
+		 */
+		@Nullable
+		Object getVersion();
+
+		/**
+		 * Returns the underlying bean.
+		 *
+		 * @return
+		 */
+		T getBean();
+
+		/**
+		 * Returns whether the entity is considered to be new.
+		 *
+		 * @return
+		 */
+		boolean isNew();
+	}
+
+	/**
+	 * Information and commands on an entity.
+	 */
+	interface AdaptibleEntity<T> extends Entity<T> {
+
+		/**
+		 * Appends a {@code IF} condition to an {@link Update} statement for optimistic locking to perform the update only
+		 * if the version number matches. This method accepts {@code currentVersionNumber} as the {@link Update} typically
+		 * requires to increment the version number upon assembly time.
+		 *
+		 * @param update the {@link Update} statement to append the condition to.
+		 * @param currentVersionNumber previous version number.
+		 * @return the altered {@link Update} containing the {@code IF} condition for optimistic locking.
+		 */
+		Statement appendVersionCondition(Update update, Number currentVersionNumber);
+
+		/**
+		 * Appends a {@code IF} condition to an {@link Delete} statement for optimistic locking to perform the delete only
+		 * if the version number matches. The {@link #getVersion() version number} is derived from the actual state as
+		 * delete statements typically do not increment the version prior to statement creation.
+		 *
+		 * @param delete the {@link Delete} statement to append the condition to.
+		 * @return the altered {@link Delete} containing the {@code IF} condition for optimistic locking.
+		 * @see #getVersion()
+		 */
+		Statement appendVersionCondition(Delete delete);
+
+		/**
+		 * Initializes the version property of the of the current entity if available.
+		 *
+		 * @return the entity with the version property updated if available.
+		 */
+		T initializeVersionProperty();
+
+		/**
+		 * Increments the value of the version property if available.
+		 *
+		 * @return the entity with the version property incremented if available.
+		 */
+		T incrementVersion();
+
+		/**
+		 * Returns the current version value if the entity has a version property.
+		 *
+		 * @return the current version or {@literal null} in case it's uninitialized or the entity doesn't expose a version
+		 *         property.
+		 */
+		@Nullable
+		Number getVersion();
+	}
+
+	@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+	private static class MappedEntity<T> implements Entity<T> {
+
+		private final @NonNull CassandraPersistentEntity<?> entity;
+		private final @NonNull PersistentPropertyAccessor<T> propertyAccessor;
+
+		private static <T> MappedEntity<T> of(T bean,
+				MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> context) {
+
+			CassandraPersistentEntity<?> entity = context.getRequiredPersistentEntity(bean.getClass());
+			PersistentPropertyAccessor<T> propertyAccessor = entity.getPropertyAccessor(bean);
+
+			return new MappedEntity<>(entity, propertyAccessor);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.EntityOperations.Entity#isVersionedEntity()
+		 */
+		@Override
+		public boolean isVersionedEntity() {
+			return entity.hasVersionProperty();
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.EntityOperations.Entity#getVersion()
+		 */
+		@Override
+		@Nullable
+		public Object getVersion() {
+			return propertyAccessor.getProperty(entity.getRequiredVersionProperty());
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.EntityOperations.Entity#getBean()
+		 */
+		@Override
+		public T getBean() {
+			return propertyAccessor.getBean();
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.EntityOperations.Entity#isNew()
+		 */
+		@Override
+		public boolean isNew() {
+			return entity.isNew(propertyAccessor.getBean());
+		}
+	}
+
+	private static class AdaptibleMappedEntity<T> extends MappedEntity<T> implements AdaptibleEntity<T> {
+
+		private final CassandraPersistentEntity<?> entity;
+		private final ConvertingPropertyAccessor<T> propertyAccessor;
+
+		private AdaptibleMappedEntity(CassandraPersistentEntity<?> entity, ConvertingPropertyAccessor<T> propertyAccessor) {
+
+			super(entity, propertyAccessor);
+
+			this.entity = entity;
+			this.propertyAccessor = propertyAccessor;
+		}
+
+		private static <T> AdaptibleEntity<T> of(T bean,
+				MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> context,
+				ConversionService conversionService) {
+
+			CassandraPersistentEntity<?> entity = context.getRequiredPersistentEntity(bean.getClass());
+			PersistentPropertyAccessor<T> propertyAccessor = entity.getPropertyAccessor(bean);
+
+			return new AdaptibleMappedEntity<>(entity, new ConvertingPropertyAccessor<>(propertyAccessor, conversionService));
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.EntityOperations.AdaptibleEntity#appendVersionCondition(com.datastax.driver.core.querybuilder.Update, java.lang.Number)
+		 */
+		@Override
+		public Statement appendVersionCondition(com.datastax.driver.core.querybuilder.Update update,
+				Number currentVersionNumber) {
+			return update.onlyIf(QueryBuilder.eq(getVersionColumnName().toCql(), currentVersionNumber));
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.EntityOperations.AdaptibleEntity#appendVersionCondition(com.datastax.driver.core.querybuilder.Delete)
+		 */
+		@Override
+		public Statement appendVersionCondition(Delete delete) {
+			return delete.onlyIf(QueryBuilder.eq(getVersionColumnName().toCql(), getVersion()));
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.EntityOperations.AdaptibleEntity#initializeVersionProperty()
+		 */
+		@Override
+		public T initializeVersionProperty() {
+
+			if (!entity.hasVersionProperty()) {
+				return propertyAccessor.getBean();
+			}
+
+			CassandraPersistentProperty versionProperty = entity.getRequiredVersionProperty();
+
+			propertyAccessor.setProperty(versionProperty, versionProperty.getType().isPrimitive() ? 1 : 0);
+
+			return propertyAccessor.getBean();
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.EntityOperations.AdaptibleEntity#incrementVersion()
+		 */
+		@Override
+		public T incrementVersion() {
+
+			CassandraPersistentProperty versionProperty = entity.getRequiredVersionProperty();
+			Number version = getVersion();
+			Number nextVersion = version == null ? 0 : version.longValue() + 1;
+
+			propertyAccessor.setProperty(versionProperty, nextVersion);
+
+			return propertyAccessor.getBean();
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.EntityOperations.MappedEntity#getVersion()
+		 */
+		@Override
+		@Nullable
+		public Number getVersion() {
+
+			CassandraPersistentProperty versionProperty = entity.getRequiredVersionProperty();
+
+			return propertyAccessor.getProperty(versionProperty, Number.class);
+		}
+
+		private CqlIdentifier getVersionColumnName() {
+			return entity.getRequiredVersionProperty().getColumnName();
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
@@ -18,8 +18,10 @@ package org.springframework.data.cassandra.core;
 import lombok.Value;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.SynchronousSink;
 
 import java.util.Collections;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
@@ -27,9 +29,11 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.cassandra.ReactiveResultSet;
 import org.springframework.data.cassandra.ReactiveSession;
 import org.springframework.data.cassandra.ReactiveSessionFactory;
+import org.springframework.data.cassandra.core.EntityOperations.AdaptibleEntity;
 import org.springframework.data.cassandra.core.convert.CassandraConverter;
 import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
 import org.springframework.data.cassandra.core.convert.QueryMapper;
@@ -99,13 +103,15 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 
 	private final CassandraConverter converter;
 
-	private final MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> mappingContext;
-
 	private final ReactiveCqlOperations cqlOperations;
 
-	private final StatementFactory statementFactory;
+	private final MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> mappingContext;
 
 	private final SpelAwareProxyProjectionFactory projectionFactory;
+
+	private final EntityOperations operations;
+
+	private final StatementFactory statementFactory;
 
 	private @Nullable ApplicationEventPublisher eventPublisher;
 
@@ -168,8 +174,9 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 		this.converter = converter;
 		this.cqlOperations = reactiveCqlOperations;
 		this.mappingContext = this.converter.getMappingContext();
-		this.statementFactory = new StatementFactory(new QueryMapper(converter), new UpdateMapper(converter));
 		this.projectionFactory = new SpelAwareProxyProjectionFactory();
+		this.operations = new EntityOperations(converter.getMappingContext());
+		this.statementFactory = new StatementFactory(new QueryMapper(converter), new UpdateMapper(converter));
 	}
 
 	/* (non-Javadoc)
@@ -494,19 +501,39 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 
 	<T> Mono<EntityWriteResult<T>> doInsert(T entity, WriteOptions options, CqlIdentifier tableName) {
 
+		AdaptibleEntity<T> source = operations.forEntity(entity, converter.getConversionService());
 		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
 
-		Insert insert = EntityQueryUtils.createInsertQuery(tableName.toCql(), entity, options, getConverter(),
+		T entityToUse = source.isVersionedEntity() ? source.initializeVersionProperty() : entity;
+
+		Insert insert = EntityQueryUtils.createInsertQuery(tableName.toCql(), entityToUse, options, getConverter(),
 				persistentEntity);
 
-		// noinspection ConstantConditions
-		Mono<EntityWriteResult<T>> result = getReactiveCqlOperations() //
-				.execute(new StatementCallback(insert)) //
-				.doOnSubscribe(it -> maybeEmitEvent(new BeforeSaveEvent<>(entity, tableName, insert))) //
-				.map(it -> EntityWriteResult.of(it, entity)) //
-				.next();
+		if (source.isVersionedEntity()) {
+			return doInsertVersioned(insert.ifNotExists(), entityToUse, source, tableName);
+		}
 
-		return result.doOnNext(it -> maybeEmitEvent(new AfterSaveEvent<>(entity, tableName)));
+		return doInsert(insert, entityToUse, tableName);
+	}
+
+	private <T> Mono<EntityWriteResult<T>> doInsertVersioned(Insert insert, T entity, AdaptibleEntity<T> source,
+			CqlIdentifier tableName) {
+
+		return executeSave(entity, tableName, insert, (result, sink) -> {
+
+			if (!result.wasApplied()) {
+				sink.error(new OptimisticLockingFailureException(
+						String.format("Cannot insert entity %s with version, %s into table %s as it already exists", entity,
+								source.getVersion(), tableName)));
+				return;
+			}
+
+			sink.next(result);
+		});
+	}
+
+	private <T> Mono<EntityWriteResult<T>> doInsert(Insert insert, T entity, CqlIdentifier tableName) {
+		return executeSave(entity, tableName, insert);
 	}
 
 	/* (non-Javadoc)
@@ -514,7 +541,7 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 	 */
 	@Override
 	public <T> Mono<T> update(T entity) {
-		return update(entity, UpdateOptions.empty()).map(writeResult -> entity);
+		return update(entity, UpdateOptions.empty()).map(EntityWriteResult::getEntity);
 	}
 
 	/* (non-Javadoc)
@@ -528,15 +555,42 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 
 		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
 		CqlIdentifier tableName = persistentEntity.getTableName();
+		AdaptibleEntity<T> source = operations.forEntity(entity, converter.getConversionService());
+
+		if (source.isVersionedEntity()) {
+			return doUpdateVersioned(source, options, tableName, persistentEntity);
+		}
+
+		return doUpdate(entity, options, tableName, persistentEntity);
+	}
+
+	private <T> Mono<EntityWriteResult<T>> doUpdateVersioned(AdaptibleEntity<T> source, UpdateOptions options,
+			CqlIdentifier tableName, CassandraPersistentEntity<?> persistentEntity) {
+
+		Number previousVersion = source.getVersion();
+		T entity = source.incrementVersion();
+
 		Update update = getStatementFactory().update(entity, options, getConverter(), persistentEntity, tableName);
 
-		Mono<EntityWriteResult<T>> result = getReactiveCqlOperations() //
-				.execute(new StatementCallback(update)) //
-				.doOnSubscribe(it -> maybeEmitEvent(new BeforeSaveEvent<>(entity, tableName, update))) //
-				.map(it -> EntityWriteResult.of(it, entity)) //
-				.next();
+		return executeSave(entity, tableName, source.appendVersionCondition(update, previousVersion), (result, sink) -> {
 
-		return result.doOnNext(it -> maybeEmitEvent(new AfterSaveEvent<>(entity, tableName)));
+			if (!result.wasApplied()) {
+				sink.error(new OptimisticLockingFailureException(
+						String.format("Cannot save entity %s with version %s to table %s. Has it been modified meanwhile?", entity,
+								source.getVersion(), tableName)));
+				return;
+			}
+
+			sink.next(result);
+		});
+	}
+
+	private <T> Mono<EntityWriteResult<T>> doUpdate(T entity, UpdateOptions options, CqlIdentifier tableName,
+			CassandraPersistentEntity<?> persistentEntity) {
+
+		Update update = getStatementFactory().update(entity, options, getConverter(), persistentEntity, tableName);
+
+		return executeSave(entity, tableName, update);
 	}
 
 	/* (non-Javadoc)
@@ -558,14 +612,35 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 
 		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
 		CqlIdentifier tableName = persistentEntity.getTableName();
+		AdaptibleEntity<Object> source = operations.forEntity(entity, converter.getConversionService());
+
 		Delete delete = getStatementFactory().delete(entity, options, getConverter(), persistentEntity, tableName);
 
-		Mono<WriteResult> result = getReactiveCqlOperations() //
-				.execute(new StatementCallback(delete)) //
-				.doOnSubscribe(it -> maybeEmitEvent(new BeforeDeleteEvent<>(delete, entity.getClass(), tableName))) //
-				.next();
+		if (source.isVersionedEntity()) {
+			return doDeleteVersioned(delete, entity, source, tableName);
+		}
 
-		return result.doOnNext(it -> maybeEmitEvent(new AfterDeleteEvent<>(delete, entity.getClass(), tableName)));
+		return doDelete(delete, entity, tableName);
+	}
+
+	private Mono<WriteResult> doDeleteVersioned(Delete delete, Object entity, AdaptibleEntity<Object> source,
+			CqlIdentifier tableName) {
+
+		return executeDelete(entity, tableName, source.appendVersionCondition(delete), (result, sink) -> {
+
+			if (!result.wasApplied()) {
+				sink.error(new OptimisticLockingFailureException(
+						String.format("Cannot delete entity %s with version, %s in table %s. Has it been modified meanwhile?",
+								entity, source.getVersion(), tableName)));
+				return;
+			}
+
+			sink.next(result);
+		});
+	}
+
+	private Mono<WriteResult> doDelete(Delete delete, Object entity, CqlIdentifier tableName) {
+		return executeDelete(entity, tableName, delete, (result, sink) -> sink.next(result));
 	}
 
 	/* (non-Javadoc)
@@ -683,7 +758,37 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 	}
 
 	CqlIdentifier getTableName(Class<?> entityClass) {
-		return getRequiredPersistentEntity(entityClass).getTableName();
+		return operations.getTableName(entityClass);
+	}
+
+	private <T> Mono<EntityWriteResult<T>> executeSave(T entity, CqlIdentifier tableName, Statement statement) {
+		return executeSave(entity, tableName, statement, (writeResult, sink) -> sink.next(writeResult));
+	}
+
+	private <T> Mono<EntityWriteResult<T>> executeSave(T entity, CqlIdentifier tableName, Statement statement,
+			BiConsumer<EntityWriteResult<T>, SynchronousSink<EntityWriteResult<T>>> handler) {
+
+		maybeEmitEvent(new BeforeSaveEvent<>(entity, tableName, statement));
+
+		Flux<WriteResult> execute = getReactiveCqlOperations().execute(new StatementCallback(statement));
+
+		return execute.map(it -> EntityWriteResult.of(it, entity)).handle(handler) //
+				.doOnSubscribe(it -> maybeEmitEvent(new BeforeSaveEvent<>(entity, tableName, statement))) //
+				.doOnNext(it -> maybeEmitEvent(new AfterSaveEvent<>(it, tableName))) //
+				.next();
+	}
+
+	private Mono<WriteResult> executeDelete(Object entity, CqlIdentifier tableName, Statement statement,
+			BiConsumer<WriteResult, SynchronousSink<WriteResult>> handler) {
+
+		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entity.getClass(), tableName));
+
+		Flux<WriteResult> execute = getReactiveCqlOperations().execute(new StatementCallback(statement));
+
+		return execute.map(it -> EntityWriteResult.of(it, entity)).handle(handler) //
+				.doOnSubscribe(it -> maybeEmitEvent(new BeforeSaveEvent<>(entity, tableName, statement))) //
+				.doOnNext(it -> maybeEmitEvent(new AfterDeleteEvent<>(statement, entity.getClass(), tableName))) //
+				.next();
 	}
 
 	private CqlIdentifier getTableName(Object entity) {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
@@ -799,6 +799,24 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 		return getMappingContext().getRequiredPersistentEntity(ClassUtils.getUserClass(entityType));
 	}
 
+	@SuppressWarnings("ConstantConditions")
+	private Mono<Integer> getEffectiveFetchSize(Statement statement) {
+
+		if (statement.getFetchSize() > 0) {
+			return Mono.just(statement.getFetchSize());
+		}
+
+		if (getReactiveCqlOperations() instanceof CassandraAccessor) {
+			CassandraAccessor accessor = (CassandraAccessor) getReactiveCqlOperations();
+			if (accessor.getFetchSize() != -1) {
+				return Mono.just(accessor.getFetchSize());
+			}
+		}
+
+		return getReactiveCqlOperations().execute((ReactiveSessionCallback<Integer>) session -> Mono
+				.just(session.getCluster().getConfiguration().getQueryOptions().getFetchSize())).single();
+	}
+
 	@SuppressWarnings("unchecked")
 	private <T> Function<Row, T> getMapper(Class<?> entityType, Class<T> targetType, CqlIdentifier tableName) {
 
@@ -836,24 +854,6 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 		converter.afterPropertiesSet();
 
 		return converter;
-	}
-
-	@SuppressWarnings("ConstantConditions")
-	private Mono<Integer> getEffectiveFetchSize(Statement statement) {
-
-		if (statement.getFetchSize() > 0) {
-			return Mono.just(statement.getFetchSize());
-		}
-
-		if (getReactiveCqlOperations() instanceof CassandraAccessor) {
-			CassandraAccessor accessor = (CassandraAccessor) getReactiveCqlOperations();
-			if (accessor.getFetchSize() != -1) {
-				return Mono.just(accessor.getFetchSize());
-			}
-		}
-
-		return getReactiveCqlOperations().execute((ReactiveSessionCallback<Integer>) session -> Mono
-				.just(session.getCluster().getConfiguration().getQueryOptions().getFetchSize())).single();
 	}
 
 	@Value

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
@@ -526,8 +526,9 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "UpdateOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-		Update update = EntityQueryUtils.createUpdateQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Update update = getStatementFactory().update(entity, options, getConverter(), persistentEntity, tableName);
 
 		Mono<EntityWriteResult<T>> result = getReactiveCqlOperations() //
 				.execute(new StatementCallback(update)) //
@@ -555,9 +556,9 @@ public class ReactiveCassandraTemplate implements ReactiveCassandraOperations, A
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "QueryOptions must not be null");
 
-		CqlIdentifier tableName = getTableName(entity);
-
-		Delete delete = EntityQueryUtils.createDeleteQuery(tableName.toCql(), entity, options, getConverter());
+		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
+		CqlIdentifier tableName = persistentEntity.getTableName();
+		Delete delete = getStatementFactory().delete(entity, options, getConverter(), persistentEntity, tableName);
 
 		Mono<WriteResult> result = getReactiveCqlOperations() //
 				.execute(new StatementCallback(delete)) //

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/QueryMapper.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/QueryMapper.java
@@ -132,9 +132,8 @@ public class QueryMapper {
 
 			Object value = predicate.getValue();
 
-			Object mappedValue = value != null
-				? getConverter().convertToColumnType(value, getTypeInformation(field, value))
-				: null;
+			Object mappedValue = value != null ? getConverter().convertToColumnType(value, getTypeInformation(field, value))
+					: null;
 
 			Predicate mappedPredicate = new Predicate(predicate.getOperator(), mappedValue);
 
@@ -166,9 +165,8 @@ public class QueryMapper {
 
 			Field field = createPropertyField(entity, column);
 
-			columns.getSelector(column).ifPresent(selector ->
-				getCqlIdentifier(column, field).ifPresent(cqlIdentifier ->
-					selectors.add(getMappedSelector(selector, cqlIdentifier))));
+			columns.getSelector(column).ifPresent(selector -> getCqlIdentifier(column, field)
+					.ifPresent(cqlIdentifier -> selectors.add(getMappedSelector(selector, cqlIdentifier))));
 		}
 
 		if (columns.isEmpty()) {
@@ -255,10 +253,8 @@ public class QueryMapper {
 
 			field.getProperty().ifPresent(seen::add);
 
-			columns.getSelector(column)
-					.filter(selector -> selector instanceof ColumnSelector)
-					.ifPresent(columnSelector ->
-						getCqlIdentifier(column, field).map(CqlIdentifier::toCql).ifPresent(columnNames::add));
+			columns.getSelector(column).filter(selector -> selector instanceof ColumnSelector).ifPresent(
+					columnSelector -> getCqlIdentifier(column, field).map(CqlIdentifier::toCql).ifPresent(columnNames::add));
 		}
 
 		if (columns.isEmpty()) {
@@ -333,7 +329,7 @@ public class QueryMapper {
 
 	Field createPropertyField(@Nullable CassandraPersistentEntity<?> entity, ColumnName key) {
 
-		return Optional.ofNullable(entity).<Field>map(e -> new MetadataBackedField(key, e, getMappingContext()))
+		return Optional.ofNullable(entity).<Field> map(e -> new MetadataBackedField(key, e, getMappingContext()))
 				.orElseGet(() -> new Field(key));
 	}
 
@@ -464,8 +460,8 @@ public class QueryMapper {
 				PropertyPath propertyPath = PropertyPath.from(pathExpression.replaceAll("\\.\\d", ""),
 						this.entity.getTypeInformation());
 
-				PersistentPropertyPath<CassandraPersistentProperty> persistentPropertyPath =
-						this.mappingContext.getPersistentPropertyPath(propertyPath);
+				PersistentPropertyPath<CassandraPersistentProperty> persistentPropertyPath = this.mappingContext
+						.getPersistentPropertyPath(propertyPath);
 
 				return Optional.of(persistentPropertyPath);
 			} catch (PropertyReferenceException e) {
@@ -473,18 +469,16 @@ public class QueryMapper {
 			}
 		}
 
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.mongodb.core.convert.QueryMapper.Field#with(java.lang.String)
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.convert.QueryMapper.Field#with(org.springframework.data.cassandra.core.query.ColumnName)
 		 */
 		@Override
 		public MetadataBackedField with(ColumnName name) {
 			return new MetadataBackedField(name, entity, mappingContext, property);
 		}
 
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.mongodb.core.convert.QueryMapper.Field#getProperty()
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.convert.QueryMapper.Field#getProperty()
 		 */
 		@Override
 		public Optional<CassandraPersistentProperty> getProperty() {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/SerializationUtils.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/SerializationUtils.java
@@ -43,7 +43,7 @@ abstract class SerializationUtils {
 	/**
 	 * Serializes the given object into pseudo-CQL meaning it's trying to create a CQL representation as far as possible
 	 * but falling back to the given object's {@link Object#toString()} method if it's not serializable. Useful for
-	 * printing raw {@link Criteria}s containing complex values before actually converting them into Mongo native types.
+	 * printing raw {@link Criteria}s containing complex values before actually converting them into CQL native types.
 	 *
 	 * @param criteria may be {@literal null}.
 	 * @return may be {@literal null}.
@@ -64,7 +64,7 @@ abstract class SerializationUtils {
 	/**
 	 * Serializes the given object into pseudo-CQL meaning it's trying to create a CQL representation as far as possible
 	 * but falling back to the given object's {@link Object#toString()} method if it's not serializable. Useful for
-	 * printing raw {@link Criteria}s containing complex values before actually converting them into Mongo native types.
+	 * printing raw {@link Criteria}s containing complex values before actually converting them into CQL native types.
 	 *
 	 * @param value value to serialize to CQL, may be {@literal null}.
 	 * @return the value as a serialized CQL {@link String}, may be {@literal null}.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParametersParameterAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/query/CassandraParametersParameterAccessor.java
@@ -66,8 +66,7 @@ public class CassandraParametersParameterAccessor extends ParametersParameterAcc
 				: CassandraSimpleTypeHolder.getDataTypeFor(getParameterType(index)));
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#findCassandraType(int)
 	 */
 	@Nullable
@@ -75,8 +74,7 @@ public class CassandraParametersParameterAccessor extends ParametersParameterAcc
 		return getParameters().getParameter(index).getCassandraType();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#getParameterType(int)
 	 */
 	@Override
@@ -84,8 +82,7 @@ public class CassandraParametersParameterAccessor extends ParametersParameterAcc
 		return getParameters().getParameter(index).getType();
 	}
 
-	/*
-	 * (non-Javadoc)
+	/* (non-Javadoc)
 	 * @see org.springframework.data.repository.query.ParametersParameterAccessor#getParameters()
 	 */
 	@Override
@@ -93,18 +90,16 @@ public class CassandraParametersParameterAccessor extends ParametersParameterAcc
 		return (CassandraParameters) super.getParameters();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.repository.query.CassandraParameterAccessor#getValues()
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#getValues()
 	 */
 	@Override
 	public Object[] getValues() {
 		return this.values.toArray();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.repository.query.CassandraParameterAccessor#getQueryOptions()
+	/* (non-Javadoc)
+	 * @see org.springframework.data.cassandra.repository.query.CassandraParameterAccessor#getQueryOptions()
 	 */
 	@Nullable
 	@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/MappingCassandraEntityInformation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/repository/support/MappingCassandraEntityInformation.java
@@ -21,7 +21,7 @@ import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity
 import org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty;
 import org.springframework.data.cassandra.core.mapping.MapId;
 import org.springframework.data.cassandra.repository.query.CassandraEntityInformation;
-import org.springframework.data.repository.core.support.AbstractEntityInformation;
+import org.springframework.data.repository.core.support.PersistentEntityInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -33,7 +33,7 @@ import org.springframework.util.Assert;
  * @author Matthew T. Adams
  * @author Mark Paluch
  */
-public class MappingCassandraEntityInformation<T, ID> extends AbstractEntityInformation<T, ID>
+public class MappingCassandraEntityInformation<T, ID> extends PersistentEntityInformation<T, ID>
 		implements CassandraEntityInformation<T, ID> {
 
 	private final CassandraPersistentEntity<T> entityMetadata;
@@ -47,7 +47,7 @@ public class MappingCassandraEntityInformation<T, ID> extends AbstractEntityInfo
 	 */
 	public MappingCassandraEntityInformation(CassandraPersistentEntity<T> entity, CassandraConverter converter) {
 
-		super(entity.getType());
+		super(entity);
 
 		this.entityMetadata = entity;
 		this.converter = converter;

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBeanUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSessionFactoryBeanUnitTests.java
@@ -16,8 +16,7 @@
 package org.springframework.data.cassandra.config;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.data.cassandra.config.CassandraSessionFactoryBean.*;
 
@@ -29,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.cassandra.core.convert.CassandraConverter;
+import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
@@ -55,6 +55,7 @@ public class CassandraSessionFactoryBeanUnitTests {
 	public void setup() {
 
 		when(mockCluster.connect()).thenReturn(mockSession);
+		when(mockConverter.getMappingContext()).thenReturn(new CassandraMappingContext());
 
 		factoryBean = spy(new CassandraSessionFactoryBean());
 		factoryBean.setCluster(mockCluster);

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/AsyncOptimisticLockingIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/AsyncOptimisticLockingIntegrationTests.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.Data;
+import lombok.experimental.Wither;
+
+import java.util.concurrent.Future;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.cql.CqlTemplate;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.repository.support.SchemaTestUtils;
+import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+
+/**
+ * Integration tests for optimistic locking through {@link AsyncCassandraTemplate}.
+ *
+ * @author Mark Paluch
+ */
+public class AsyncOptimisticLockingIntegrationTests extends AbstractKeyspaceCreatingIntegrationTest {
+
+	AsyncCassandraTemplate template;
+
+	@Before
+	public void setUp() {
+
+		MappingCassandraConverter converter = new MappingCassandraConverter();
+		converter.afterPropertiesSet();
+
+		template = new AsyncCassandraTemplate(session, converter);
+
+		CassandraTemplate syncTemplate = new CassandraTemplate(new CqlTemplate(session), converter);
+
+		SchemaTestUtils.potentiallyCreateTableFor(VersionedEntity.class, syncTemplate);
+		SchemaTestUtils.truncate(VersionedEntity.class, syncTemplate);
+	}
+
+	@Test // DATACASS-576
+	public void shouldInsertVersioned() {
+
+		VersionedEntity versionedEntity = new VersionedEntity(42);
+
+		VersionedEntity saved = getUninterruptibly(template.insert(versionedEntity));
+		VersionedEntity loaded = getUninterruptibly(template.selectOne(Query.empty(), VersionedEntity.class));
+
+		assertThat(saved.version).isEqualTo(1);
+		assertThat(loaded).isNotNull();
+		assertThat(loaded.version).isEqualTo(1);
+	}
+
+	@Test // DATACASS-576
+	public void duplicateInsertShouldFail() {
+
+		getUninterruptibly(template.insert(new VersionedEntity(42)));
+
+		assertThatThrownBy(() -> getUninterruptibly(template.insert(new VersionedEntity(42))))
+				.hasRootCauseInstanceOf(OptimisticLockingFailureException.class);
+	}
+
+	@Test // DATACASS-576
+	public void shouldUpdateVersioned() {
+
+		VersionedEntity versionedEntity = new VersionedEntity(42);
+
+		VersionedEntity saved = getUninterruptibly(template.insert(versionedEntity));
+		VersionedEntity updated = getUninterruptibly(template.update(saved));
+		VersionedEntity loaded = getUninterruptibly(template.selectOne(Query.empty(), VersionedEntity.class));
+
+		assertThat(saved.version).isEqualTo(1);
+		assertThat(updated.version).isEqualTo(2);
+		assertThat(loaded).isNotNull();
+		assertThat(loaded.version).isEqualTo(2);
+	}
+
+	@Test // DATACASS-576
+	public void updateForOutdatedEntityShouldFail() {
+
+		VersionedEntity versionedEntity = new VersionedEntity(42);
+
+		getUninterruptibly(template.insert(versionedEntity));
+		assertThatThrownBy(() -> getUninterruptibly(template.update(new VersionedEntity(42, 5, "f"))))
+				.hasRootCauseInstanceOf(OptimisticLockingFailureException.class);
+	}
+
+	@Test // DATACASS-576
+	public void shouldDeleteVersionedEntity() {
+
+		VersionedEntity versionedEntity = new VersionedEntity(42);
+
+		VersionedEntity saved = getUninterruptibly(template.insert(versionedEntity));
+		getUninterruptibly(template.delete(saved));
+
+		VersionedEntity loaded = getUninterruptibly(template.selectOne(Query.empty(), VersionedEntity.class));
+		assertThat(loaded).isNull();
+	}
+
+	@Test // DATACASS-576
+	public void deleteForOutdatedEntityShouldFail() {
+
+		getUninterruptibly(template.insert(new VersionedEntity(42)));
+
+		assertThatThrownBy(() -> getUninterruptibly(template.delete(new VersionedEntity(42))))
+				.hasRootCauseInstanceOf(OptimisticLockingFailureException.class);
+
+		VersionedEntity loaded = getUninterruptibly(template.selectOne(Query.empty(), VersionedEntity.class));
+		assertThat(loaded).isNotNull();
+	}
+
+	private static <T> T getUninterruptibly(Future<T> future) {
+
+		try {
+			return future.get();
+		} catch (Exception cause) {
+			throw new IllegalStateException(cause);
+		}
+	}
+
+	@Data
+	@Wither
+	static class VersionedEntity {
+
+		@Id final long id;
+
+		@Version final long version;
+
+		final String name;
+
+		public VersionedEntity(long id) {
+			this(id, 0, null);
+		}
+
+		@PersistenceConstructor
+		public VersionedEntity(long id, long version, String name) {
+			this.id = id;
+			this.version = version;
+			this.name = name;
+		}
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/DeleteOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/DeleteOptionsUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,45 +24,41 @@ import org.junit.Test;
 import org.springframework.data.cassandra.core.query.Query;
 
 /**
- * Unit tests for {@link UpdateOptions}.
+ * Unit tests for {@link DeleteOptions}.
  *
  * @author Mark Paluch
- * @author Lukasz Antoniak
  */
-public class UpdateOptionsUnitTests {
+public class DeleteOptionsUnitTests {
 
-	@Test // DATACASS-250, DATACASS-155
-	public void shouldConfigureUpdateOptions() {
+	@Test // DATACASS-575
+	public void shouldConfigureDeleteOptions() {
 
 		Instant now = Instant.ofEpochSecond(1234);
 
-		UpdateOptions updateOptions = UpdateOptions.builder() //
+		DeleteOptions deleteOptions = DeleteOptions.builder() //
 				.ttl(10) //
 				.timestamp(now) //
 				.withIfExists() //
 				.build();
 
-		assertThat(updateOptions.getTtl()).isEqualTo(Duration.ofSeconds(10));
-		assertThat(updateOptions.getTimestamp()).isEqualTo(now.toEpochMilli() * 1000);
-		assertThat(updateOptions.isIfExists()).isTrue();
+		assertThat(deleteOptions.getTtl()).isEqualTo(Duration.ofSeconds(10));
+		assertThat(deleteOptions.getTimestamp()).isEqualTo(now.toEpochMilli() * 1000);
+		assertThat(deleteOptions.isIfExists()).isTrue();
 	}
 
-	@Test // DATACASS-56, DATACASS-155
-	public void buildUpdateOptionsMutate() {
+	@Test // DATACASS-575
+	public void buildDeleteOptionsMutate() {
 
-		UpdateOptions updateOptions = UpdateOptions.builder() //
+		DeleteOptions deleteOptions = DeleteOptions.builder() //
 				.ttl(10) //
 				.timestamp(1519222753) //
 				.withIfExists() //
 				.build();
 
-		UpdateOptions mutated = updateOptions.mutate() //
-				.ttl(20) //
-				.timestamp(1519000753) //
-				.build();
+		DeleteOptions mutated = deleteOptions.mutate().ttl(20).timestamp(1519000753).build();
 
 		assertThat(mutated).isNotNull();
-		assertThat(mutated).isNotSameAs(updateOptions);
+		assertThat(mutated).isNotSameAs(deleteOptions);
 		assertThat(mutated.getTtl()).isEqualTo(Duration.ofSeconds(20));
 		assertThat(mutated.getTimestamp()).isEqualTo(1519000753);
 		assertThat(mutated.isIfExists()).isTrue();
@@ -71,12 +67,12 @@ public class UpdateOptionsUnitTests {
 	@Test // DATACASS-575
 	public void shouldApplyFilterCondition() {
 
-		UpdateOptions updateOptions = UpdateOptions.builder() //
+		DeleteOptions deleteOptions = DeleteOptions.builder() //
 				.withIfExists() //
 				.ifCondition(Query.empty()) //
 				.build();
 
-		assertThat(updateOptions.isIfExists()).isFalse();
-		assertThat(updateOptions.getIfCondition()).isEqualTo(Query.empty());
+		assertThat(deleteOptions.isIfExists()).isFalse();
+		assertThat(deleteOptions.getIfCondition()).isEqualTo(Query.empty());
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/OptimisticLockingIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/OptimisticLockingIntegrationTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.Data;
+import lombok.experimental.Wither;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.repository.support.SchemaTestUtils;
+import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+
+/**
+ * Integration tests for optimistic locking through {@link CassandraTemplate}.
+ *
+ * @author Mark Paluch
+ */
+public class OptimisticLockingIntegrationTests extends AbstractKeyspaceCreatingIntegrationTest {
+
+	CassandraTemplate template;
+
+	@Before
+	public void setUp() {
+
+		MappingCassandraConverter converter = new MappingCassandraConverter();
+		converter.afterPropertiesSet();
+
+		template = new CassandraTemplate(session, converter);
+
+		SchemaTestUtils.potentiallyCreateTableFor(VersionedEntity.class, template);
+		SchemaTestUtils.truncate(VersionedEntity.class, template);
+	}
+
+	@Test // DATACASS-576
+	public void shouldInsertVersioned() {
+
+		VersionedEntity versionedEntity = new VersionedEntity(42);
+
+		VersionedEntity saved = template.insert(versionedEntity);
+		VersionedEntity loaded = template.query(VersionedEntity.class).firstValue();
+
+		assertThat(saved.version).isEqualTo(1);
+		assertThat(loaded).isNotNull();
+		assertThat(loaded.version).isEqualTo(1);
+	}
+
+	@Test // DATACASS-576
+	public void duplicateInsertShouldFail() {
+
+		template.insert(new VersionedEntity(42));
+
+		assertThatThrownBy(() -> template.insert(new VersionedEntity(42)))
+				.isInstanceOf(OptimisticLockingFailureException.class);
+	}
+
+	@Test // DATACASS-576
+	public void shouldUpdateVersioned() {
+
+		VersionedEntity versionedEntity = new VersionedEntity(42);
+
+		VersionedEntity saved = template.insert(versionedEntity);
+		VersionedEntity updated = template.update(saved);
+		VersionedEntity loaded = template.query(VersionedEntity.class).firstValue();
+
+		assertThat(saved.version).isEqualTo(1);
+		assertThat(updated.version).isEqualTo(2);
+		assertThat(loaded).isNotNull();
+		assertThat(loaded.version).isEqualTo(2);
+	}
+
+	@Test // DATACASS-576
+	public void updateForOutdatedEntityShouldFail() {
+
+		VersionedEntity versionedEntity = new VersionedEntity(42);
+
+		template.insert(versionedEntity);
+		assertThatThrownBy(() -> template.update(new VersionedEntity(42, 5, "f")))
+				.isInstanceOf(OptimisticLockingFailureException.class);
+	}
+
+	@Test // DATACASS-576
+	public void shouldDeleteVersionedEntity() {
+
+		VersionedEntity versionedEntity = new VersionedEntity(42);
+
+		VersionedEntity saved = template.insert(versionedEntity);
+		template.delete(saved);
+
+		VersionedEntity loaded = template.query(VersionedEntity.class).firstValue();
+		assertThat(loaded).isNull();
+	}
+
+	@Test // DATACASS-576
+	public void deleteForOutdatedEntityShouldFail() {
+
+		template.insert(new VersionedEntity(42));
+
+		assertThatThrownBy(() -> template.delete(new VersionedEntity(42)))
+				.isInstanceOf(OptimisticLockingFailureException.class);
+
+		VersionedEntity loaded = template.query(VersionedEntity.class).firstValue();
+		assertThat(loaded).isNotNull();
+	}
+
+	@Data
+	@Wither
+	static class VersionedEntity {
+
+		@Id final long id;
+
+		@Version final long version;
+
+		final String name;
+
+		public VersionedEntity(long id) {
+			this(id, 0, null);
+		}
+
+		@PersistenceConstructor
+		public VersionedEntity(long id, long version, String name) {
+			this.id = id;
+			this.version = version;
+			this.name = name;
+		}
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveOptimisticLockingIntegrationTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/ReactiveOptimisticLockingIntegrationTests.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.Data;
+import lombok.experimental.Wither;
+import reactor.test.StepVerifier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.cql.CqlTemplate;
+import org.springframework.data.cassandra.core.cql.session.DefaultBridgedReactiveSession;
+import org.springframework.data.cassandra.core.query.Query;
+import org.springframework.data.cassandra.repository.support.SchemaTestUtils;
+import org.springframework.data.cassandra.test.util.AbstractKeyspaceCreatingIntegrationTest;
+
+/**
+ * Integration tests for optimistic locking through {@link ReactiveCassandraTemplate}.
+ *
+ * @author Mark Paluch
+ */
+public class ReactiveOptimisticLockingIntegrationTests extends AbstractKeyspaceCreatingIntegrationTest {
+
+	ReactiveCassandraTemplate template;
+
+	@Before
+	public void setUp() {
+
+		MappingCassandraConverter converter = new MappingCassandraConverter();
+		converter.afterPropertiesSet();
+
+		template = new ReactiveCassandraTemplate(new DefaultBridgedReactiveSession(session), converter);
+
+		CassandraTemplate syncTemplate = new CassandraTemplate(new CqlTemplate(session), converter);
+
+		SchemaTestUtils.potentiallyCreateTableFor(VersionedEntity.class, syncTemplate);
+		SchemaTestUtils.truncate(VersionedEntity.class, syncTemplate);
+	}
+
+	@Test // DATACASS-576
+	public void shouldInsertVersioned() {
+
+		VersionedEntity versionedEntity = new VersionedEntity(42);
+
+		template.insert(versionedEntity) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual.version).isEqualTo(1);
+				}).verifyComplete();
+
+		template.selectOne(Query.empty(), VersionedEntity.class) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual.version).isEqualTo(1);
+				}).verifyComplete();
+	}
+
+	@Test // DATACASS-576
+	public void duplicateInsertShouldFail() {
+
+		template.insert(new VersionedEntity(42)) //
+				.as(StepVerifier::create) //
+				.expectNextCount(1) //
+				.verifyComplete();
+
+		template.insert(new VersionedEntity(42)) //
+				.as(StepVerifier::create) //
+				.verifyError(OptimisticLockingFailureException.class);
+	}
+
+	@Test // DATACASS-576
+	public void shouldUpdateVersioned() {
+
+		VersionedEntity versionedEntity = new VersionedEntity(42);
+
+		template.insert(versionedEntity).flatMap(template::update) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual.version).isEqualTo(2);
+				}).verifyComplete();
+
+		template.selectOne(Query.empty(), VersionedEntity.class) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual.version).isEqualTo(2);
+				}).verifyComplete();
+	}
+
+	@Test // DATACASS-576
+	public void updateForOutdatedEntityShouldFail() {
+
+		template.insert(new VersionedEntity(42)) //
+				.as(StepVerifier::create) //
+				.expectNextCount(1) //
+				.verifyComplete();
+
+		template.update(new VersionedEntity(42, 5, "f")) //
+				.as(StepVerifier::create) //
+				.verifyError(OptimisticLockingFailureException.class);
+	}
+
+	@Test // DATACASS-576
+	public void shouldDeleteVersionedEntity() {
+
+		VersionedEntity versionedEntity = new VersionedEntity(42);
+
+		template.insert(versionedEntity).flatMap(template::delete) //
+				.as(StepVerifier::create) //
+				.expectNextCount(1) //
+				.verifyComplete();
+
+		template.query(VersionedEntity.class).first() //
+				.as(StepVerifier::create) //
+				.verifyComplete();
+	}
+
+	@Test // DATACASS-576
+	public void deleteForOutdatedEntityShouldFail() {
+
+		template.insert(new VersionedEntity(42))//
+				.as(StepVerifier::create) //
+				.expectNextCount(1) //
+				.verifyComplete();
+
+		template.delete(new VersionedEntity(42)) //
+				.as(StepVerifier::create) //
+				.verifyError(OptimisticLockingFailureException.class);
+
+		template.query(VersionedEntity.class).first() //
+				.as(StepVerifier::create) //
+				.expectNextCount(1) //
+				.verifyComplete();
+	}
+
+	@Data
+	@Wither
+	static class VersionedEntity {
+
+		@Id final long id;
+
+		@Version final long version;
+
+		final String name;
+
+		public VersionedEntity(long id) {
+			this(id, 0, null);
+		}
+
+		@PersistenceConstructor
+		public VersionedEntity(long id, long version, String name) {
+			this.id = id;
+			this.version = version;
+			this.name = name;
+		}
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/CassandraRepositoryFactoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/CassandraRepositoryFactoryUnitTests.java
@@ -43,11 +43,8 @@ import org.springframework.data.repository.Repository;
 public class CassandraRepositoryFactoryUnitTests {
 
 	@Mock CassandraConverter converter;
-
 	@Mock CassandraMappingContext mappingContext;
-
 	@Mock BasicCassandraPersistentEntity entity;
-
 	@Mock CassandraTemplate template;
 
 	@Before

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/CassandraRepositoryFactoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/CassandraRepositoryFactoryUnitTests.java
@@ -61,7 +61,6 @@ public class CassandraRepositoryFactoryUnitTests {
 	public void usesMappingCassandraEntityInformationIfMappingContextSet() {
 
 		when(mappingContext.getRequiredPersistentEntity(Person.class)).thenReturn(entity);
-		when(entity.getType()).thenReturn(Person.class);
 
 		CassandraRepositoryFactory repositoryFactory = new CassandraRepositoryFactory(template);
 
@@ -75,7 +74,6 @@ public class CassandraRepositoryFactoryUnitTests {
 	public void createsRepositoryWithIdTypeLong() {
 
 		when(mappingContext.getRequiredPersistentEntity(Person.class)).thenReturn(entity);
-		when(entity.getType()).thenReturn(Person.class);
 
 		CassandraRepositoryFactory repositoryFactory = new CassandraRepositoryFactory(template);
 		MyPersonRepository repository = repositoryFactory.getRepository(MyPersonRepository.class);

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/ReactiveCassandraRepositoryFactoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/ReactiveCassandraRepositoryFactoryUnitTests.java
@@ -60,7 +60,6 @@ public class ReactiveCassandraRepositoryFactoryUnitTests {
 	public void usesMappingCassandraEntityInformationIfMappingContextSet() {
 
 		when(mappingContext.getRequiredPersistentEntity(Person.class)).thenReturn(entity);
-		when(entity.getType()).thenReturn(Person.class);
 
 		ReactiveCassandraRepositoryFactory repositoryFactory = new ReactiveCassandraRepositoryFactory(template);
 
@@ -74,7 +73,6 @@ public class ReactiveCassandraRepositoryFactoryUnitTests {
 	public void createsRepositoryWithIdTypeLong() {
 
 		when(mappingContext.getRequiredPersistentEntity(Person.class)).thenReturn(entity);
-		when(entity.getType()).thenReturn(Person.class);
 
 		ReactiveCassandraRepositoryFactory repositoryFactory = new ReactiveCassandraRepositoryFactory(template);
 		MyPersonRepository repository = repositoryFactory.getRepository(MyPersonRepository.class);

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/ReactiveCassandraRepositoryFactoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/ReactiveCassandraRepositoryFactoryUnitTests.java
@@ -43,11 +43,8 @@ import org.springframework.data.repository.Repository;
 public class ReactiveCassandraRepositoryFactoryUnitTests {
 
 	@Mock CassandraConverter converter;
-
 	@Mock CassandraMappingContext mappingContext;
-
 	@Mock BasicCassandraPersistentEntity entity;
-
 	@Mock ReactiveCassandraTemplate template;
 
 	@Before

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/SimpleReactiveCassandraRepositoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/SimpleReactiveCassandraRepositoryUnitTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.repository.support;
+
+import static org.mockito.Mockito.*;
+
+import lombok.Data;
+import reactor.core.publisher.Mono;
+
+import java.io.Serializable;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.cassandra.core.EntityWriteResult;
+import org.springframework.data.cassandra.core.InsertOptions;
+import org.springframework.data.cassandra.core.ReactiveCassandraOperations;
+import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
+import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
+import org.springframework.data.cassandra.core.mapping.UserTypeResolver;
+
+import com.datastax.driver.core.UserType;
+import com.datastax.driver.core.querybuilder.Insert;
+
+/**
+ * Unit tests for {@link SimpleReactiveCassandraRepository}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("unchecked")
+public class SimpleReactiveCassandraRepositoryUnitTests {
+
+	CassandraMappingContext mappingContext = new CassandraMappingContext();
+	MappingCassandraConverter converter = new MappingCassandraConverter(mappingContext);
+
+	SimpleReactiveCassandraRepository<Object, ? extends Serializable> repository;
+
+	@Mock ReactiveCassandraOperations cassandraOperations;
+	@Mock UserTypeResolver userTypeResolver;
+	@Mock UserType userType;
+	@Mock EntityWriteResult writeResult;
+
+	@Captor ArgumentCaptor<Insert> insertCaptor;
+
+	@Before
+	public void before() {
+		mappingContext.setUserTypeResolver(userTypeResolver);
+		when(cassandraOperations.getConverter()).thenReturn(converter);
+	}
+
+	@Test // DATACASS-576
+	public void shouldInsertNewVersionedEntity() {
+
+		when(cassandraOperations.insert(any(), any(InsertOptions.class))).thenReturn(Mono.just(writeResult));
+
+		CassandraPersistentEntity<?> entity = converter.getMappingContext()
+				.getRequiredPersistentEntity(VersionedPerson.class);
+
+		repository = new SimpleReactiveCassandraRepository<Object, String>(
+				new MappingCassandraEntityInformation(entity, converter), cassandraOperations);
+
+		VersionedPerson versionedPerson = new VersionedPerson();
+
+		repository.save(versionedPerson);
+
+		verify(cassandraOperations).insert(versionedPerson, InsertOptions.builder().withInsertNulls().build());
+	}
+
+	@Test // DATACASS-576
+	public void shouldUpdateExistingVersionedEntity() {
+
+		CassandraPersistentEntity<?> entity = converter.getMappingContext()
+				.getRequiredPersistentEntity(VersionedPerson.class);
+
+		repository = new SimpleReactiveCassandraRepository<Object, String>(
+				new MappingCassandraEntityInformation(entity, converter), cassandraOperations);
+
+		VersionedPerson versionedPerson = new VersionedPerson();
+		versionedPerson.setVersion(2);
+
+		repository.save(versionedPerson);
+
+		verify(cassandraOperations).update(versionedPerson);
+	}
+
+	@Data
+	static class VersionedPerson {
+
+		@Id String id;
+		@Version long version;
+	}
+
+}

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -3,6 +3,11 @@
 
 This chapter summarizes changes and new features for each release.
 
+[[new-features.2-2-0]]
+== What's new in Spring Data for Apache Cassandra 2.2
+* Lightweight transaction support via `DeleteOptions` using the Template API.
+* Filter conditions for lightweight transaction update and delete (`UPDATE … IF <condition>`, `DELETE … IF <condition>`).
+
 [[new-features.2-1-0]]
 == What's new in Spring Data for Apache Cassandra 2.1
 * New annotations for `@CountQuery` and `@ExistsQuery`.

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -7,6 +7,7 @@ This chapter summarizes changes and new features for each release.
 == What's new in Spring Data for Apache Cassandra 2.2
 * Lightweight transaction support via `DeleteOptions` using the Template API.
 * Filter conditions for lightweight transaction update and delete (`UPDATE … IF <condition>`, `DELETE … IF <condition>`).
+* Optimistic Locking support.
 
 [[new-features.2-1-0]]
 == What's new in Spring Data for Apache Cassandra 2.1

--- a/src/main/asciidoc/reference/cassandra.adoc
+++ b/src/main/asciidoc/reference/cassandra.adoc
@@ -1167,6 +1167,45 @@ You can use the following overloaded methods to remove an object from the databa
 * `T` *delete* `(T entity, QueryOptions queryOptions)`: Deletes the given object applying `QueryOptions`.
 * `boolean` *deleteById* `(Object id, Class<?> entityClass)`: Deletes the object using the given Id.
 
+[[cassandra.template.optimistic-locking]]
+=== Optimistic Locking
+
+The `@Version` annotation provides syntax similar to that of JPA in the context of Cassandra and makes sure updates are only applied to rows with a matching version.
+Optimistic Locking leverages Cassandra's lightweight transactions to conditionally insert, update and delete rows.
+Therefore, `INSERT` statements are executed with the `IF NOT EXISTS` condition.
+For updates and deletes, the actual value of the version property is added to the `UPDATE` condition in such a way that the modification does not have any effect if another operation altered the row in the meantime.
+In that case, an `OptimisticLockingFailureException` is thrown.
+The following example shows these features:
+
+====
+[source,java]
+----
+@Table
+class Person {
+
+  @Id String id;
+  String firstname;
+  String lastname;
+  @Version Long version;
+}
+
+Person daenerys = template.insert(new Person("Daenerys"));                            <1>
+
+Person tmp = template.findOne(query(where("id").is(daenerys.getId())), Person.class); <2>
+
+daenerys.setLastname("Targaryen");
+template.save(daenerys);                                                              <3>
+
+template.save(tmp); // throws OptimisticLockingFailureException                       <4>
+----
+<1> Intially insert document. `version` is set to `0`.
+<2> Load the just inserted document. `version` is still `0`.
+<3> Update the document with `version = 0`. Set the `lastname` and bump `version` to `1`.
+<4> Try to update the previously loaded document that still has `version = 0`. The operation fails with an `OptimisticLockingFailureException`, as the current `version` is `1`.
+====
+
+NOTE: Optimistic Locking is only supported with single-entity operations and not for batch operations.
+
 [[cassandra.template.query]]
 == Querying Rows
 

--- a/src/main/asciidoc/reference/mapping.adoc
+++ b/src/main/asciidoc/reference/mapping.adoc
@@ -426,6 +426,7 @@ Types are derived from the declaration by default.
 * `@Tuple`: Applied at the type level to use a type as a mapped tuple.
 * `@Element`: Applied at the field level to specify element or field ordinals within a mapped tuple.
 Types are derived from the property declaration by default.
+* `@Version`: Applied at field level is used for optimistic locking and checked for modification on save operations. The initial value is `zero` which is bumped automatically on every update.
 
 The mapping metadata infrastructure is defined in the separate, spring-data-commons project that is both
 technology- and data store-agnostic.


### PR DESCRIPTION
We now support Optimistic Locking for insert, update and delete operations leveraging Cassandra's lightweight transaction support. Modifying statements are enhanced with `IF` conditions to conditionally insert and modify rows and to prevent concurrent modifications by throwing `OptimisticLockingFailureException`.

```java
@Table
class Person {

  @Id String id;
  String firstname;
  String lastname;
  @Version Long version;
}

Person daenerys = template.insert(new Person("Daenerys"));

Person tmp = template.findOne(query(where("id").is(daenerys.getId())), Person.class);

daenerys.setLastname("Targaryen");
template.save(daenerys);

template.save(tmp); // throws OptimisticLockingFailureException
```

---

Depends on: [DATACASS-575](https://jira.spring.io/browse/DATACASS-575), #135.
Related ticket: [DATACASS-576](https://jira.spring.io/browse/DATACASS-576).