### PR TITLE
Fix typo regarding the usage of Query objects (again)

### DIFF
--- a/src/main/asciidoc/reference/cassandra.adoc
+++ b/src/main/asciidoc/reference/cassandra.adoc
@@ -1286,12 +1286,11 @@ The `Query` class has some additional methods that you can use to provide option
 The `Query` class has the following methods that return rows:
 
 * `List<T>` *select* `(Query query, Class<T> entityClass)`: Query for a list of objects of type `T` from the table.
-* `T` *selectOneById* `(Query query, Class<T> entityClass)`: Query for a single object of type `T` from the table.
-* `Slice<T>` *slice* `(Query query, Class<T> entityClass)`: Starts or continues paging by querying for a `Slice` of objects of type `T` from the table.
 * `T` *selectOne* `(Query query, Class<T> entityClass)`: Query for a single object of type `T` from the table.
+* `Slice<T>` *slice* `(Query query, Class<T> entityClass)`: Starts or continues paging by querying for a `Slice` of objects of type `T` from the table.
 * `Stream<T>` *stream* `(Query query, Class<T> entityClass)`: Query for a stream of objects of type `T` from the table.
 * `List<T>` *select* `(String cql, Class<T> entityClass)`: Ad-hoc query for a list of objects of type `T` from the table by providing a CQL statement.
-* `T` *selectOneById* `(String cql, Class<T> entityClass)`: Ad-hoc query for a single object of type `T` from the table by providing a CQL statement.
+* `T` *selectOne* `(String cql, Class<T> entityClass)`: Ad-hoc query for a single object of type `T` from the table by providing a CQL statement.
 * `Stream<T>` *stream* `(String cql, Class<T> entityClass)`: Ad-hoc query for a stream of objects of type `T` from the table by providing a CQL statement.
 
 The query methods must specify the target type `T` that is returned.


### PR DESCRIPTION
- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACASS).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Sorry, there are 2 more typos in the documentation regarding Query objects. I didn't notice them until after https://github.com/spring-projects/spring-data-cassandra/pull/160 got merged.

'selectOneById' changed to 'selectOne' in that section.