### PR TITLE
URL Cleanup

### DIFF
--- a/attic/gradle/build.gradle
+++ b/attic/gradle/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        maven { url 'http://repo.springsource.org/plugins-release' }
+        maven { url 'https://repo.springsource.org/plugins-release' }
     }
     dependencies {
         classpath 'org.springframework.build.gradle:bundlor-plugin:0.1.2'
@@ -12,9 +12,9 @@ description = 'Spring Data Cassandra'
 group = 'org.springframework.data'
 
 repositories {
-  maven { url "http://repo1.maven.org/maven2" }
-  maven { url "http://repo.springsource.org/libs-snapshot" }
-  maven { url "http://repo.springsource.org/plugins-release" }
+  maven { url "https://repo1.maven.org/maven2" }
+  maven { url "https://repo.springsource.org/libs-snapshot" }
+  maven { url "https://repo.springsource.org/plugins-release" }
   maven { url "repo" }
 }
 
@@ -87,9 +87,9 @@ javadoc {
       ]
 
      links = [
-        "http://static.springframework.org/spring/docs/3.0.x/javadoc-api",
-        "http://download.oracle.com/javase/6/docs/api",
-        "http://jackson.codehaus.org/1.8.2/javadoc"
+        "https://docs.spring.io/spring/docs/3.0.x/javadoc-api",
+        "https://download.oracle.com/javase/6/docs/api",
+        "https://jackson.codehaus.org/1.8.2/javadoc"
      ]
 
      exclude "org/springframework/data/cassandra/config/**"

--- a/attic/gradle/maven.gradle
+++ b/attic/gradle/maven.gradle
@@ -31,20 +31,20 @@ def customizePom(pom, gradleProject) {
         generatedPom.project {
             name = gradleProject.description
             description = gradleProject.description
-            url = 'http://github.com/shvid/spring-data-cassandra'
+            url = 'https://github.com/shvid/spring-data-cassandra'
             organization {
                 name = 'Mirantis'
-                url = 'http://www.mirantis.com/spring-data/cassandra'
+                url = 'https://www.mirantis.com/spring-data/cassandra'
             }
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }
             scm {
-                url = 'http://github.com/shvid/spring-data-cassandra'
+                url = 'https://github.com/shvid/spring-data-cassandra'
                 connection = 'scm:git:git://github.com/shvid/spring-data-cassandra'
                 developerConnection = 'scm:git:git://github.com/shvid/spring-data-cassandra'
             }

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -10,7 +10,7 @@
 
 	<name>Spring Data Cassandra</name>
 	<description>Spring Data Cassandra</description>
-	<url>http://www.springsource.org/spring-data/cassandra</url>
+	<url>https://www.springsource.org/spring-data/cassandra</url>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>

--- a/spring-cql/pom.xml
+++ b/spring-cql/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.prowaveconsulting.com (200) with 1 occurrences could not be migrated:  
   ([https](https://www.prowaveconsulting.com) result SSLHandshakeException).
* http://www.scispike.com (200) with 1 occurrences could not be migrated:  
   ([https](https://www.scispike.com) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://jackson.codehaus.org/1.8.2/javadoc (UnknownHostException) with 1 occurrences migrated to:  
  https://jackson.codehaus.org/1.8.2/javadoc ([https](https://jackson.codehaus.org/1.8.2/javadoc) result UnknownHostException).
* http://www.mirantis.com/spring-data/cassandra (301) with 1 occurrences migrated to:  
  https://www.mirantis.com/spring-data/cassandra ([https](https://www.mirantis.com/spring-data/cassandra) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 4 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://static.springframework.org/spring/docs/3.0.x/javadoc-api (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/javadoc-api ([https](https://static.springframework.org/spring/docs/3.0.x/javadoc-api) result 301).
* http://github.com/shvid/spring-data-cassandra with 2 occurrences migrated to:  
  https://github.com/shvid/spring-data-cassandra ([https](https://github.com/shvid/spring-data-cassandra) result 301).
* http://repo.springsource.org/libs-snapshot with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://repo.springsource.org/plugins-release with 2 occurrences migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://download.oracle.com/javase/6/docs/api with 1 occurrences migrated to:  
  https://download.oracle.com/javase/6/docs/api ([https](https://download.oracle.com/javase/6/docs/api) result 302).
* http://repo1.maven.org/maven2 with 1 occurrences migrated to:  
  https://repo1.maven.org/maven2 ([https](https://repo1.maven.org/maven2) result 302).
* http://www.springsource.org/spring-data/cassandra with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data/cassandra ([https](https://www.springsource.org/spring-data/cassandra) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 8 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences