### PR TITLE
DATACASS-631 - Deprecate Kotlin extensions providing a KClass overload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACASS-631-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATACASS-631-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.2.0.DATACASS-631-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/AsyncCassandraOperationsExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/AsyncCassandraOperationsExtensions.kt
@@ -36,6 +36,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [AsyncCassandraOperations.select] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(cql)"))
 fun <T : Any> AsyncCassandraOperations.select(cql: String, entityClass: KClass<T>): ListenableFuture<List<T>> =
 		select(cql, entityClass.java)
 
@@ -48,6 +49,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.select(cql: String): Liste
 /**
  * Extension for [AsyncCassandraOperations.select] providing a Consumer-like function.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(cql, consumer)"))
 fun <T : Any> AsyncCassandraOperations.select(cql: String, entityClass: KClass<T>, consumer: (T) -> Unit): ListenableFuture<Void> =
 		select(cql, consumer, entityClass.java)
 
@@ -60,6 +62,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.select(cql: String, crossi
 /**
  * Extension for [AsyncCassandraOperations.selectOne] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOne<T>(cql)"))
 fun <T : Any> AsyncCassandraOperations.selectOne(cql: String, entityClass: KClass<T>): ListenableFuture<T?> =
 		selectOne(cql, entityClass.java)
 
@@ -76,6 +79,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.selectOne(cql: String): Li
 /**
  * Extension for [AsyncCassandraOperations.select] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(statement)"))
 fun <T : Any> AsyncCassandraOperations.select(statement: Statement, entityClass: KClass<T>): ListenableFuture<List<T>> =
 		select(statement, entityClass.java)
 
@@ -88,6 +92,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.select(statement: Statemen
 /**
  * Extension for [AsyncCassandraOperations.select] providing a Consumer-like function.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(statement, consumer)"))
 fun <T : Any> AsyncCassandraOperations.select(statement: Statement, entityClass: KClass<T>, consumer: (T) -> Unit): ListenableFuture<Void> =
 		select(statement, consumer, entityClass.java)
 
@@ -100,6 +105,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.select(statement: Statemen
 /**
  * Extension for [AsyncCassandraOperations.slice] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("slice<T>(statement)"))
 fun <T : Any> AsyncCassandraOperations.slice(statement: Statement, entityClass: KClass<T>): ListenableFuture<Slice<T>> =
 		slice(statement, entityClass.java)
 
@@ -112,6 +118,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.slice(statement: Statement
 /**
  * Extension for [AsyncCassandraOperations.selectOne] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOne<T>(statement)"))
 fun <T : Any> AsyncCassandraOperations.selectOne(statement: Statement, entityClass: KClass<T>): ListenableFuture<T?> =
 		selectOne(statement, entityClass.java)
 
@@ -128,6 +135,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.selectOne(statement: State
 /**
  * Extension for [AsyncCassandraOperations.select] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(query)"))
 fun <T : Any> AsyncCassandraOperations.select(query: Query, entityClass: KClass<T>): ListenableFuture<List<T>> =
 		select(query, entityClass.java)
 
@@ -140,18 +148,21 @@ inline fun <reified T : Any> AsyncCassandraOperations.select(query: Query): List
 /**
  * Extension for [AsyncCassandraOperations.select] providing a Consumer-like function.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(query, consumer)"))
 fun <T : Any> AsyncCassandraOperations.select(query: Query, entityClass: KClass<T>, consumer: (T) -> Unit): ListenableFuture<Void> =
 		select(query, consumer, entityClass.java)
 
 /**
  * Extension for [AsyncCassandraOperations.select] providing a Consumer-like function leveraging reified type parameters.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(query, consumer)"))
 inline fun <reified T : Any> AsyncCassandraOperations.select(query: Query, crossinline consumer: (T) -> Unit): ListenableFuture<Void> =
 		select(query, { consumer(it) }, T::class.java)
 
 /**
  * Extension for [AsyncCassandraOperations.slice] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("slice<T>(query)"))
 fun <T : Any> AsyncCassandraOperations.slice(query: Query, entityClass: KClass<T>): ListenableFuture<Slice<T>> =
 		slice(query, entityClass.java)
 
@@ -164,6 +175,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.slice(query: Query): Liste
 /**
  * Extension for [AsyncCassandraOperations.selectOne] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOne<T>(query)"))
 fun <T : Any> AsyncCassandraOperations.selectOne(query: Query, entityClass: KClass<T>): ListenableFuture<T?> =
 		selectOne(query, entityClass.java)
 
@@ -176,6 +188,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.selectOne(query: Query): L
 /**
  * Extension for [AsyncCassandraOperations.update] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("update<T>(query, update)"))
 fun <T : Any> AsyncCassandraOperations.update(query: Query, update: Update, entityClass: KClass<T>): ListenableFuture<Boolean> =
 		update(query, update, entityClass.java)
 
@@ -188,6 +201,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.update(query: Query, updat
 /**
  * Extension for [AsyncCassandraOperations.delete] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("delete<T>(query)"))
 fun <T : Any> AsyncCassandraOperations.delete(query: Query, entityClass: KClass<T>): ListenableFuture<Boolean> =
 		delete(query, entityClass.java)
 
@@ -205,6 +219,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.delete(query: Query): List
 /**
  * Extension for [AsyncCassandraOperations.count] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("count<T>()"))
 fun <T : Any> AsyncCassandraOperations.count(entityClass: KClass<T>): ListenableFuture<Long> =
 		count(entityClass.java)
 
@@ -217,6 +232,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.count(): ListenableFuture<
 /**
  * Extension for [AsyncCassandraOperations.count] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("count<T>(query)"))
 fun <T : Any> AsyncCassandraOperations.count(query: Query, entityClass: KClass<T>): ListenableFuture<Long> =
 		count(query, entityClass.java)
 
@@ -229,6 +245,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.count(query: Query): Liste
 /**
  * Extension for [AsyncCassandraOperations.exists] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("exists<T>(id)"))
 fun <T : Any> AsyncCassandraOperations.exists(id: Any, entityClass: KClass<T>): ListenableFuture<Boolean> =
 		exists(id, entityClass.java)
 
@@ -236,11 +253,12 @@ fun <T : Any> AsyncCassandraOperations.exists(id: Any, entityClass: KClass<T>): 
  * Extension for [AsyncCassandraOperations.exists] leveraging reified type parameters.
  */
 inline fun <reified T : Any> AsyncCassandraOperations.exists(id: Any): ListenableFuture<Boolean> =
-		exists(id, T::class)
+		exists(id, T::class.java)
 
 /**
  * Extension for [AsyncCassandraOperations.count] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("exists<T>(query)"))
 fun <T : Any> AsyncCassandraOperations.exists(query: Query, entityClass: KClass<T>): ListenableFuture<Boolean> =
 		exists(query, entityClass.java)
 
@@ -253,6 +271,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.exists(query: Query): List
 /**
  * Extension for [AsyncCassandraOperations.selectOneById] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOneById<T>(id)"))
 fun <T : Any> AsyncCassandraOperations.selectOneById(id: Any, entityClass: KClass<T>): ListenableFuture<T?> =
 		selectOneById(id, entityClass.java)
 
@@ -265,6 +284,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.selectOneById(id: Any): Li
 /**
  * Extension for [AsyncCassandraOperations.deleteById] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("deleteById<T>(id)"))
 fun <T : Any> AsyncCassandraOperations.deleteById(id: Any, entityClass: KClass<T>): ListenableFuture<Boolean> =
 		deleteById(id, entityClass.java)
 
@@ -277,6 +297,7 @@ inline fun <reified T : Any> AsyncCassandraOperations.deleteById(id: Any): Liste
 /**
  * Extension for [AsyncCassandraOperations.truncate] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("truncate<T>()"))
 fun <T : Any> AsyncCassandraOperations.truncate(entityClass: KClass<T>): ListenableFuture<Void> =
 		truncate(entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/CassandraOperationsExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/CassandraOperationsExtensions.kt
@@ -33,6 +33,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [CassandraOperations.getTableName] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("getTableName<T>()"))
 fun <T : Any> CassandraOperations.getTableName(entityClass: KClass<T>): CqlIdentifier =
 		getTableName(entityClass.java)
 
@@ -49,6 +50,7 @@ inline fun <reified T : Any> CassandraOperations.getTableName(): CqlIdentifier =
 /**
  * Extension for [CassandraOperations.select] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(cql)"))
 fun <T : Any> CassandraOperations.select(cql: String, entityClass: KClass<T>): List<T> =
 		select(cql, entityClass.java)
 
@@ -61,6 +63,7 @@ inline fun <reified T : Any> CassandraOperations.select(cql: String): List<T> =
 /**
  * Extension for [CassandraOperations.stream] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("stream<T>(cql)"))
 fun <T : Any> CassandraOperations.stream(cql: String, entityClass: KClass<T>): Stream<T> =
 		stream(cql, entityClass.java)
 
@@ -73,6 +76,7 @@ inline fun <reified T : Any> CassandraOperations.stream(cql: String): Stream<T> 
 /**
  * Extension for [CassandraOperations.selectOne] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOne<T>(cql)"))
 fun <T : Any> CassandraOperations.selectOne(cql: String, entityClass: KClass<T>): T? =
 		selectOne(cql, entityClass.java)
 
@@ -89,6 +93,7 @@ inline fun <reified T : Any> CassandraOperations.selectOne(cql: String): T? =
 /**
  * Extension for [CassandraOperations.select] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(statement)"))
 fun <T : Any> CassandraOperations.select(statement: Statement, entityClass: KClass<T>): List<T> =
 		select(statement, entityClass.java)
 
@@ -101,6 +106,7 @@ inline fun <reified T : Any> CassandraOperations.select(statement: Statement): L
 /**
  * Extension for [CassandraOperations.slice] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("slice<T>(statement)"))
 fun <T : Any> CassandraOperations.slice(statement: Statement, entityClass: KClass<T>): Slice<T> =
 		slice(statement, entityClass.java)
 
@@ -113,6 +119,7 @@ inline fun <reified T : Any> CassandraOperations.slice(statement: Statement): Sl
 /**
  * Extension for [CassandraOperations.stream] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("stream<T>(statement)"))
 fun <T : Any> CassandraOperations.stream(statement: Statement, entityClass: KClass<T>): Stream<T> =
 		stream(statement, entityClass.java)
 
@@ -125,6 +132,7 @@ inline fun <reified T : Any> CassandraOperations.stream(statement: Statement): S
 /**
  * Extension for [CassandraOperations.selectOne] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOne<T>(statement)"))
 fun <T : Any> CassandraOperations.selectOne(statement: Statement, entityClass: KClass<T>): T? =
 		selectOne(statement, entityClass.java)
 
@@ -141,6 +149,7 @@ inline fun <reified T : Any> CassandraOperations.selectOne(statement: Statement)
 /**
  * Extension for [CassandraOperations.select] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(query)"))
 fun <T : Any> CassandraOperations.select(query: Query, entityClass: KClass<T>): List<T> =
 		select(query, entityClass.java)
 
@@ -153,6 +162,7 @@ inline fun <reified T : Any> CassandraOperations.select(query: Query): List<T> =
 /**
  * Extension for [CassandraOperations.slice] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("slice<T>(query)"))
 fun <T : Any> CassandraOperations.slice(query: Query, entityClass: KClass<T>): Slice<T> =
 		slice(query, entityClass.java)
 
@@ -165,6 +175,7 @@ inline fun <reified T : Any> CassandraOperations.slice(query: Query): Slice<T> =
 /**
  * Extension for [CassandraOperations.stream] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("stream<T>(query)"))
 fun <T : Any> CassandraOperations.stream(query: Query, entityClass: KClass<T>): Stream<T> =
 		stream(query, entityClass.java)
 
@@ -177,6 +188,7 @@ inline fun <reified T : Any> CassandraOperations.stream(query: Query): Stream<T>
 /**
  * Extension for [CassandraOperations.selectOne] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOne<T>(query)"))
 fun <T : Any> CassandraOperations.selectOne(query: Query, entityClass: KClass<T>): T? =
 		selectOne(query, entityClass.java)
 
@@ -189,6 +201,7 @@ inline fun <reified T : Any> CassandraOperations.selectOne(query: Query): T? =
 /**
  * Extension for [CassandraOperations.update] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("update<T>(query, update)"))
 fun <T : Any> CassandraOperations.update(query: Query, update: Update, entityClass: KClass<T>): Boolean =
 		update(query, update, entityClass.java)
 
@@ -201,6 +214,7 @@ inline fun <reified T : Any> CassandraOperations.update(query: Query, update: Up
 /**
  * Extension for [CassandraOperations.delete] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("delete<T>(query)"))
 fun <T : Any> CassandraOperations.delete(query: Query, entityClass: KClass<T>): Boolean =
 		delete(query, entityClass.java)
 
@@ -218,6 +232,7 @@ inline fun <reified T : Any> CassandraOperations.delete(query: Query): Boolean =
 /**
  * Extension for [CassandraOperations.count] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("count<T>()"))
 fun <T : Any> CassandraOperations.count(entityClass: KClass<T>): Long =
 		count(entityClass.java)
 
@@ -230,6 +245,7 @@ inline fun <reified T : Any> CassandraOperations.count(): Long =
 /**
  * Extension for [CassandraOperations.count] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("count<T>(query)"))
 fun <T : Any> CassandraOperations.count(query: Query, entityClass: KClass<T>): Long =
 		count(query, entityClass.java)
 
@@ -242,6 +258,7 @@ inline fun <reified T : Any> CassandraOperations.count(query: Query): Long =
 /**
  * Extension for [CassandraOperations.exists] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("exists<T>(id)"))
 fun <T : Any> CassandraOperations.exists(id: Any, entityClass: KClass<T>): Boolean =
 		exists(id, entityClass.java)
 
@@ -249,11 +266,12 @@ fun <T : Any> CassandraOperations.exists(id: Any, entityClass: KClass<T>): Boole
  * Extension for [CassandraOperations.exists] leveraging reified type parameters.
  */
 inline fun <reified T : Any> CassandraOperations.exists(id: Any): Boolean =
-		exists(id, T::class)
+		exists(id, T::class.java)
 
 /**
  * Extension for [CassandraOperations.count] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("exists<T>(query)"))
 fun <T : Any> CassandraOperations.exists(query: Query, entityClass: KClass<T>): Boolean =
 		exists(query, entityClass.java)
 
@@ -266,6 +284,7 @@ inline fun <reified T : Any> CassandraOperations.exists(query: Query): Boolean =
 /**
  * Extension for [CassandraOperations.selectOneById] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOneById<T>(id)"))
 fun <T : Any> CassandraOperations.selectOneById(id: Any, entityClass: KClass<T>): T? =
 		selectOneById(id, entityClass.java)
 
@@ -278,6 +297,7 @@ inline fun <reified T : Any> CassandraOperations.selectOneById(id: Any): T? =
 /**
  * Extension for [CassandraOperations.deleteById] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("deleteById<T>(id)"))
 fun <T : Any> CassandraOperations.deleteById(id: Any, entityClass: KClass<T>): Boolean =
 		deleteById(id, entityClass.java)
 
@@ -290,6 +310,7 @@ inline fun <reified T : Any> CassandraOperations.deleteById(id: Any): Boolean =
 /**
  * Extension for [CassandraOperations.truncate] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("truncate<T>()"))
 fun <T : Any> CassandraOperations.truncate(entityClass: KClass<T>): Unit =
 		truncate(entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ExecutableDeleteOperationExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ExecutableDeleteOperationExtensions.kt
@@ -27,6 +27,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [ExecutableRemoveOperation.delete] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("delete<T>()"))
 fun <T : Any> ExecutableDeleteOperation.delete(entityClass: KClass<T>): ExecutableDeleteOperation.ExecutableDelete =
 		delete(entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ExecutableInsertOperationExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ExecutableInsertOperationExtensions.kt
@@ -27,6 +27,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [ExecutableInsertOperation.insert] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("insert<T>()"))
 fun <T : Any> ExecutableInsertOperation.insert(entityClass: KClass<T>): ExecutableInsertOperation.ExecutableInsert<T> =
 		insert(entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ExecutableSelectOperationExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ExecutableSelectOperationExtensions.kt
@@ -27,6 +27,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [ExecutableSelectOperation.query] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("query<T>()"))
 fun <T : Any> ExecutableSelectOperation.query(entityClass: KClass<T>): ExecutableSelectOperation.ExecutableSelect<T> =
 		query(entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ExecutableUpdateOperationExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ExecutableUpdateOperationExtensions.kt
@@ -27,6 +27,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [ExecutableUpdateOperation.update] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("update<T>()"))
 fun <T : Any> ExecutableUpdateOperation.update(entityClass: KClass<T>): ExecutableUpdateOperation.ExecutableUpdate =
 		update(entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ReactiveCassandraOperationsExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ReactiveCassandraOperationsExtensions.kt
@@ -36,6 +36,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [ReactiveCassandraOperations.select] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(cql)"))
 fun <T : Any> ReactiveCassandraOperations.select(cql: String, entityClass: KClass<T>): Flux<T> =
 		select(cql, entityClass.java)
 
@@ -48,6 +49,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.select(cql: String): Fl
 /**
  * Extension for [ReactiveCassandraOperations.selectOne] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOne<T>(cql)"))
 fun <T : Any> ReactiveCassandraOperations.selectOne(cql: String, entityClass: KClass<T>): Mono<T> =
 		selectOne(cql, entityClass.java)
 
@@ -64,6 +66,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.selectOne(cql: String):
 /**
  * Extension for [ReactiveCassandraOperations.select] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(statement)"))
 fun <T : Any> ReactiveCassandraOperations.select(statement: Statement, entityClass: KClass<T>): Flux<T> =
 		select(statement, entityClass.java)
 
@@ -76,6 +79,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.select(statement: State
 /**
  * Extension for [ReactiveCassandraOperations.selectOne] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOne<T>(statement)"))
 fun <T : Any> ReactiveCassandraOperations.selectOne(statement: Statement, entityClass: KClass<T>): Mono<T> =
 		selectOne(statement, entityClass.java)
 
@@ -92,6 +96,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.selectOne(statement: St
 /**
  * Extension for [ReactiveCassandraOperations.select] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("select<T>(query)"))
 fun <T : Any> ReactiveCassandraOperations.select(query: Query, entityClass: KClass<T>): Flux<T> =
 		select(query, entityClass.java)
 
@@ -104,6 +109,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.select(query: Query): F
 /**
  * Extension for [ReactiveCassandraOperations.selectOne] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOne<T>(query)"))
 fun <T : Any> ReactiveCassandraOperations.selectOne(query: Query, entityClass: KClass<T>): Mono<T> =
 		selectOne(query, entityClass.java)
 
@@ -116,6 +122,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.selectOne(query: Query)
 /**
  * Extension for [ReactiveCassandraOperations.update] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("update<T>(query, update)"))
 fun <T : Any> ReactiveCassandraOperations.update(query: Query, update: Update, entityClass: KClass<T>): Mono<Boolean> =
 		update(query, update, entityClass.java)
 
@@ -128,6 +135,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.update(query: Query, up
 /**
  * Extension for [ReactiveCassandraOperations.delete] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("delete<T>(query)"))
 fun <T : Any> ReactiveCassandraOperations.delete(query: Query, entityClass: KClass<T>): Mono<Boolean> =
 		delete(query, entityClass.java)
 
@@ -145,6 +153,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.delete(query: Query): M
 /**
  * Extension for [ReactiveCassandraOperations.count] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("count<T>()"))
 fun <T : Any> ReactiveCassandraOperations.count(entityClass: KClass<T>): Mono<Long> =
 		count(entityClass.java)
 
@@ -157,6 +166,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.count(): Mono<Long> =
 /**
  * Extension for [ReactiveCassandraOperations.count] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("count<T>(query)"))
 fun <T : Any> ReactiveCassandraOperations.count(query: Query, entityClass: KClass<T>): Mono<Long> =
 		count(query, entityClass.java)
 
@@ -169,6 +179,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.count(query: Query): Mo
 /**
  * Extension for [ReactiveCassandraOperations.exists] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("exists<T>(id)"))
 fun <T : Any> ReactiveCassandraOperations.exists(id: Any, entityClass: KClass<T>): Mono<Boolean> =
 		exists(id, entityClass.java)
 
@@ -181,6 +192,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.exists(id: Any): Mono<B
 /**
  * Extension for [ReactiveCassandraOperations.count] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("exists<T>(query)"))
 fun <T : Any> ReactiveCassandraOperations.exists(query: Query, entityClass: KClass<T>): Mono<Boolean> =
 		exists(query, entityClass.java)
 
@@ -193,6 +205,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.exists(query: Query): M
 /**
  * Extension for [ReactiveCassandraOperations.selectOneById] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("selectOneById<T>(id)"))
 fun <T : Any> ReactiveCassandraOperations.selectOneById(id: Any, entityClass: KClass<T>): Mono<T> =
 		selectOneById(id, entityClass.java)
 
@@ -205,6 +218,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.selectOneById(id: Any):
 /**
  * Extension for [ReactiveCassandraOperations.deleteById] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("deleteById<T>(id)"))
 fun <T : Any> ReactiveCassandraOperations.deleteById(id: Any, entityClass: KClass<T>): Mono<Boolean> =
 		deleteById(id, entityClass.java)
 
@@ -217,6 +231,7 @@ inline fun <reified T : Any> ReactiveCassandraOperations.deleteById(id: Any): Mo
 /**
  * Extension for [ReactiveCassandraOperations.truncate] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("truncate<T>()"))
 fun <T : Any> ReactiveCassandraOperations.truncate(entityClass: KClass<T>): Mono<Void> =
 		truncate(entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ReactiveDeleteOperationExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ReactiveDeleteOperationExtensions.kt
@@ -27,6 +27,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [ReactiveDeleteOperation.delete] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("delete<T>()"))
 fun <T : Any> ReactiveDeleteOperation.delete(entityClass: KClass<T>): ReactiveDeleteOperation.ReactiveDelete =
 		delete(entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ReactiveInsertOperationExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ReactiveInsertOperationExtensions.kt
@@ -27,6 +27,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [ReactiveInsertOperation.insert] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("insert<T>()"))
 fun <T : Any> ReactiveInsertOperation.insert(entityClass: KClass<T>): ReactiveInsertOperation.ReactiveInsert<T> =
 		insert(entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ReactiveSelectOperationExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ReactiveSelectOperationExtensions.kt
@@ -27,6 +27,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [ReactiveSelectOperation.query] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("query<T>()"))
 fun <T : Any> ReactiveSelectOperation.query(entityClass: KClass<T>): ReactiveSelectOperation.ReactiveSelect<T> =
 		query(entityClass.java)
 
@@ -39,6 +40,7 @@ inline fun <reified T : Any> ReactiveSelectOperation.query(): ReactiveSelectOper
 /**
  * Extension for [ReactiveSelectOperation.SelectWithProjection. as] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("asType<T>()"))
 fun <T : Any> ReactiveSelectOperation.SelectWithProjection<*>.asType(resultType: KClass<T>): ReactiveSelectOperation.SelectWithQuery<T> =
 		`as`(resultType.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ReactiveUpdateOperationExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/ReactiveUpdateOperationExtensions.kt
@@ -27,6 +27,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [ReactiveUpdateOperation.update] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("update<T>()"))
 fun <T : Any> ReactiveUpdateOperation.update(entityClass: KClass<T>): ReactiveUpdateOperation.ReactiveUpdate =
 		update(entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/cql/AsyncCqlOperationsExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/cql/AsyncCqlOperationsExtensions.kt
@@ -31,6 +31,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [AsyncCqlOperations.queryForObject] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForObject<T>(cql)"))
 fun <T : Any> AsyncCqlOperations.queryForObject(cql: String, entityClass: KClass<T>): ListenableFuture<T?> =
 		queryForObject(cql, entityClass.java)
 
@@ -43,6 +44,7 @@ inline fun <reified T : Any> AsyncCqlOperations.queryForObject(cql: String): Lis
 /**
  * Extension for [AsyncCqlOperations.queryForObject] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForObject<T>(cql, args)"))
 fun <T : Any> AsyncCqlOperations.queryForObject(cql: String, entityClass: KClass<T>, vararg args: Any): ListenableFuture<T?> =
 		queryForObject(cql, entityClass.java, args)
 
@@ -61,6 +63,7 @@ fun <T : Any> AsyncCqlOperations.queryForObject(cql: String, vararg args: Any, f
 /**
  * Extension for [AsyncCqlOperations.queryForObject] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForObject<T>(statement)"))
 fun <T : Any> AsyncCqlOperations.queryForObject(statement: Statement, entityClass: KClass<T>): ListenableFuture<T?> =
 		queryForObject(statement, entityClass.java)
 
@@ -87,6 +90,7 @@ inline fun <reified T : Any> AsyncCqlOperations.queryForList(cql: String, vararg
 /**
  * Extension for [AsyncCqlOperations.queryForList] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForList<T>(statement)"))
 fun <T : Any> AsyncCqlOperations.queryForList(statement: Statement, entityClass: KClass<T>): ListenableFuture<List<T>> =
 		queryForList(statement, entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/cql/CqlOperationsExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/cql/CqlOperationsExtensions.kt
@@ -30,6 +30,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [CqlOperations.queryForObject] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForObject<T>(cql)"))
 fun <T : Any> CqlOperations.queryForObject(cql: String, entityClass: KClass<T>): T? =
 		queryForObject(cql, entityClass.java)
 
@@ -42,6 +43,7 @@ inline fun <reified T : Any> CqlOperations.queryForObject(cql: String): T? =
 /**
  * Extension for [CqlOperations.queryForObject] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForObject<T>(cql, args)"))
 fun <T : Any> CqlOperations.queryForObject(cql: String, entityClass: KClass<T>, vararg args: Any): T? =
 		queryForObject(cql, entityClass.java, args)
 
@@ -60,6 +62,7 @@ fun <T : Any> CqlOperations.queryForObject(cql: String, vararg args: Any, functi
 /**
  * Extension for [CqlOperations.queryForObject] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForObject<T>(statement)"))
 fun <T : Any> CqlOperations.queryForObject(statement: Statement, entityClass: KClass<T>): T? =
 		queryForObject(statement, entityClass.java)
 
@@ -86,6 +89,7 @@ inline fun <reified T : Any> CqlOperations.queryForList(cql: String, vararg args
 /**
  * Extension for [CqlOperations.queryForList] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForList<T>(statement)"))
 fun <T : Any> CqlOperations.queryForList(statement: Statement, entityClass: KClass<T>): List<T> =
 		queryForList(statement, entityClass.java)
 

--- a/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/cql/ReactiveCqlOperationsExtensions.kt
+++ b/spring-data-cassandra/src/main/kotlin/org/springframework/data/cassandra/core/cql/ReactiveCqlOperationsExtensions.kt
@@ -33,6 +33,7 @@ import kotlin.reflect.KClass
 /**
  * Extension for [ReactiveCqlOperations.queryForObject] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForObject<T>(cql)"))
 fun <T : Any> ReactiveCqlOperations.queryForObject(cql: String, entityClass: KClass<T>): Mono<T> =
 		queryForObject(cql, entityClass.java)
 
@@ -45,6 +46,7 @@ inline fun <reified T : Any> ReactiveCqlOperations.queryForObject(cql: String): 
 /**
  * Extension for [ReactiveCqlOperations.queryForObject] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForObject<T>(cql, args)"))
 fun <T : Any> ReactiveCqlOperations.queryForObject(cql: String, entityClass: KClass<T>, vararg args: Any): Mono<T> =
 		queryForObject(cql, entityClass.java, args)
 
@@ -63,6 +65,7 @@ fun <T : Any> ReactiveCqlOperations.queryForObject(cql: String, vararg args: Any
 /**
  * Extension for [ReactiveCqlOperations.queryForObject] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForObject<T>(statement)"))
 fun <T : Any> ReactiveCqlOperations.queryForObject(statement: Statement, entityClass: KClass<T>): Mono<T> =
 		queryForObject(statement, entityClass.java)
 
@@ -89,6 +92,7 @@ inline fun <reified T : Any> ReactiveCqlOperations.queryForFlux(cql: String, var
 /**
  * Extension for [ReactiveCqlOperations.queryForFlux] providing a [KClass] based variant.
  */
+@Deprecated("Since 2.2, use the reified variant", replaceWith = ReplaceWith("queryForFlux<T>(statement)"))
 fun <T : Any> ReactiveCqlOperations.queryForFlux(statement: Statement, entityClass: KClass<T>): Flux<T> =
 		queryForFlux(statement, entityClass.java)
 


### PR DESCRIPTION
We promote the usage of reified Kotlin API usage (`myMethod<Person>()` instead of `myMethod(Person::class)`) to facilitate a single and more idiomatic approach to Kotlin API usage.

Extension methods accepting `KClass` are deprecated now.

---

Related ticket: [DATACASS-631](https://jira.spring.io/browse/DATACASS-631).