### PR TITLE
DATACASS-167 - Add support for embedded entities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-cassandra-parent</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>3.0.0.DATACASS-167-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Cassandra</name>

--- a/spring-data-cassandra-distribution/pom.xml
+++ b/spring-data-cassandra-distribution/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATACASS-167-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-cassandra-parent</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.DATACASS-167-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/IndexSpecificationFactory.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/IndexSpecificationFactory.java
@@ -42,6 +42,7 @@ import org.springframework.util.StringUtils;
  * index-annotated {@link CassandraPersistentProperty properties}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.0
  * @see Indexed
  * @see SASI
@@ -124,7 +125,7 @@ class IndexSpecificationFactory {
 		return indexes;
 	}
 
-	private static CreateIndexSpecification createIndexSpecification(Indexed annotation,
+	static CreateIndexSpecification createIndexSpecification(Indexed annotation,
 			CassandraPersistentProperty property) {
 
 		CreateIndexSpecification index;

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverter.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverter.java
@@ -27,7 +27,6 @@ import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.context.ApplicationContext;
@@ -41,6 +40,9 @@ import org.springframework.data.cassandra.core.mapping.BasicMapId;
 import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
 import org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty;
+import org.springframework.data.cassandra.core.mapping.Embedded;
+import org.springframework.data.cassandra.core.mapping.Embedded.OnEmpty;
+import org.springframework.data.cassandra.core.mapping.EmbeddedEntityOperations;
 import org.springframework.data.cassandra.core.mapping.MapId;
 import org.springframework.data.cassandra.core.mapping.MapIdentifiable;
 import org.springframework.data.cassandra.core.mapping.UserTypeResolver;
@@ -83,6 +85,7 @@ import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
  * @author Mark Paluch
  * @author Antoine Toulme
  * @author John Blum
+ * @author Christoph Strobl
  */
 public class MappingCassandraConverter extends AbstractCassandraConverter
 		implements ApplicationContextAware, BeanClassLoaderAware {
@@ -100,6 +103,7 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 	private SpELContext spELContext;
 
 	private final DefaultColumnTypeResolver cassandraTypeResolver;
+	private final EmbeddedEntityOperations embeddedEntityOperations;
 
 	/**
 	 * Create a new {@link MappingCassandraConverter} with a {@link CassandraMappingContext}.
@@ -117,6 +121,7 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 				userTypeName -> getUserTypeResolver().resolveType(userTypeName), this::getCodecRegistry,
 				this::getCustomConversions);
 		this.setCustomConversions(conversions);
+		this.embeddedEntityOperations = new EmbeddedEntityOperations(mappingContext);
 	}
 
 	/**
@@ -137,6 +142,7 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 				userTypeName -> getUserTypeResolver().resolveType(userTypeName), this::getCodecRegistry,
 				this::getCustomConversions);
 		this.setCustomConversions(mappingContext.getCustomConversions());
+		this.embeddedEntityOperations = new EmbeddedEntityOperations(mappingContext);
 	}
 
 	private static ConversionService newConversionService() {
@@ -404,7 +410,7 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 			return;
 		}
 
-		if (property.isCompositePrimaryKey() || valueProvider.hasProperty(property)) {
+		if (property.isCompositePrimaryKey() || valueProvider.hasProperty(property) || property.isEmbedded()) {
 			propertyAccessor.setProperty(property, getReadValue(valueProvider, property));
 		}
 	}
@@ -493,11 +499,21 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 				continue;
 			}
 
-			if (log.isDebugEnabled()) {
-				log.debug("Adding map.entry [{}] - [{}]", property.getRequiredColumnName(), value);
-			}
+			if (value != null && property.isEmbedded() && property.isEntity()) {
 
-			sink.put(property.getRequiredColumnName(), value);
+				if (log.isDebugEnabled()) {
+					log.debug("Mapping embedded property [{}] - [{}]", property.getRequiredColumnName(), value);
+				}
+
+				write(value, sink, embeddedEntityOperations.getEntity(property));
+			} else {
+
+				if (log.isDebugEnabled()) {
+					log.debug("Adding map.entry [{}] - [{}]", property.getRequiredColumnName(), value);
+				}
+
+				sink.put(property.getRequiredColumnName(), value);
+			}
 		}
 	}
 
@@ -625,6 +641,7 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 				continue;
 			}
 
+			// value resolution
 			Object value = getWriteValue(property, propertyAccessor);
 
 			if (log.isDebugEnabled()) {
@@ -634,6 +651,23 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 
 			if (log.isDebugEnabled()) {
 				log.debug("Adding udt.value [{}] - [{}]", property.getRequiredColumnName(), value);
+			}
+
+			if (property.isEmbedded() && property.isEntity()) {
+
+				if (log.isDebugEnabled()) {
+					log.debug("Mapping embedded property [{}] - [{}]", property.getRequiredColumnName(), value);
+				}
+
+				if (value == null) {
+					continue;
+				}
+
+				CassandraPersistentEntity<?> targetEntity = embeddedEntityOperations.getEntity(property);
+				writeUDTValue(new ConvertingPropertyAccessor<>(targetEntity.getPropertyAccessor(value), getConversionService()),
+						udtValue, targetEntity);
+
+				continue;
 			}
 
 			TypeCodec<Object> typeCodec = getCodec(property);
@@ -900,12 +934,43 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 			return doReadEntity(keyEntity, valueProvider);
 		}
 
+		if (property.isEntity() && property.isEmbedded()) {
+
+			CassandraPersistentEntity<?> targetEntity = embeddedEntityOperations.getEntity(property);
+			return isNullEmbedded(targetEntity, property, valueProvider) ? null : doReadEntity(targetEntity, valueProvider);
+		}
+
 		if (!valueProvider.hasProperty(property)) {
 			return null;
 		}
 
 		Object value = valueProvider.getPropertyValue(property);
 		return value == null ? null : convertReadValue(value, property.getTypeInformation());
+	}
+
+	/**
+	 * @param entity the property domain type
+	 * @param property the current property annotated with {@link Embedded}.
+	 * @param valueProvider
+	 * @return {@literal true} if the property represents a {@link Embedded.Nullable nullable embedded} entity where all
+	 *         values obtainable from the given {@link CassandraValueProvider} are {@literal null}.
+	 * @since 3.0
+	 */
+	private boolean isNullEmbedded(CassandraPersistentEntity<?> entity, CassandraPersistentProperty property,
+			CassandraValueProvider valueProvider) {
+
+		if (OnEmpty.USE_EMPTY.equals(property.findAnnotation(Embedded.class).onEmpty())) {
+			return false;
+		}
+
+		for (CassandraPersistentProperty embeddedProperty : entity) {
+
+			if (valueProvider.hasProperty(embeddedProperty) && valueProvider.getPropertyValue(embeddedProperty) != null) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	@Nullable
@@ -1123,5 +1188,4 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 			return parent.getSource();
 		}
 	}
-
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentProperty.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentProperty.java
@@ -34,6 +34,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * @author David T. Webb
  * @author Mark Paluch
  * @author John Blum
+ * @author Christoph Strobl
  */
 public interface CassandraPersistentProperty
 		extends PersistentProperty<CassandraPersistentProperty>, ApplicationContextAware {
@@ -156,6 +157,14 @@ public interface CassandraPersistentProperty
 	 * @see #isClusterKeyColumn()
 	 */
 	boolean isPrimaryKeyColumn();
+
+	/**
+	 * @return {@literal true} if the property should be embedded.
+	 * @since 3.0
+	 */
+	default boolean isEmbedded() {
+		return findAnnotation(Embedded.class) != null;
+	}
 
 	/**
 	 * Find an {@link AnnotatedType} by {@code annotationType} derived from the property type. Annotated type is looked up

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/Embedded.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/Embedded.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.annotation.meta.When;
+
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * @author Christoph Strobl
+ * @since 3.0
+ */
+@Documented
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+public @interface Embedded {
+	/**
+	 * Set the load strategy for the embedded object if all contained fields yield {@literal null} values.
+	 * <p />
+	 * {@link Nullable @Embedded.Nullable} and {@link Empty @Embedded.Empty} offer shortcuts for this.
+	 *
+	 * @return never {@link} null.
+	 */
+	OnEmpty onEmpty();
+
+	/**
+	 * @return prefix for columns in the embedded value object. An empty {@link String} by default.
+	 */
+	String prefix() default "";
+
+	/**
+	 * Load strategy to be used {@link Embedded#onEmpty()}.
+	 *
+	 * @author Christoph Strobl
+	 * @since 1.1
+	 */
+	enum OnEmpty {
+		USE_NULL, USE_EMPTY
+	}
+
+	/**
+	 * Shortcut for a nullable embedded property.
+	 *
+	 * <pre>
+	 * <code>
+	 * &#64;Embedded.Nullable
+	 * private Address address;
+	 * </code>
+	 * </pre>
+	 *
+	 * as alternative to the more verbose
+	 *
+	 * <pre>
+	 * <code>
+	 *
+	 * &#64;Embedded(onEmpty = USE_NULL)
+	 * &#64;javax.annotation.Nonnull(when = When.MAYBE)
+	 * private Address address;
+	 *
+	 * </code>
+	 * </pre>
+	 *
+	 * @author Christoph Strobl
+	 * @since 3.0
+	 * @see Embedded#onEmpty()
+	 */
+	@Embedded(onEmpty = OnEmpty.USE_NULL)
+	@Documented
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.FIELD, ElementType.METHOD })
+	@javax.annotation.Nonnull(when = When.MAYBE)
+	@interface Nullable {
+
+		/**
+		 * @return prefix for columns in the embedded value object. An empty {@link String} by default.
+		 */
+		@AliasFor(annotation = Embedded.class, attribute = "prefix")
+		String prefix() default "";
+	}
+
+	/**
+	 * Shortcut for an empty embedded property.
+	 *
+	 * <pre>
+	 * <code>
+	 * &#64;Embedded.Empty
+	 * private Address address;
+	 * </code>
+	 * </pre>
+	 *
+	 * as alternative to the more verbose
+	 *
+	 * <pre>
+	 * <code>
+	 *
+	 * &#64;Embedded(onEmpty = USE_EMPTY)
+	 * &#64;javax.annotation.Nonnull(when = When.NEVER)
+	 * private Address address;
+	 *
+	 * </code>
+	 * </pre>
+	 *
+	 * @author Christoph Strobl
+	 * @since 3.0
+	 * @see Embedded#onEmpty()
+	 */
+	@Embedded(onEmpty = OnEmpty.USE_EMPTY)
+	@Documented
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.FIELD, ElementType.METHOD })
+	@javax.annotation.Nonnull(when = When.NEVER)
+	@interface Empty {
+
+		/**
+		 * @return prefix for columns in the embedded value object. An empty {@link String} by default.
+		 */
+		@AliasFor(annotation = Embedded.class, attribute = "prefix")
+		String prefix() default "";
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
@@ -1,0 +1,610 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core.mapping;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.cassandra.core.cql.Ordering;
+import org.springframework.data.cassandra.core.mapping.Embedded.Nullable;
+import org.springframework.data.mapping.*;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.util.StringUtils;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+
+/**
+ * @author Christoph Strobl
+ * @since 3.0
+ */
+public class EmbeddedEntityOperations {
+
+	private final MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> mappingContext;
+
+	public EmbeddedEntityOperations(MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> mappingContext) {
+		this.mappingContext = mappingContext;
+	}
+
+	public CassandraPersistentEntity<?> getEntity(CassandraPersistentProperty property) {
+		return withPrefix(getPrefix(property), mappingContext.getPersistentEntity(property));
+	}
+
+	static <T> CassandraPersistentEntity<T> withPrefix(@org.springframework.lang.Nullable String prefix,
+			CassandraPersistentEntity<T> source) {
+
+		if (!StringUtils.hasText(prefix)) {
+			return source;
+		}
+
+		return new PrefixedCassandraPersistentEntity<>(prefix, source);
+	}
+
+	@Nullable
+	static String getPrefix(CassandraPersistentProperty property) {
+
+		Embedded embedded = property.findAnnotation(Embedded.class);
+		return embedded != null ? embedded.prefix() : null;
+	}
+
+	static class PrefixedCassandraPersistentEntity<T> implements CassandraPersistentEntity<T> {
+
+		private final String prefix;
+		private CassandraPersistentEntity<T> delegate;
+
+		public PrefixedCassandraPersistentEntity(String prefix, CassandraPersistentEntity<T> delegate) {
+
+			this.prefix = prefix;
+			this.delegate = delegate;
+		}
+
+		@Override
+		public boolean isCompositePrimaryKey() {
+			return delegate.isCompositePrimaryKey();
+		}
+
+		@Override
+		@Deprecated
+		public void setForceQuote(boolean forceQuote) {
+			delegate.setForceQuote(forceQuote);
+		}
+
+		@Override
+		public CqlIdentifier getTableName() {
+			return delegate.getTableName();
+		}
+
+		@Override
+		@Deprecated
+		public void setTableName(org.springframework.data.cassandra.core.cql.CqlIdentifier tableName) {
+			delegate.setTableName(tableName);
+		}
+
+		@Override
+		public void setTableName(CqlIdentifier tableName) {
+			delegate.setTableName(tableName);
+		}
+
+		@Override
+		public boolean isTupleType() {
+			return delegate.isTupleType();
+		}
+
+		@Override
+		public boolean isUserDefinedType() {
+			return delegate.isUserDefinedType();
+		}
+
+		@Override
+		public String getName() {
+			return delegate.getName();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public PreferredConstructor<T, CassandraPersistentProperty> getPersistenceConstructor() {
+			return delegate.getPersistenceConstructor();
+		}
+
+		@Override
+		public boolean isConstructorArgument(PersistentProperty<?> property) {
+			return delegate.isConstructorArgument(property);
+		}
+
+		@Override
+		public boolean isIdProperty(PersistentProperty<?> property) {
+			return delegate.isIdProperty(property);
+		}
+
+		@Override
+		public boolean isVersionProperty(PersistentProperty<?> property) {
+			return delegate.isVersionProperty(property);
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public CassandraPersistentProperty getIdProperty() {
+			return delegate.getIdProperty();
+		}
+
+		@Override
+		public CassandraPersistentProperty getRequiredIdProperty() {
+			return delegate.getRequiredIdProperty();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public CassandraPersistentProperty getVersionProperty() {
+			return delegate.getVersionProperty();
+		}
+
+		@Override
+		public CassandraPersistentProperty getRequiredVersionProperty() {
+			return delegate.getRequiredVersionProperty();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public CassandraPersistentProperty getPersistentProperty(String name) {
+			return new PrefixedCassandraPersistentProperty(prefix, delegate.getPersistentProperty(name));
+		}
+
+		@Override
+		public CassandraPersistentProperty getRequiredPersistentProperty(String name) {
+			return new PrefixedCassandraPersistentProperty(prefix, delegate.getRequiredPersistentProperty(name));
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public CassandraPersistentProperty getPersistentProperty(Class<? extends Annotation> annotationType) {
+			return new PrefixedCassandraPersistentProperty(prefix, delegate.getPersistentProperty(annotationType));
+		}
+
+		@Override
+		public Iterable<CassandraPersistentProperty> getPersistentProperties(Class<? extends Annotation> annotationType) {
+			return delegate.getPersistentProperties(annotationType);
+		}
+
+		@Override
+		public boolean hasIdProperty() {
+			return delegate.hasIdProperty();
+		}
+
+		@Override
+		public boolean hasVersionProperty() {
+			return delegate.hasVersionProperty();
+		}
+
+		@Override
+		public Class<T> getType() {
+			return delegate.getType();
+		}
+
+		@Override
+		public Alias getTypeAlias() {
+			return delegate.getTypeAlias();
+		}
+
+		@Override
+		public TypeInformation<T> getTypeInformation() {
+			return delegate.getTypeInformation();
+		}
+
+		@Override
+		public void doWithProperties(PropertyHandler<CassandraPersistentProperty> handler) {
+
+			delegate.doWithProperties((PropertyHandler<CassandraPersistentProperty>) property -> {
+				handler.doWithPersistentProperty(wrap(property));
+			});
+		}
+
+		@Override
+		public void doWithProperties(SimplePropertyHandler handler) {
+
+			delegate.doWithProperties((SimplePropertyHandler) property -> {
+
+				if (property instanceof CassandraPersistentProperty) {
+					handler.doWithPersistentProperty(wrap((CassandraPersistentProperty) property));
+				} else {
+					handler.doWithPersistentProperty(property);
+				}
+			});
+			delegate.doWithProperties(handler);
+		}
+
+		@Override
+		public void doWithAssociations(AssociationHandler<CassandraPersistentProperty> handler) {
+			delegate.doWithAssociations(handler);
+		}
+
+		@Override
+		public void doWithAssociations(SimpleAssociationHandler handler) {
+			delegate.doWithAssociations(handler);
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public <A extends Annotation> A findAnnotation(Class<A> annotationType) {
+			return delegate.findAnnotation(annotationType);
+		}
+
+		@Override
+		public <A extends Annotation> A getRequiredAnnotation(Class<A> annotationType) throws IllegalStateException {
+			return delegate.getRequiredAnnotation(annotationType);
+		}
+
+		@Override
+		public <A extends Annotation> boolean isAnnotationPresent(Class<A> annotationType) {
+			return delegate.isAnnotationPresent(annotationType);
+		}
+
+		@Override
+		public <B> PersistentPropertyAccessor<B> getPropertyAccessor(B bean) {
+			return delegate.getPropertyAccessor(bean);
+		}
+
+		@Override
+		public <B> PersistentPropertyPathAccessor<B> getPropertyPathAccessor(B bean) {
+			return delegate.getPropertyPathAccessor(bean);
+		}
+
+		@Override
+		public IdentifierAccessor getIdentifierAccessor(Object bean) {
+			return delegate.getIdentifierAccessor(bean);
+		}
+
+		@Override
+		public boolean isNew(Object bean) {
+			return delegate.isNew(bean);
+		}
+
+		@Override
+		public boolean isImmutable() {
+			return delegate.isImmutable();
+		}
+
+		@Override
+		public boolean requiresPropertyPopulation() {
+			return delegate.requiresPropertyPopulation();
+		}
+
+		@NotNull
+		@Override
+		public Iterator<CassandraPersistentProperty> iterator() {
+
+			List<CassandraPersistentProperty> target = new ArrayList<>();
+			delegate.iterator().forEachRemaining(it -> target.add(wrap(it)));
+			return target.iterator();
+		}
+
+		@Override
+		public void forEach(Consumer<? super CassandraPersistentProperty> action) {
+			delegate.forEach(it -> action.accept(wrap(it)));
+		}
+
+		@Override
+		public Spliterator<CassandraPersistentProperty> spliterator() {
+			return delegate.spliterator();
+		}
+
+		private PrefixedCassandraPersistentProperty wrap(CassandraPersistentProperty source) {
+			return new PrefixedCassandraPersistentProperty(prefix, source);
+		}
+	}
+
+	static class PrefixedCassandraPersistentProperty implements CassandraPersistentProperty {
+
+		private final String prefix;
+		private final CassandraPersistentProperty delegate;
+
+		public PrefixedCassandraPersistentProperty(String prefix, CassandraPersistentProperty delegate) {
+			this.prefix = prefix;
+			this.delegate = delegate;
+		}
+
+		@Override
+		@Deprecated
+		public void setColumnName(org.springframework.data.cassandra.core.cql.CqlIdentifier columnName) {
+			delegate.setColumnName(columnName);
+		}
+
+		@Override
+		public void setColumnName(CqlIdentifier columnName) {
+			delegate.setColumnName(columnName);
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public CqlIdentifier getColumnName() {
+			return CqlIdentifier.fromInternal(prefix + delegate.getColumnName().asInternal());
+		}
+
+		@Override
+		@Deprecated
+		public void setForceQuote(boolean forceQuote) {
+			delegate.setForceQuote(forceQuote);
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public Integer getOrdinal() {
+			return delegate.getOrdinal();
+		}
+
+		@Override
+		public int getRequiredOrdinal() {
+			return delegate.getRequiredOrdinal();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public Ordering getPrimaryKeyOrdering() {
+			return delegate.getPrimaryKeyOrdering();
+		}
+
+		@Override
+		public boolean isClusterKeyColumn() {
+			return delegate.isClusterKeyColumn();
+		}
+
+		@Override
+		public boolean isCompositePrimaryKey() {
+			return delegate.isCompositePrimaryKey();
+		}
+
+		@Override
+		public boolean isMapLike() {
+			return delegate.isMapLike();
+		}
+
+		@Override
+		public boolean isPartitionKeyColumn() {
+			return delegate.isPartitionKeyColumn();
+		}
+
+		@Override
+		public boolean isPrimaryKeyColumn() {
+			return delegate.isPrimaryKeyColumn();
+		}
+
+		@Override
+		public boolean isEmbedded() {
+			return delegate.isEmbedded();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public AnnotatedType findAnnotatedType(Class<? extends Annotation> annotationType) {
+			return delegate.findAnnotatedType(annotationType);
+		}
+
+		@Override
+		public PersistentEntity<?, CassandraPersistentProperty> getOwner() {
+			return delegate.getOwner();
+		}
+
+		@Override
+		public String getName() {
+			return delegate.getName();
+		}
+
+		@Override
+		public Class<?> getType() {
+			return delegate.getType();
+		}
+
+		@Override
+		public TypeInformation<?> getTypeInformation() {
+			return delegate.getTypeInformation();
+		}
+
+		@Override
+		public Iterable<? extends TypeInformation<?>> getPersistentEntityTypes() {
+			return delegate.getPersistentEntityTypes();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public Method getGetter() {
+			return delegate.getGetter();
+		}
+
+		@Override
+		public Method getRequiredGetter() {
+			return delegate.getRequiredGetter();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public Method getSetter() {
+			return delegate.getSetter();
+		}
+
+		@Override
+		public Method getRequiredSetter() {
+			return delegate.getRequiredSetter();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public Method getWither() {
+			return delegate.getWither();
+		}
+
+		@Override
+		public Method getRequiredWither() {
+			return delegate.getRequiredWither();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public Field getField() {
+			return delegate.getField();
+		}
+
+		@Override
+		public Field getRequiredField() {
+			return delegate.getRequiredField();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public String getSpelExpression() {
+			return delegate.getSpelExpression();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public Association<CassandraPersistentProperty> getAssociation() {
+			return delegate.getAssociation();
+		}
+
+		@Override
+		public Association<CassandraPersistentProperty> getRequiredAssociation() {
+			return delegate.getRequiredAssociation();
+		}
+
+		@Override
+		public boolean isEntity() {
+			return delegate.isEntity();
+		}
+
+		@Override
+		public boolean isIdProperty() {
+			return delegate.isIdProperty();
+		}
+
+		@Override
+		public boolean isVersionProperty() {
+			return delegate.isVersionProperty();
+		}
+
+		@Override
+		public boolean isCollectionLike() {
+			return delegate.isCollectionLike();
+		}
+
+		@Override
+		public boolean isMap() {
+			return delegate.isMap();
+		}
+
+		@Override
+		public boolean isArray() {
+			return delegate.isArray();
+		}
+
+		@Override
+		public boolean isTransient() {
+			return delegate.isTransient();
+		}
+
+		@Override
+		public boolean isWritable() {
+			return delegate.isWritable();
+		}
+
+		@Override
+		public boolean isImmutable() {
+			return delegate.isImmutable();
+		}
+
+		@Override
+		public boolean isAssociation() {
+			return delegate.isAssociation();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public Class<?> getComponentType() {
+			return delegate.getComponentType();
+		}
+
+		@Override
+		public Class<?> getRawType() {
+			return delegate.getRawType();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public Class<?> getMapValueType() {
+			return delegate.getMapValueType();
+		}
+
+		@Override
+		public Class<?> getActualType() {
+			return delegate.getActualType();
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public <A extends Annotation> A findAnnotation(Class<A> annotationType) {
+			return delegate.findAnnotation(annotationType);
+		}
+
+		@Override
+		public <A extends Annotation> A getRequiredAnnotation(Class<A> annotationType) throws IllegalStateException {
+			return delegate.getRequiredAnnotation(annotationType);
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public <A extends Annotation> A findPropertyOrOwnerAnnotation(Class<A> annotationType) {
+			return delegate.findPropertyOrOwnerAnnotation(annotationType);
+		}
+
+		@Override
+		public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+			return delegate.isAnnotationPresent(annotationType);
+		}
+
+		@Override
+		public boolean usePropertyAccess() {
+			return delegate.usePropertyAccess();
+		}
+
+		@Override
+		public boolean hasActualTypeAnnotation(Class<? extends Annotation> annotationType) {
+			return delegate.hasActualTypeAnnotation(annotationType);
+		}
+
+		@Override
+		@org.springframework.lang.Nullable
+		public Class<?> getAssociationTargetType() {
+			return delegate.getAssociationTargetType();
+		}
+
+		@Override
+		public <T> PersistentPropertyAccessor<T> getAccessorForOwner(T owner) {
+			return delegate.getAccessorForOwner(owner);
+		}
+
+		@Override
+		public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+			delegate.setApplicationContext(applicationContext);
+		}
+	}
+}

--- a/src/main/asciidoc/reference/mapping.adoc
+++ b/src/main/asciidoc/reference/mapping.adoc
@@ -344,6 +344,63 @@ public class LoginEvent {
 ----
 ====
 
+[[mapping.embedded-entities]]
+=== Embedded Entity Support
+
+Embedded entities are used to have value objects in your java data model who's properties are flattened out into the table.
+In the following example you see, that `User.name` is annotated with `@Embedded`.
+The consequence of this is the properties of `UserName` are folded into the `user` table which consists of 3 columns (`user_id`, `firstname`, `lastname`).
+
+[WARNING]
+====
+Embedded entities may only contain simple property types. It is not possible to nest an embedded entity into another embedded one.
+====
+
+However, if the `firstname` and `lastname` column values are actually `null` within the result set, the entire property `name` will be set to `null` according to the `onEmpty` of `@Embedded`, which ``null``s objects when all nested properties are `null`. +
+Opposite to this behavior `USE_EMPTY` tries to create a new instance using either a default constructor or one that accepts nullable parameter values from the result set.
+
+.Sample Code of embedding objects
+====
+[source, java]
+----
+public class User {
+
+	@PrimaryKey("user_id")
+    private String userId;
+
+    @Embedded(onEmpty = USE_NULL) <1>
+    UserName name;
+}
+
+public class UserName {
+    private String firstname;
+    private String lastname;
+}
+----
+<1> ``Null``s `embeddedEntity` if `name` in `null`. Use `USE_EMPTY` to instantiate `embeddedEntity` with a potential `null` value for the `name` property.
+====
+
+If you need a value object multiple times in an entity, this can be achieved with the optional `prefix` element of the `@Embedded` annotation.
+This element represents a prefix and is prepend for each column name in the embedded object.
+
+[TIP]
+====
+Make use of the shortcuts `@Embedded.Nullable` & `@Embedded.Empty` for `@Embedded(onEmpty = USE_NULL)` and `@Embedded(onEmpty = USE_EMPTY)` to reduce verbosity and simultaneously set JSR-305 `@javax.annotation.Nonnull` accordingly.
+
+[source, java]
+----
+public class MyEntity {
+
+    @Id
+    Integer id;
+
+    @Embedded.Nullable <1>
+    EmbeddedEntity embeddedEntity;
+}
+----
+<1> Shortcut for `@Embedded(onEmpty = USE_NULL)`.
+====
+
 [[mapping.usage-annotations]]
 === Mapping Annotation Overview
 
@@ -439,6 +496,11 @@ The following example shows a number of ways to create an index:
 ----
 include::../{example-root}/mapping/PersonWithIndexes.java[tags=class]
 ----
+====
+
+[NOTE]
+====
+The `@Indexed` annotation can be applied to single properties of embedded entities or along side with the `@Embedded` annotation, in which case all properties of the embedded are indexed.
 ====
 
 CAUTION: Index creation on session initialization may have a severe performance impact on application startup.


### PR DESCRIPTION
Embedded entities are used to have value objects in your java data model who's properties are flattened out into the table.
In the following example you see, that `User.name` is annotated with `@Embedded`.
The consequence of this is the properties of `UserName` are folded into the `user` table which consists of 3 columns (`user_id`, `firstname`, `lastname`).

Embedded entities may only contain simple property types. It is not possible to nest an embedded entity into another embedded one.

However, if the `firstname` and `lastname` column values are actually `null` within the result set, the entire property `name` will be set to `null` according to the `onEmpty` of `@Embedded`, which ``null``s objects when all nested properties are `null`.

Opposite to this behaviour `USE_EMPTY` tries to create a new instance using either a default constructor or one that accepts nullable parameter values from the result set.

```java
public class User {

    @PrimaryKey("user_id")
    private String userId;

    @Embedded(onEmpty = USE_NULL)
    UserName name;
}

public class UserName {
    private String firstname;
    private String lastname;
}
```

If you need a value object multiple times in an entity, this can be achieved with the optional `prefix` element of the `@Embedded` annotation.
This element represents a prefix and is prepend for each column name in the embedded object.

The `@Indexed` annotation can be applied to single properties of embedded entities or along side with the `@Embedded` annotation, in which case all properties of the embedded are indexed.

Query derivation follows the general rules using either camel case or explicit underscore notation when accessing properties of the embedded type in a repository query method.

```java
public interface UserRepository extends CassandraRepository<User, String> {
    User findByName_Firstname(String firstname);
}
``` 

On template level paths to embedded properties use the `.` (dot) notation.

```java
Criteria.where("name.firstname").is("walter")
``` 

