### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
 
 	<name>Spring Data for Apache Cassandra</name>
 	<description>Spring Data for Apache Cassandra</description>
-	<url>http://projects.spring.io/spring-data-cassandra/</url>
+	<url>https://projects.spring.io/spring-data-cassandra/</url>
 
 	<developers>
 		<developer>
@@ -58,7 +58,7 @@
 			<name>John Blum</name>
 			<email>jblum at pivotal.io</email>
 			<organization>Pivotal</organization>
-			<organizationUrl>http://www.pivotal.io</organizationUrl>
+			<organizationUrl>https://www.pivotal.io</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>
@@ -69,7 +69,7 @@
 			<name>Mark Paluch</name>
 			<email>mpaluch at pivotal.io</email>
 			<organization>Pivotal</organization>
-			<organizationUrl>http://www.pivotal.io</organizationUrl>
+			<organizationUrl>https://www.pivotal.io</organizationUrl>
 			<roles>
 				<role>Developer</role>
 			</roles>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-data-cassandra/src/test/resources/config/spring-data-cassandra-basic.xml
+++ b/spring-data-cassandra/src/test/resources/config/spring-data-cassandra-basic.xml
@@ -4,9 +4,9 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
-		http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
 ">
 
 	<bean name="randomKeyspaceName" class="java.lang.String">

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/CassandraNamespaceIntegrationTests-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/CassandraNamespaceIntegrationTests-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:cql="http://www.springframework.org/schema/cql"
-	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/cql http://www.springframework.org/schema/cql/spring-cql.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/cql https://www.springframework.org/schema/cql/spring-cql.xsd">
 
 	<bean id="nettyOptions" class="org.springframework.data.cassandra.support.IntegrationTestNettyOptions"/>
 

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/FullySpecifiedKeyspaceCreatingXmlConfigIntegrationTests-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/FullySpecifiedKeyspaceCreatingXmlConfigIntegrationTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cass="http://www.springframework.org/schema/cql"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/cql http://www.springframework.org/schema/cql/spring-cql.xsd
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	http://www.springframework.org/schema/cql https://www.springframework.org/schema/cql/spring-cql.xsd
+	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<context:property-placeholder
 			location="classpath:/config/cassandra-connection.properties,classpath:/org/springframework/data/cassandra/config/FullySpecifiedKeyspaceCreatingXmlConfigIntegrationTests.properties"/>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/MinimalKeyspaceCreatingXmlConfigIntegrationTests-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/MinimalKeyspaceCreatingXmlConfigIntegrationTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cass="http://www.springframework.org/schema/cql"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/cql http://www.springframework.org/schema/cql/spring-cql.xsd
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	http://www.springframework.org/schema/cql https://www.springframework.org/schema/cql/spring-cql.xsd
+	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<context:property-placeholder
 		location="classpath:/config/cassandra-connection.properties" />

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/MinimalXmlConfigIntegrationTests-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/MinimalXmlConfigIntegrationTests-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cass="http://www.springframework.org/schema/cql"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/cql http://www.springframework.org/schema/cql/spring-cql.xsd
-                         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/cql https://www.springframework.org/schema/cql/spring-cql.xsd
+                         http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                         http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<context:property-placeholder
 		location="classpath:/config/cassandra-connection.properties" />

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/PropertyPlaceholderNamespaceCreatingXmlConfigIntegrationTests-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/PropertyPlaceholderNamespaceCreatingXmlConfigIntegrationTests-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/cql http://www.springframework.org/schema/cql/spring-cql.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/cql https://www.springframework.org/schema/cql/spring-cql.xsd
 ">
 
 	<context:property-placeholder

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/XmlConfigIntegrationTests-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/XmlConfigIntegrationTests-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:task="http://www.springframework.org/schema/task"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/cql http://www.springframework.org/schema/cql/spring-cql.xsd
-	   	http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/cql https://www.springframework.org/schema/cql/spring-cql.xsd
+	   	http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
 ">
 
 	<context:property-placeholder location="classpath:/config/cassandra-connection.properties"/>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/cluster-and-mock-session.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/cluster-and-mock-session.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
-	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
 
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<cass:cluster/>
 	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-converter.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-converter.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
-	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
 
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>
 	<cass:converter />

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-mapping-converter.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/mock-session-mapping-converter.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
-	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
 
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>
 	<cass:mapping/>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-converters.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-converters.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
-	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
 
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<cass:cluster/>
 

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-mapping-contexts.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-mapping-contexts.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
-	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<cass:cluster/>
 	<bean class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-session-factories.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-session-factories.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
-	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd
 
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<cass:cluster/>
 	<cass:session id="session-1" keyspace-name="system"/>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-sessions.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/multiple-sessions.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
-	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
 
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<cass:cluster/>
 	<bean id="mockSession1" class="org.springframework.data.cassandra.config.CassandraMappingBeanFactoryPostProcessorUnitTests.MockSessionFactory"/>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/two-keyspaces-namespace.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/config/two-keyspaces-namespace.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
-	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.5.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra-1.5.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<cass:cluster/>
 

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/repository/forcequote/compositeprimarykey/ForceQuotedCompositePrimaryKeyRepositoryXmlConfigIntegrationTests-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/repository/forcequote/compositeprimarykey/ForceQuotedCompositePrimaryKeyRepositoryXmlConfigIntegrationTests-context.xml
@@ -3,8 +3,8 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 ">
 
 	<import resource="classpath:/config/spring-data-cassandra-basic.xml"/>

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/repository/forcequote/config/ForceQuotedRepositoryXmlConfigIntegrationTests-context.xml
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/repository/forcequote/config/ForceQuotedRepositoryXmlConfigIntegrationTests-context.xml
@@ -3,8 +3,8 @@
 	   xmlns:cass="http://www.springframework.org/schema/data/cassandra"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/data/cassandra http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/data/cassandra https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 ">
 
 	<import resource="classpath:/config/spring-data-cassandra-basic.xml"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.prowaveconsulting.com (200) with 1 occurrences could not be migrated:  
   ([https](https://www.prowaveconsulting.com) result SSLHandshakeException).
* http://www.scispike.com (200) with 1 occurrences could not be migrated:  
   ([https](https://www.scispike.com) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.springframework.org/schema/cql/spring-cql.xsd (404) with 6 occurrences migrated to:  
  https://www.springframework.org/schema/cql/spring-cql.xsd ([https](https://www.springframework.org/schema/cql/spring-cql.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://projects.spring.io/spring-data-cassandra/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-cassandra/ ([https](https://projects.spring.io/spring-data-cassandra/) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 10 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 7 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.0.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd ([https](https://www.springframework.org/schema/data/cassandra/spring-cassandra-1.0.xsd) result 200).
* http://www.springframework.org/schema/data/cassandra/spring-cassandra-1.5.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/data/cassandra/spring-cassandra-1.5.xsd ([https](https://www.springframework.org/schema/data/cassandra/spring-cassandra-1.5.xsd) result 200).
* http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd ([https](https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd) result 200).
* http://www.springframework.org/schema/task/spring-task.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task.xsd ([https](https://www.springframework.org/schema/task/spring-task.xsd) result 200).
* http://www.pivotal.io with 2 occurrences migrated to:  
  https://www.pivotal.io ([https](https://www.pivotal.io) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.springframework.org/schema/beans with 34 occurrences
* http://www.springframework.org/schema/context with 14 occurrences
* http://www.springframework.org/schema/cql with 12 occurrences
* http://www.springframework.org/schema/data/cassandra with 24 occurrences
* http://www.springframework.org/schema/task with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 20 occurrences