### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Spring Data for Apache Cassandra](https://spring.io/badges/spring-data-cassandra/ga.svg)](http://projects.spring.io/spring-data-cassandra/#quick-start)
-[![Spring Data for Apache Cassandra](https://spring.io/badges/spring-data-cassandra/snapshot.svg)](http://projects.spring.io/spring-data-cassandra/#quick-start)
+[![Spring Data for Apache Cassandra](https://spring.io/badges/spring-data-cassandra/ga.svg)](https://projects.spring.io/spring-data-cassandra/#quick-start)
+[![Spring Data for Apache Cassandra](https://spring.io/badges/spring-data-cassandra/snapshot.svg)](https://projects.spring.io/spring-data-cassandra/#quick-start)
 
 # Spring Data for Apache Cassandra
 
-The primary goal of the [Spring Data](http://projects.spring.io/spring-data) project is to make it easier to build Spring-powered applications that use new data access technologies such as non-relational databases, map-reduce frameworks, and cloud based data services.
+The primary goal of the [Spring Data](https://projects.spring.io/spring-data) project is to make it easier to build Spring-powered applications that use new data access technologies such as non-relational databases, map-reduce frameworks, and cloud based data services.
 
 The Spring Data for Apache Cassandra project aims to provide a familiar and consistent Spring-based programming model for new datastores while retaining store-specific features and capabilities. The Spring Data for Apache Cassandra project provides integration with the Apache Cassandra database. Key functional areas of Spring Data for Apache Cassandra are a CQL abstraction, a POJO centric model for interacting with an Apache Cassandra tables and easily writing a repository style data access layer.
 
@@ -12,12 +12,12 @@ The Spring Data for Apache Cassandra project aims to provide a familiar and cons
 
 For a comprehensive treatment of all the Spring Data for Apache Cassandra features, please refer to:
 
-* the [User Guide](http://docs.spring.io/spring-data/cassandra/docs/current/reference/html/)
-* the [JavaDocs](http://docs.spring.io/spring-data/cassandra/docs/current/api/) have extensive comments in them as well.
-* the home page of [Spring Data for Apache Cassandra](http://projects.spring.io/spring-data-cassandra) contains links to articles and other resources.
-* for more detailed questions, use [Spring Data for Apache Cassandra on Stackoverflow](http://stackoverflow.com/questions/tagged/spring-data-cassandra).
+* the [User Guide](https://docs.spring.io/spring-data/cassandra/docs/current/reference/html/)
+* the [JavaDocs](https://docs.spring.io/spring-data/cassandra/docs/current/api/) have extensive comments in them as well.
+* the home page of [Spring Data for Apache Cassandra](https://projects.spring.io/spring-data-cassandra) contains links to articles and other resources.
+* for more detailed questions, use [Spring Data for Apache Cassandra on Stackoverflow](https://stackoverflow.com/questions/tagged/spring-data-cassandra).
 
-If you are new to Spring as well as to Spring Data, look for information about [Spring projects](http://projects.spring.io/).
+If you are new to Spring as well as to Spring Data, look for information about [Spring projects](https://projects.spring.io/).
 
 
 ## Quick Start
@@ -51,7 +51,7 @@ If you would rather like the latest snapshots of the upcoming major version, use
 <repository>
   <id>spring-libs-snapshot</id>
   <name>Spring Snapshot Repository</name>
-  <url>http://repo.spring.io/libs-snapshot</url>
+  <url>https://repo.spring.io/libs-snapshot</url>
 </repository>
 ```
 
@@ -60,7 +60,7 @@ If you would rather like the latest snapshots of the upcoming major version, use
 `CassandraTemplate` is the central support class for Cassandra database operations. It provides:
 
 * Increased productivity by handling common Cassandra operations properly. Includes integrated object mapping between CQL Tables and POJOs.
-* Exception translation into Spring's [technology agnostic DAO exception hierarchy](http://docs.spring.io/spring/docs/current/spring-framework-reference/html/dao.html#dao-exceptions).
+* Exception translation into Spring's [technology agnostic DAO exception hierarchy](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/dao.html#dao-exceptions).
 * Feature rich object mapping integrated with Spring’s Conversion Service.
 * Annotation-based mapping metadata but extensible to support other metadata formats.
 
@@ -166,10 +166,10 @@ Spring Data for Apache Cassandra adds object mapping, schema generation and repo
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community on Stackoverflow and help out on the [spring-data-cassandra](http://stackoverflow.com/questions/tagged/spring-data-cassandra) tag by responding to questions and joining the debate.
+* Get involved with the Spring community on Stackoverflow and help out on the [spring-data-cassandra](https://stackoverflow.com/questions/tagged/spring-data-cassandra) tag by responding to questions and joining the debate.
 * Create [JIRA](https://jira.spring.io/browse/DATACASS) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/). If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by [subscribing](http://spring.io/blog) to spring.io.
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/). If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Watch for upcoming articles on Spring by [subscribing](https://spring.io/blog) to spring.io.
 
 Before we accept a non-trivial patch or pull request we will need you to [sign the Contributor License Agreement](https://cla.pivotal.io/sign/spring). Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. If you forget to do so, you'll be reminded when you submit a pull request. Active contributors might be asked to join the core team, and given the ability to merge pull requests.
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/CassandraThreeTenBackPortConverters.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/CassandraThreeTenBackPortConverters.java
@@ -38,7 +38,7 @@ import com.datastax.driver.core.DataType.Name;
  * the classpath.
  *
  * @author Mark Paluch
- * @see <a href="http://www.threeten.org/threetenbp">Threeten Backport</a>
+ * @see <a href="https://www.threeten.org/threetenbp">Threeten Backport</a>
  * @since 1.5
  */
 public abstract class CassandraThreeTenBackPortConverters {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CassandraAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CassandraAccessor.java
@@ -298,7 +298,7 @@ public class CassandraAccessor implements InitializingBean {
 	 * @param ex the offending {@link DriverException}
 	 * @return the DataAccessException, wrapping the {@code DriverException}
 	 * @see <a href=
-	 *      "http://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html#dao-exceptions">Consistent
+	 *      "https://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html#dao-exceptions">Consistent
 	 *      exception hierarchy</a>
 	 * @see DataAccessException
 	 */
@@ -324,7 +324,7 @@ public class CassandraAccessor implements InitializingBean {
 	 * @return the DataAccessException, wrapping the {@code DriverException}
 	 * @see org.springframework.dao.DataAccessException#getRootCause()
 	 * @see <a href=
-	 *      "http://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html#dao-exceptions">Consistent
+	 *      "https://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html#dao-exceptions">Consistent
 	 *      exception hierarchy</a>
 	 */
 	protected DataAccessException translate(String task, @Nullable String cql, DriverException ex) {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/ReactiveCassandraAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/ReactiveCassandraAccessor.java
@@ -113,7 +113,7 @@ public abstract class ReactiveCassandraAccessor implements InitializingBean {
 	 * @param ex the offending {@link DriverException}
 	 * @return the DataAccessException, wrapping the {@code DriverException}
 	 * @see <a href=
-	 *      "http://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html#dao-exceptions">Consistent
+	 *      "https://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html#dao-exceptions">Consistent
 	 *      exception hierarchy</a>
 	 * @see DataAccessException
 	 */
@@ -139,7 +139,7 @@ public abstract class ReactiveCassandraAccessor implements InitializingBean {
 	 * @return the DataAccessException, wrapping the {@code DriverException}
 	 * @see org.springframework.dao.DataAccessException#getRootCause()
 	 * @see <a href=
-	 *      "http://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html#dao-exceptions">Consistent
+	 *      "https://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html#dao-exceptions">Consistent
 	 *      exception hierarchy</a>
 	 */
 	protected DataAccessException translate(String task, @Nullable String cql, DriverException ex) {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/ReservedKeyword.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/ReservedKeyword.java
@@ -25,7 +25,7 @@ import org.springframework.util.StringUtils;
  * CQL keywords.
  *
  * @see <a href=
- *      "http://cassandra.apache.org/doc/cql3/CQL.html#appendixA">http://cassandra.apache.org/doc/cql3/CQL.html#appendixA</a>
+ *      "https://cassandra.apache.org/doc/cql3/CQL.html#appendixA">https://cassandra.apache.org/doc/cql3/CQL.html#appendixA</a>
  * @author Matthew T. Adams
  * @author Mark Paluch
  */

--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.0.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.0.xsd
@@ -7,13 +7,13 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-				schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-				schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
-				schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd"/>
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[

--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.5.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-1.5.xsd
@@ -7,13 +7,13 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-		schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd" />
+		schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-		schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+		schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-		schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+		schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
-		schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />
+		schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd" />
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[

--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-2.0.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cassandra-2.0.xsd
@@ -7,13 +7,13 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"
-		schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd" />
+		schemaLocation="https://www.springframework.org/schema/beans/spring-beans.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-		schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+		schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-		schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+		schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
-		schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />
+		schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd" />
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[

--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cql-1.0.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cql-1.0.xsd
@@ -6,7 +6,7 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-				schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[

--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cql-1.5.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cql-1.5.xsd
@@ -6,7 +6,7 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-		schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+		schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[

--- a/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cql-2.0.xsd
+++ b/spring-data-cassandra/src/main/resources/org/springframework/data/cassandra/config/spring-cql-2.0.xsd
@@ -6,7 +6,7 @@
 			elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool"
-		schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd" />
+		schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd" />
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/FlatGroup.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/FlatGroup.java
@@ -24,7 +24,7 @@ import org.springframework.data.cassandra.core.mapping.Table;
 /**
  * @author Mark Paluch
  * @see <a href=
- *      "http://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling">http://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling</a>
+ *      "https://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling">https://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling</a>
  */
 @Table
 @Data

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/Group.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/Group.java
@@ -24,7 +24,7 @@ import org.springframework.data.cassandra.core.mapping.Table;
 /**
  * @author Mark Paluch
  * @see <a href=
- *      "http://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling">http://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling</a>
+ *      "https://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling">https://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling</a>
  */
 @Table
 @Data

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/GroupKey.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/GroupKey.java
@@ -28,7 +28,7 @@ import org.springframework.data.cassandra.core.mapping.PrimaryKeyColumn;
 /**
  * @author Mark Paluch
  * @see <a href=
- *      "http://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling">http://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling</a>
+ *      "https://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling">https://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling</a>
  */
 @PrimaryKeyClass
 @Data

--- a/spring-data-cassandra/src/test/resources/embedded-cassandra.yaml
+++ b/spring-data-cassandra/src/test/resources/embedded-cassandra.yaml
@@ -1,6 +1,6 @@
 # Cassandra storage config YAML
 
-#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   See https://wiki.apache.org/cassandra/StorageConfiguration for
 #   full explanations of configuration directives
 # /NOTE
 
@@ -19,14 +19,14 @@ cluster_name: 'Test Cluster'
 # Specifying initial_token will override this setting.
 #
 # If you already have a cluster with 1 token per node, and wish to migrate to
-# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
+# multiple tokens per node, see https://wiki.apache.org/cassandra/Operations
 # num_tokens: 256
 
 # If you haven't specified num_tokens, or have set it to the default of 1 then
 # you should always specify InitialToken when setting up a production
 # cluster for the first time, and often when adding capacity later.
 # The principle is that each node should be given an equal slice of
-# the token ring; see http://wiki.apache.org/cassandra/Operations
+# the token ring; see https://wiki.apache.org/cassandra/Operations
 # for more details.
 #
 # If blank, Cassandra will request a token bisecting the range of
@@ -35,7 +35,7 @@ cluster_name: 'Test Cluster'
 # a random token, which will lead to hot spots.
 initial_token:
 
-# See http://wiki.apache.org/cassandra/HintedHandoff
+# See https://wiki.apache.org/cassandra/HintedHandoff
 hinted_handoff_enabled: false
 
 # this defines the maximum amount of time a dead host will have hints
@@ -98,7 +98,7 @@ authorizer: org.apache.cassandra.auth.AllowAllAuthorizer
 # - CollatingOPP collates according to EN,US rules rather than lexical byte
 #   ordering.  Use this as an example if you need custom collation.
 #
-# See http://wiki.apache.org/cassandra/Operations for more on
+# See https://wiki.apache.org/cassandra/Operations for more on
 # partitioners and token selection.
 partitioner: org.apache.cassandra.dht.Murmur3Partitioner
 
@@ -608,7 +608,7 @@ index_interval: 128
 #
 # The passwords used in these options must match the passwords used when generating
 # the keystore and truststore.  For instructions on generating these files, see:
-# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+# https://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
 #
 server_encryption_options:
     internode_encryption: none

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -4,7 +4,7 @@ David Webb, Matthew Adams, John Blum, Mark Paluch, Jay Bryant
 :revdate: {localdate}
 ifdef::backend-epub3[:front-cover-image: image:epub-cover.png[Front Cover,1050,1600]]
 :spring-data-commons-docs: ../../../../../spring-data-commons/src/main/asciidoc
-:spring-framework-docs: http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/
+:spring-framework-docs: https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/
 
 (C) 2008-2019 The original author(s).
 

--- a/src/main/asciidoc/preface.adoc
+++ b/src/main/asciidoc/preface.adoc
@@ -37,34 +37,34 @@ you must configure some parts of the library by using Spring.
 
 To learn more about Spring, you can refer to the comprehensive {spring-framework-docs}[documentation]
 that explains the Spring Framework in detail. There are a lot of articles, blog entries, and books on Spring.
-See the Spring Framework http://projects.spring.io/spring-framework/[home page] for more information.
+See the Spring Framework https://projects.spring.io/spring-framework/[home page] for more information.
 
 [[get-started:first-steps:nosql]]
 == Knowing NoSQL and Cassandra
 
 NoSQL stores have taken the storage world by storm. It is a vast domain with a plethora of solutions, terms, and patterns.
-(To make things worse, even the term itself has multiple http://www.google.com/search?q=nosoql+acronym[meanings].)
+(To make things worse, even the term itself has multiple https://www.google.com/search?q=nosoql+acronym[meanings].)
 While some of the principles are common, it is crucial that you be familiar to some degree with
 the Cassandra Columnar NoSQL Datastore supported by Spring Data for Apache Cassandra. The best way to get acquainted with Cassandra
 is to read the documentation and follow the examples.  It usually does not take more then 5-10 minutes to go through them,
 and, if you come from a RDBMS background, these exercises can often be an eye opener.
 
-The starting point for learning about Cassandra is http://cassandra.apache.org/[cassandra.apache.org]. Also, here is
+The starting point for learning about Cassandra is https://cassandra.apache.org/[cassandra.apache.org]. Also, here is
 a list of other useful resources:
 
-* The http://datastax.com/[DataStax] site offers http://www.datastax.com/what-we-offer/products-services/support[commercial support]
-and many resources, including, but not limited to, http://docs.datastax.com/en/landing_page/doc/landing_page/current.html[documentation],
-http://docs.datastax.com/en/landing_page/doc/landing_page/current.html[DataStax Academy], a http://www.datastax.com/dev/blog[Tech Blog],
+* The https://datastax.com/[DataStax] site offers https://www.datastax.com/what-we-offer/products-services/support[commercial support]
+and many resources, including, but not limited to, https://docs.datastax.com/en/landing_page/doc/landing_page/current.html[documentation],
+https://docs.datastax.com/en/landing_page/doc/landing_page/current.html[DataStax Academy], a https://www.datastax.com/dev/blog[Tech Blog],
 and so on.
 * The https://academy.datastax.com/resources/ds101-introduction-cassandra[DataStax Academy introduction to Cassandra].
-* The http://cassandra.apache.org/doc/latest/getting_started/index.html[Cassandra Quick Start Guide].
+* The https://cassandra.apache.org/doc/latest/getting_started/index.html[Cassandra Quick Start Guide].
 
 [[requirements]]
 == Requirements
 
-Spring Data for Apache Cassandra 2.x binaries require JDK level 8.0 and later and http://spring.io/docs[Spring Framework] {springVersion} and later.
+Spring Data for Apache Cassandra 2.x binaries require JDK level 8.0 and later and https://spring.io/docs[Spring Framework] {springVersion} and later.
 
-It requires http://cassandra.apache.org/[Cassandra] 2.0 or later.
+It requires https://cassandra.apache.org/[Cassandra] 2.0 or later.
 
 == Additional Help Resources
 
@@ -74,28 +74,28 @@ However, if you encounter issues or you need advice, feel free to use one of the
 
 [[get-started:help:community]]
 Community Forum::
-Spring Data on http://stackoverflow.com/questions/tagged/spring-data[Stack Overflow] is a
+Spring Data on https://stackoverflow.com/questions/tagged/spring-data[Stack Overflow] is a
 tag for all Spring Data (not just Cassandra) users to share information and help each other.
 Note that registration is needed only for posting. The two key tags to search for related answers to
-this project are http://stackoverflow.com/questions/tagged/spring-data[spring-data] and http://stackoverflow.com/questions/tagged/spring-data-cassandra[spring-data-cassandra].
+this project are https://stackoverflow.com/questions/tagged/spring-data[spring-data] and https://stackoverflow.com/questions/tagged/spring-data-cassandra[spring-data-cassandra].
 
 [[get-started:help:professional]]
 Professional Support::
 Professional, from-the-source support, with guaranteed response time, is available from
-http://pivotal.io/[Pivotal Sofware, Inc.], the company behind Spring Data and Spring.
+https://pivotal.io/[Pivotal Sofware, Inc.], the company behind Spring Data and Spring.
 
 [[get-started:up-to-date]]
 === Following Development
 
 For information on the Spring Data for Apache Cassandra source code repository, nightly builds, and snapshot artifacts
-see the http://projects.spring.io/spring-data-cassandra/[Spring Data for Apache Cassandra home page].
+see the https://projects.spring.io/spring-data-cassandra/[Spring Data for Apache Cassandra home page].
 You can help make Spring Data best serve the needs of the Spring community by interacting with developers
-through the community on http://stackoverflow.com/questions/tagged/spring-data[Stack Overflow].
+through the community on https://stackoverflow.com/questions/tagged/spring-data[Stack Overflow].
 To follow developer activity, look for the mailing list information on the Spring Data for Apache Cassandra home page.
 If you encounter a bug or want to suggest an improvement, please create a ticket on the Spring Data issue
 https://jira.spring.io/browse/DATACASS[tracker]. To stay up-to-date with the latest news and announcements
-in the Spring ecosystem, subscribe to the Spring Community http://spring.io[Portal].
-Finally, you can follow the Spring  http://spring.io/blog[blog] or the project team on Twitter (http://twitter.com/SpringData[SpringData]).
+in the Spring ecosystem, subscribe to the Spring Community https://spring.io[Portal].
+Finally, you can follow the Spring  https://spring.io/blog[blog] or the project team on Twitter (https://twitter.com/SpringData[SpringData]).
 
 
 [[get-started:project-metadata]]

--- a/src/main/asciidoc/reference/cassandra-repositories.adoc
+++ b/src/main/asciidoc/reference/cassandra-repositories.adoc
@@ -59,9 +59,9 @@ Next, in your Spring configuration, add the following (if you use XML for config
   xmlns:cassandra="http://www.springframework.org/schema/data/cassandra"
   xsi:schemaLocation="
     http://www.springframework.org/schema/data/cassandra
-    http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
+    https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
     http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd">
+    https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <cassandra:cluster port="9042"/>
     <cassandra:session keyspace-name="keyspaceName"/>

--- a/src/main/asciidoc/reference/cassandra.adoc
+++ b/src/main/asciidoc/reference/cassandra.adoc
@@ -22,10 +22,10 @@ the DataStax Java Driver so that they are familiar and so that you can map your 
 [[cassandra.getting-started]]
 == Getting Started
 
-Spring Data for Apache Cassandra requires Apache Cassandra 2.1 or later and Datastax Java Driver 3.0 or later. An easy way to quickly set up and bootstrap a working environment is to create a Spring-based project in http://spring.io/tools/sts[STS] or use http://start.spring.io/[Spring Initializer].
+Spring Data for Apache Cassandra requires Apache Cassandra 2.1 or later and Datastax Java Driver 3.0 or later. An easy way to quickly set up and bootstrap a working environment is to create a Spring-based project in https://spring.io/tools/sts[STS] or use https://start.spring.io/[Spring Initializer].
 
 First, you need to set up a running Apache Cassandra server. See the
-http://cassandra.apache.org/doc/latest/getting_started/index.html[Apache Cassandra Quick Start Guide]
+https://cassandra.apache.org/doc/latest/getting_started/index.html[Apache Cassandra Quick Start Guide]
 for an explanation on how to start Apache Cassandra. Once installed, starting Cassandra is typically a matter of
 executing the following command: `CASSANDRA_HOME/bin/cassandra -f`.
 
@@ -67,12 +67,12 @@ repository for Maven to your pom.xml file so that it is at the same level of you
   <repository>
     <id>spring-milestone</id>
     <name>Spring Maven MILESTONE Repository</name>
-    <url>http://repo.spring.io/libs-milestone</url>
+    <url>https://repo.spring.io/libs-milestone</url>
   </repository>
 </repositories>
 ----
 
-The repository is also http://repo.spring.io/milestone/org/springframework/data/[browseable here].
+The repository is also https://repo.spring.io/milestone/org/springframework/data/[browseable here].
 
 You can also browse all Spring repositories https://repo.spring.io/webapp/#/home[here].
 
@@ -197,7 +197,7 @@ bean metadata. These are discussed in the following sections.
 
 NOTE: For those not familiar with how to configure the Spring container using Java-based bean metadata instead of
 XML-based metadata, see the high-level introduction in the reference docs
-http://docs.spring.io/spring/docs/3.2.x/spring-framework-reference/html/new-in-3.0.html#new-java-configuration[here]
+https://docs.spring.io/spring/docs/3.2.x/spring-framework-reference/html/new-in-3.0.html#new-java-configuration[here]
 as well as the detailed documentation {spring-framework-docs}core.html#beans-java-instantiating-container[here].
 
 [[cassandra.cassandra-java-config]]
@@ -400,9 +400,9 @@ The following example shows how to configure the `cql` namespace:
   xmlns:cql="http://www.springframework.org/schema/data/cql"
   xsi:schemaLocation="
     http://www.springframework.org/schema/cql
-    http://www.springframework.org/schema/cql/spring-cql.xsd
+    https://www.springframework.org/schema/cql/spring-cql.xsd
     http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd">
+    https://www.springframework.org/schema/beans/spring-beans.xsd">
 
   <!-- Default bean name is 'cassandraCluster' -->
   <cql:cluster contact-points="localhost" port="9042">
@@ -428,9 +428,9 @@ To use the Cassandra namespace elements, you need to reference the Cassandra sch
   xmlns:cassandra="http://www.springframework.org/schema/data/cassandra"
   xsi:schemaLocation="
     http://www.springframework.org/schema/data/cassandra
-    http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
+    https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd
     http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd">
+    https://www.springframework.org/schema/beans/spring-beans.xsd">
 
   <!-- Default bean name is 'cassandraCluster' -->
   <cassandra:cluster contact-points="localhost" port="9042">

--- a/src/main/asciidoc/reference/reactive-cassandra-repositories.adoc
+++ b/src/main/asciidoc/reference/reactive-cassandra-repositories.adoc
@@ -10,8 +10,8 @@ Reactive usage is broken up into two phases: Composition and Execution.
 Calling repository methods lets you compose a reactive sequence by obtaining `Publisher` instances and applying operators.
 No I/O happens until you subscribe. Passing the reactive sequence to a reactive execution infrastructure,
 such as {spring-framework-docs}web.html#web-reactive[Spring WebFlux]
-or http://vertx.io/docs/vertx-reactive-streams/java/[Vert.x]), subscribes to the publisher and initiate
-the actual execution. See http://projectreactor.io/docs/core/release/reference/#reactive.subscribe[the Project reactor documentation] for more detail.
+or https://vertx.io/docs/vertx-reactive-streams/java/[Vert.x]), subscribes to the publisher and initiate
+the actual execution. See https://projectreactor.io/docs/core/release/reference/#reactive.subscribe[the Project reactor documentation] for more detail.
 
 
 [[cassandra.reactive.repositories.libraries]]
@@ -22,7 +22,7 @@ https://github.com/ReactiveX/RxJava[RxJava] and https://projectreactor.io/[Proje
 
 Spring Data for Apache Cassandra is built on top of the https://github.com/datastax/java-driver[DataStax Cassandra Driver].
 The driver is not reactive but the asynchronous capabilities allow us to adopt and expose the `Publisher` APIs
-to provide maximum interoperability by relying on the http://www.reactive-streams.org/[Reactive Streams] initiative.
+to provide maximum interoperability by relying on the https://www.reactive-streams.org/[Reactive Streams] initiative.
 Static APIs, such as `ReactiveCassandraOperations`, are provided by using Project Reactor's `Flux` and `Mono` types.
 Project Reactor offers various adapters to convert reactive wrapper types (`Flux` to `Observable` and back),
 but conversion can easily clutter your code.

--- a/src/main/asciidoc/reference/reactive-cassandra.adoc
+++ b/src/main/asciidoc/reference/reactive-cassandra.adoc
@@ -22,10 +22,10 @@ onto the Spring APIs.
 [[cassandra.reactive.getting-started]]
 == Getting Started
 
-Spring Data for Apache Cassandra requires Apache Cassandra 2.1 or later and Datastax Java Driver 3.0 or later. An easy way to quickly set up and bootstrap a working environment is to create a Spring-based project in http://spring.io/tools/sts[STS] or use http://start.spring.io/[Spring Initializer].
+Spring Data for Apache Cassandra requires Apache Cassandra 2.1 or later and Datastax Java Driver 3.0 or later. An easy way to quickly set up and bootstrap a working environment is to create a Spring-based project in https://spring.io/tools/sts[STS] or use https://start.spring.io/[Spring Initializer].
 
 First, you need to set up a running Apache Cassandra server. See the
-http://cassandra.apache.org/doc/latest/getting_started/index.html[Apache Cassandra Quick Start Guide]
+https://cassandra.apache.org/doc/latest/getting_started/index.html[Apache Cassandra Quick Start Guide]
 for an explanation on how to start Apache Cassandra. Once installed, starting Cassandra is typically a matter of
 executing the following command: `CASSANDRA_HOME/bin/cassandra -f`.
 
@@ -67,12 +67,12 @@ repository for Maven to your pom.xml file so that it is at the same level of you
   <repository>
     <id>spring-milestone</id>
     <name>Spring Maven MILESTONE Repository</name>
-    <url>http://repo.spring.io/libs-milestone</url>
+    <url>https://repo.spring.io/libs-milestone</url>
   </repository>
 </repositories>
 ----
 
-The repository is also http://repo.spring.io/milestone/org/springframework/data/[browseable here].
+The repository is also https://repo.spring.io/milestone/org/springframework/data/[browseable here].
 
 You can also browse all Spring repositories https://repo.spring.io/webapp/#/home[here].
 
@@ -202,7 +202,7 @@ bean metadata. These are discussed in the following sections.
 
 NOTE: For those not familiar with how to configure the Spring container using Java-based bean metadata instead of
 XML-based metadata, see the high-level introduction in the reference docs
-http://docs.spring.io/spring/docs/3.2.x/spring-framework-reference/html/new-in-3.0.html#new-java-configuration[here]
+https://docs.spring.io/spring/docs/3.2.x/spring-framework-reference/html/new-in-3.0.html#new-java-configuration[here]
 as well as the detailed documentation {spring-framework-docs}core.html#beans-java-instantiating-container[here].
 
 

--- a/src/main/resources/license.txt
+++ b/src/main/resources/license.txt
@@ -207,7 +207,7 @@ similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a 
 copy of the source code corresponding to the binaries for such open source 
 components and modifications thereto, if any, (the "Source Files"), by 
-downloading the Source Files from http://www.springsource.org/download, 
+downloading the Source Files from https://www.springsource.org/download, 
 or by sending a request, with your name and address to: VMware, Inc., 3401 Hillview 
 Avenue, Palo Alto, CA 94304, United States of America or email info@vmware.com.  All 
 such requests should clearly specify:  OPEN SOURCE FILES REQUEST, Attention General 

--- a/src/main/resources/readme.txt
+++ b/src/main/resources/readme.txt
@@ -13,5 +13,5 @@ The reference manual and javadoc are located in the 'docs' directory.
 
 ADDITIONAL RESOURCES:
 
-Spring Data Homepage: http://projects.spring.io/spring-data
-Spring Data Forum:    http://forum.spring.io/forum/spring-projects/data/nosql
+Spring Data Homepage: https://projects.spring.io/spring-data
+Spring Data Forum:    https://forum.spring.io/forum/spring-projects/data/nosql


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://www.prowaveconsulting.com (200) with 1 occurrences could not be migrated:  
   ([https](https://www.prowaveconsulting.com) result SSLHandshakeException).
* [ ] http://www.scispike.com (200) with 1 occurrences could not be migrated:  
   ([https](https://www.scispike.com) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://cassandra.apache.org/doc/cql3/CQL.html (404) with 2 occurrences migrated to:  
  https://cassandra.apache.org/doc/cql3/CQL.html ([https](https://cassandra.apache.org/doc/cql3/CQL.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cassandra.apache.org/ with 2 occurrences migrated to:  
  https://cassandra.apache.org/ ([https](https://cassandra.apache.org/) result 200).
* [ ] http://cassandra.apache.org/doc/latest/getting_started/index.html with 3 occurrences migrated to:  
  https://cassandra.apache.org/doc/latest/getting_started/index.html ([https](https://cassandra.apache.org/doc/latest/getting_started/index.html) result 200).
* [ ] http://docs.datastax.com/en/landing_page/doc/landing_page/current.html with 2 occurrences migrated to:  
  https://docs.datastax.com/en/landing_page/doc/landing_page/current.html ([https](https://docs.datastax.com/en/landing_page/doc/landing_page/current.html) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://pivotal.io/ with 1 occurrences migrated to:  
  https://pivotal.io/ ([https](https://pivotal.io/) result 200).
* [ ] http://projectreactor.io/docs/core/release/reference/ with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/reference/ ([https](https://projectreactor.io/docs/core/release/reference/) result 200).
* [ ] http://projects.spring.io/ with 1 occurrences migrated to:  
  https://projects.spring.io/ ([https](https://projects.spring.io/) result 200).
* [ ] http://projects.spring.io/spring-data-cassandra/ with 3 occurrences migrated to:  
  https://projects.spring.io/spring-data-cassandra/ ([https](https://projects.spring.io/spring-data-cassandra/) result 200).
* [ ] http://projects.spring.io/spring-framework/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-framework/ ([https](https://projects.spring.io/spring-framework/) result 200).
* [ ] http://repo.spring.io/milestone/org/springframework/data/ with 2 occurrences migrated to:  
  https://repo.spring.io/milestone/org/springframework/data/ ([https](https://repo.spring.io/milestone/org/springframework/data/) result 200).
* [ ] http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* [ ] http://spring.io/blog with 2 occurrences migrated to:  
  https://spring.io/blog ([https](https://spring.io/blog) result 200).
* [ ] http://spring.io/docs with 1 occurrences migrated to:  
  https://spring.io/docs ([https](https://spring.io/docs) result 200).
* [ ] http://spring.io/tools/sts with 2 occurrences migrated to:  
  https://spring.io/tools/sts ([https](https://spring.io/tools/sts) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data with 3 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data ([https](https://stackoverflow.com/questions/tagged/spring-data) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data-cassandra with 3 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data-cassandra ([https](https://stackoverflow.com/questions/tagged/spring-data-cassandra) result 200).
* [ ] http://start.spring.io/ with 2 occurrences migrated to:  
  https://start.spring.io/ ([https](https://start.spring.io/) result 200).
* [ ] http://twitter.com/SpringData with 1 occurrences migrated to:  
  https://twitter.com/SpringData ([https](https://twitter.com/SpringData) result 200).
* [ ] http://vertx.io/docs/vertx-reactive-streams/java/ with 1 occurrences migrated to:  
  https://vertx.io/docs/vertx-reactive-streams/java/ ([https](https://vertx.io/docs/vertx-reactive-streams/java/) result 200).
* [ ] http://wiki.apache.org/cassandra/HintedHandoff with 1 occurrences migrated to:  
  https://wiki.apache.org/cassandra/HintedHandoff ([https](https://wiki.apache.org/cassandra/HintedHandoff) result 200).
* [ ] http://wiki.apache.org/cassandra/Operations with 3 occurrences migrated to:  
  https://wiki.apache.org/cassandra/Operations ([https](https://wiki.apache.org/cassandra/Operations) result 200).
* [ ] http://wiki.apache.org/cassandra/StorageConfiguration with 1 occurrences migrated to:  
  https://wiki.apache.org/cassandra/StorageConfiguration ([https](https://wiki.apache.org/cassandra/StorageConfiguration) result 200).
* [ ] http://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling with 6 occurrences migrated to:  
  https://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling ([https](https://www.datastax.com/dev/blog/basic-rules-of-cassandra-data-modeling) result 200).
* [ ] http://www.google.com/search?q=nosoql+acronym with 1 occurrences migrated to:  
  https://www.google.com/search?q=nosoql+acronym ([https](https://www.google.com/search?q=nosoql+acronym) result 200).
* [ ] http://www.reactive-streams.org/ with 1 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://www.reactive-streams.org/) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.springframework.org/schema/data/repository/spring-repository.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/data/repository/spring-repository.xsd ([https](https://www.springframework.org/schema/data/repository/spring-repository.xsd) result 200).
* [ ] http://www.springframework.org/schema/tool/spring-tool.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/tool/spring-tool.xsd ([https](https://www.springframework.org/schema/tool/spring-tool.xsd) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://datastax.com/ with 1 occurrences migrated to:  
  https://datastax.com/ ([https](https://datastax.com/) result 301).
* [ ] http://docs.spring.io/spring-data/cassandra/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/cassandra/docs/current/api/ ([https](https://docs.spring.io/spring-data/cassandra/docs/current/api/) result 301).
* [ ] http://docs.spring.io/spring-data/cassandra/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/cassandra/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data/cassandra/docs/current/reference/html/) result 301).
* [ ] http://docs.spring.io/spring/docs/3.2.x/spring-framework-reference/html/new-in-3.0.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.2.x/spring-framework-reference/html/new-in-3.0.html ([https](https://docs.spring.io/spring/docs/3.2.x/spring-framework-reference/html/new-in-3.0.html) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html with 4 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/dao.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/dao.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/dao.html) result 301).
* [ ] http://forum.spring.io/forum/spring-projects/data/nosql with 1 occurrences migrated to:  
  https://forum.spring.io/forum/spring-projects/data/nosql ([https](https://forum.spring.io/forum/spring-projects/data/nosql) result 301).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://projects.spring.io/spring-data with 2 occurrences migrated to:  
  https://projects.spring.io/spring-data ([https](https://projects.spring.io/spring-data) result 301).
* [ ] http://projects.spring.io/spring-data-cassandra with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-cassandra ([https](https://projects.spring.io/spring-data-cassandra) result 301).
* [ ] http://www.datastax.com/what-we-offer/products-services/support with 1 occurrences migrated to:  
  https://www.datastax.com/what-we-offer/products-services/support ([https](https://www.datastax.com/what-we-offer/products-services/support) result 301).
* [ ] http://www.springframework.org/schema/cql/spring-cql.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cql/spring-cql.xsd ([https](https://www.springframework.org/schema/cql/spring-cql.xsd) result 301).
* [ ] http://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd ([https](https://www.springframework.org/schema/data/cassandra/spring-cassandra.xsd) result 301).
* [ ] http://www.threeten.org/threetenbp with 1 occurrences migrated to:  
  https://www.threeten.org/threetenbp ([https](https://www.threeten.org/threetenbp) result 301).
* [ ] http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html with 1 occurrences migrated to:  
  https://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html ([https](https://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html) result 302).
* [ ] http://repo.spring.io/libs-milestone with 2 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* [ ] http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* [ ] http://www.springsource.org/download with 1 occurrences migrated to:  
  https://www.springsource.org/download ([https](https://www.springsource.org/download) result 302).
* [ ] http://www.datastax.com/dev/blog with 1 occurrences migrated to:  
  https://www.datastax.com/dev/blog ([https](https://www.datastax.com/dev/blog) result 307).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/beans with 9 occurrences
* http://www.springframework.org/schema/context with 3 occurrences
* http://www.springframework.org/schema/cql with 7 occurrences
* http://www.springframework.org/schema/data/cassandra with 10 occurrences
* http://www.springframework.org/schema/data/cql with 1 occurrences
* http://www.springframework.org/schema/data/repository with 6 occurrences
* http://www.springframework.org/schema/tool with 12 occurrences
* http://www.w3.org/2001/XMLSchema with 6 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 3 occurrences