### PR TITLE
DATACASS-465 - Introduces `@Frozen` annotation to mark schema elements as Frozen.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>3.0.0.DATACASS-465-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATACASS-465-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATACASS-465-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/ColumnType.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/ColumnType.java
@@ -88,8 +88,18 @@ public interface ColumnType {
 	 * @return
 	 */
 	static CassandraColumnType listOf(CassandraColumnType componentType) {
+		return listOf(componentType, FrozenInfo.NOT_FROZEN);
+	}
+	/**
+	 * Creates a List {@link ColumnType} given its {@link CassandraColumnType component type}.
+	 *
+	 * @param componentType must not be {@literal null}.
+	 * @param frozen
+	 * @return
+	 */
+	static CassandraColumnType listOf(CassandraColumnType componentType, FrozenInfo frozen) {
 		return new DefaultCassandraColumnType(ClassTypeInformation.LIST,
-				() -> DataTypes.listOf(componentType.getDataType()), componentType);
+				() -> DataTypes.listOf(componentType.getDataType(), frozen.self), componentType);
 	}
 
 	/**
@@ -114,7 +124,17 @@ public interface ColumnType {
 	 * @return
 	 */
 	static CassandraColumnType setOf(CassandraColumnType componentType) {
-		return new DefaultCassandraColumnType(ClassTypeInformation.SET, () -> DataTypes.setOf(componentType.getDataType()),
+		return setOf(componentType, FrozenInfo.NOT_FROZEN);
+	}
+	/**
+	 * Creates a Set {@link ColumnType} given its {@link CassandraColumnType component type}.
+	 *
+	 * @param componentType must not be {@literal null}.
+	 * @param frozen must not be {@literal null}.
+	 * @return
+	 */
+	static CassandraColumnType setOf(CassandraColumnType componentType, FrozenInfo frozen) {
+		return new DefaultCassandraColumnType(ClassTypeInformation.SET, () -> DataTypes.setOf(componentType.getDataType(),frozen.self),
 				componentType);
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/ColumnTypeResolver.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/ColumnTypeResolver.java
@@ -17,6 +17,7 @@ package org.springframework.data.cassandra.core.convert;
 
 import org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty;
 import org.springframework.data.cassandra.core.mapping.CassandraType;
+import org.springframework.data.cassandra.core.mapping.Frozen;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -61,6 +62,21 @@ public interface ColumnTypeResolver {
 	 * @throws org.springframework.dao.InvalidDataAccessApiUsageException
 	 */
 	CassandraColumnType resolve(TypeInformation<?> typeInformation);
+
+	/**
+	 * Resolve a {@link CassandraColumnType} from {@link TypeInformation}. Considers potentially registered custom
+	 * converters and simple type rules.
+	 *
+	 * @param typeInformation must not be {@literal null}.
+	 * @param frozen must not be {@literal null}.
+	 * @return
+	 * @see org.springframework.data.cassandra.core.mapping.CassandraSimpleTypeHolder
+	 * @see CassandraCustomConversions
+	 * @throws org.springframework.dao.InvalidDataAccessApiUsageException
+	 */
+	default CassandraColumnType resolve(TypeInformation<?> typeInformation, FrozenInfo frozen) {
+		return resolve(typeInformation, FrozenInfo.NOT_FROZEN);
+	}
 
 	/**
 	 * Resolve a {@link CassandraColumnType} from a {@link CassandraType} annotation.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/FrozenInfo.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/FrozenInfo.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.convert;
+
+/**
+ * Information about if a type or its elements should be frozen or not.
+ */
+public class FrozenInfo {
+
+	public static final FrozenInfo NOT_FROZEN = new FrozenInfo();
+
+	final boolean self;
+	final boolean firstTypeParameter;
+	final boolean secondTypeParameter;
+
+	public static FrozenInfo frozen(boolean frozen) {
+		return new FrozenInfo(frozen);
+	}
+
+	private FrozenInfo() {
+		this(false, false, false);
+	}
+
+	private FrozenInfo(boolean selfFrozen) {
+		this(selfFrozen, false, false);
+	}
+
+	private FrozenInfo(boolean self, boolean firstTypeParameter, boolean secondTypeParameter) {
+
+		this.self = self;
+		this.firstTypeParameter = firstTypeParameter;
+		this.secondTypeParameter = secondTypeParameter;
+	}
+
+	FrozenInfo withFirstTypeParameter(boolean firstTypeParameter) {
+		return new FrozenInfo(self, firstTypeParameter, secondTypeParameter);
+	}
+
+	FrozenInfo withSecondTypeParameter(boolean secondTypeParameter) {
+		return new FrozenInfo(self, firstTypeParameter, secondTypeParameter);
+	}
+
+	FrozenInfo forFirstTypeParameter() {
+		return new FrozenInfo(firstTypeParameter);
+	}
+
+	FrozenInfo forSecondTypeParameter() {
+		return new FrozenInfo(secondTypeParameter);
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/Frozen.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/Frozen.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies a type as "frozen".
+ *
+ * @author Jens Schauder
+ * @see <a href="https://express-cassandra.readthedocs.io/en/stable/advanced/#frozen-collections">Documentation about frozen collections</a>
+ * @since 3.0
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.TYPE_USE, ElementType.FIELD, ElementType.METHOD})
+public @interface Frozen {
+
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverterMappedTupleUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverterMappedTupleUnitTests.java
@@ -28,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import org.springframework.data.cassandra.core.mapping.BasicCassandraPersistentEntity;
 import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.core.mapping.Element;

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQueryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQueryUnitTests.java
@@ -89,6 +89,7 @@ public class PartTreeCassandraQueryUnitTests {
 		when(attachmentPoint.getCodecRegistry()).thenReturn(CodecRegistry.DEFAULT);
 		when(attachmentPoint.getProtocolVersion()).thenReturn(ProtocolVersion.DEFAULT);
 
+		when(userTypeMock.copy(anyBoolean())).thenReturn(userTypeMock);
 		when(userTypeMock.getAttachmentPoint()).thenReturn(attachmentPoint);
 		when(userTypeMock.getFieldNames())
 				.thenReturn(Arrays.asList("city", "country").stream().map(CqlIdentifier::fromCql).collect(Collectors.toList()));


### PR DESCRIPTION
`@Frozen` is supported on UDTs, collection like properties (`Set`, `List` and `Map`), and their type parameters if those are UDTs.

For example

    @Frozen Map<String, @Frozen MyUdt> propertyName;

Issue: https://jira.spring.io/browse/DATACASS-465