### PR TITLE
DATACASS-751: Allow keyspace customization for CassandraPersistentEntity

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
@@ -771,7 +771,8 @@ public class AsyncCassandraTemplate
 		Assert.notNull(entityClass, "Entity type must not be null");
 
 		TableCoordinates tableCoordinates = constructTableCoordinates(entityClass);
-		Truncate truncate = QueryBuilder.truncate(tableCoordinates.getTableName());
+		Truncate truncate = QueryBuilder.truncate(tableCoordinates.getKeyspaceName().orElse(null),
+				tableCoordinates.getTableName());
 		SimpleStatement statement = truncate.build();
 
 		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entityClass, tableCoordinates.getTableName()));

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
@@ -271,8 +271,8 @@ public class AsyncCassandraTemplate
 		return getEntityOperations().getTableName(entityClass);
 	}
 
-	private CqlIdentifier getKeyspace(Class<?> entityClass) {
-		return getEntityOperations().getKeyspace(entityClass);
+	private @Nullable CqlIdentifier getKeyspaceName(Class<?> entityClass) {
+		return getEntityOperations().getKeyspaceName(entityClass);
 	}
 
 	// -------------------------------------------------------------------------
@@ -488,7 +488,7 @@ public class AsyncCassandraTemplate
 
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doCount(Query.empty(), entityClass, getKeyspace(entityClass), getTableName(entityClass));
+		return doCount(Query.empty(), entityClass, getKeyspaceName(entityClass), getTableName(entityClass));
 	}
 
 	/* (non-Javadoc)
@@ -500,7 +500,7 @@ public class AsyncCassandraTemplate
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doCount(query, entityClass, getKeyspace(entityClass), getTableName(entityClass));
+		return doCount(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass));
 	}
 
 	ListenableFuture<Long> doCount(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace,
@@ -528,7 +528,7 @@ public class AsyncCassandraTemplate
 		CassandraPersistentEntity<?> entity = getRequiredPersistentEntity(entityClass);
 
 		StatementBuilder<com.datastax.oss.driver.api.querybuilder.select.Select> select = getStatementFactory()
-				.selectOneById(id, entity, entity.getKeyspace(), entity.getTableName());
+				.selectOneById(id, entity, entity.getKeyspaceName(), entity.getTableName());
 
 		return new MappingListenableFutureAdapter<>(getAsyncCqlOperations().queryForResultSet(select.build()),
 				resultSet -> resultSet.one() != null);
@@ -544,7 +544,7 @@ public class AsyncCassandraTemplate
 		Assert.notNull(entityClass, "Entity type must not be null");
 
 		StatementBuilder<com.datastax.oss.driver.api.querybuilder.select.Select> select = getStatementFactory()
-				.select(query.limit(1), getRequiredPersistentEntity(entityClass), getKeyspace(entityClass),
+				.select(query.limit(1), getRequiredPersistentEntity(entityClass), getKeyspaceName(entityClass),
 						getTableName(entityClass));
 
 		return new MappingListenableFutureAdapter<>(getAsyncCqlOperations().queryForResultSet(select.build()),
@@ -562,7 +562,8 @@ public class AsyncCassandraTemplate
 
 		CassandraPersistentEntity<?> entity = getRequiredPersistentEntity(entityClass);
 		CqlIdentifier tableName = entity.getTableName();
-		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity, entity.getKeyspace(), tableName);
+		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity, entity.getKeyspaceName(),
+				tableName);
 		Function<Row, T> mapper = getMapper(entityClass, entityClass, tableName);
 
 		return new MappingListenableFutureAdapter<>(

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/AsyncCassandraTemplate.java
@@ -267,13 +267,13 @@ public class AsyncCassandraTemplate
 		return this.statementFactory;
 	}
 
-	private CqlIdentifier getTableName(Class<?> entityClass) {
-		return getEntityOperations().getTableName(entityClass);
+	private TableCoordinates constructTableCoordinates(Class<?> entityClass) {
+		EntityOperations entityOperations = getEntityOperations();
+		return TableCoordinates.of(entityOperations.getKeyspaceName(entityClass),
+				entityOperations.getTableName(entityClass));
 	}
 
-	private @Nullable CqlIdentifier getKeyspaceName(Class<?> entityClass) {
-		return getEntityOperations().getKeyspaceName(entityClass);
-	}
+
 
 	// -------------------------------------------------------------------------
 	// Methods dealing with static CQL
@@ -458,20 +458,22 @@ public class AsyncCassandraTemplate
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doDelete(query, entityClass, getTableName(entityClass));
+		return doDelete(query, entityClass, constructTableCoordinates(entityClass));
 	}
 
-	private ListenableFuture<Boolean> doDelete(Query query, Class<?> entityClass, CqlIdentifier tableName) {
+	private ListenableFuture<Boolean> doDelete(Query query, Class<?> entityClass, TableCoordinates tableCoordinates) {
 
 		StatementBuilder<Delete> builder = getStatementFactory().delete(query, getRequiredPersistentEntity(entityClass),
-				tableName);
+				tableCoordinates);
 		SimpleStatement delete = builder.build();
 
-		maybeEmitEvent(new BeforeDeleteEvent<>(delete, entityClass, tableName));
+		maybeEmitEvent(new BeforeDeleteEvent<>(delete, entityClass, tableCoordinates.getTableName()));
 
 		ListenableFuture<Boolean> future = getAsyncCqlOperations().execute(delete);
 
-		future.addCallback(success -> maybeEmitEvent(new AfterDeleteEvent<>(delete, entityClass, tableName)), e -> {});
+		future.addCallback(
+				success -> maybeEmitEvent(new AfterDeleteEvent<>(delete, entityClass, tableCoordinates.getTableName())),
+				e -> {});
 
 		return future;
 	}
@@ -488,7 +490,7 @@ public class AsyncCassandraTemplate
 
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doCount(Query.empty(), entityClass, getKeyspaceName(entityClass), getTableName(entityClass));
+		return doCount(Query.empty(), entityClass, constructTableCoordinates(entityClass));
 	}
 
 	/* (non-Javadoc)
@@ -500,14 +502,13 @@ public class AsyncCassandraTemplate
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doCount(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass));
+		return doCount(query, entityClass, constructTableCoordinates(entityClass));
 	}
 
-	ListenableFuture<Long> doCount(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace,
-			CqlIdentifier tableName) {
+	ListenableFuture<Long> doCount(Query query, Class<?> entityClass, TableCoordinates tableCoordinates) {
 
 		StatementBuilder<com.datastax.oss.driver.api.querybuilder.select.Select> countStatement = getStatementFactory()
-				.count(query, getRequiredPersistentEntity(entityClass), keyspace, tableName);
+				.count(query, getRequiredPersistentEntity(entityClass), tableCoordinates);
 
 		SimpleStatement statement = countStatement.build();
 
@@ -528,7 +529,7 @@ public class AsyncCassandraTemplate
 		CassandraPersistentEntity<?> entity = getRequiredPersistentEntity(entityClass);
 
 		StatementBuilder<com.datastax.oss.driver.api.querybuilder.select.Select> select = getStatementFactory()
-				.selectOneById(id, entity, entity.getKeyspaceName(), entity.getTableName());
+				.selectOneById(id, entity, TableCoordinates.of(entity));
 
 		return new MappingListenableFutureAdapter<>(getAsyncCqlOperations().queryForResultSet(select.build()),
 				resultSet -> resultSet.one() != null);
@@ -544,8 +545,7 @@ public class AsyncCassandraTemplate
 		Assert.notNull(entityClass, "Entity type must not be null");
 
 		StatementBuilder<com.datastax.oss.driver.api.querybuilder.select.Select> select = getStatementFactory()
-				.select(query.limit(1), getRequiredPersistentEntity(entityClass), getKeyspaceName(entityClass),
-						getTableName(entityClass));
+				.select(query.limit(1), getRequiredPersistentEntity(entityClass), constructTableCoordinates(entityClass));
 
 		return new MappingListenableFutureAdapter<>(getAsyncCqlOperations().queryForResultSet(select.build()),
 				resultSet -> resultSet.one() != null);
@@ -562,8 +562,8 @@ public class AsyncCassandraTemplate
 
 		CassandraPersistentEntity<?> entity = getRequiredPersistentEntity(entityClass);
 		CqlIdentifier tableName = entity.getTableName();
-		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity, entity.getKeyspaceName(),
-				tableName);
+		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity,
+				TableCoordinates.of(entity));
 		Function<Row, T> mapper = getMapper(entityClass, entityClass, tableName);
 
 		return new MappingListenableFutureAdapter<>(
@@ -588,38 +588,40 @@ public class AsyncCassandraTemplate
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "InsertOptions must not be null");
 
-		return doInsert(entity, options, getTableName(entity.getClass()));
+		return doInsert(entity, options, constructTableCoordinates(entity.getClass()));
 	}
 
-	private <T> ListenableFuture<EntityWriteResult<T>> doInsert(T entity, WriteOptions options, CqlIdentifier tableName) {
+	private <T> ListenableFuture<EntityWriteResult<T>> doInsert(T entity, WriteOptions options,
+			TableCoordinates tableCoordinates) {
 
-		AdaptibleEntity<T> source = getEntityOperations().forEntity(maybeCallBeforeConvert(entity, tableName),
+		AdaptibleEntity<T> source = getEntityOperations().forEntity(
+				maybeCallBeforeConvert(entity, tableCoordinates.getTableName()),
 				getConverter().getConversionService());
 		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
 
 		T entityToUse = source.isVersionedEntity() ? source.initializeVersionProperty() : entity;
 
 		StatementBuilder<RegularInsert> builder = getStatementFactory().insert(entityToUse, options, persistentEntity,
-				tableName);
+				tableCoordinates);
 
 		if (source.isVersionedEntity()) {
 
 			builder.apply(Insert::ifNotExists);
-			return doInsertVersioned(builder.build(), entityToUse, source, tableName);
+			return doInsertVersioned(builder.build(), entityToUse, source, tableCoordinates);
 		}
 
-		return doInsert(builder.build(), entityToUse, source, tableName);
+		return doInsert(builder.build(), entityToUse, source, tableCoordinates);
 	}
 
 	private <T> ListenableFuture<EntityWriteResult<T>> doInsertVersioned(SimpleStatement insert, T entity,
-			AdaptibleEntity<T> source, CqlIdentifier tableName) {
+			AdaptibleEntity<T> source, TableCoordinates tableCoordinates) {
 
-		return executeSave(entity, tableName, insert, result -> {
+		return executeSave(entity, tableCoordinates, insert, result -> {
 
 			if (!result.wasApplied()) {
 				throw new OptimisticLockingFailureException(
 						String.format("Cannot insert entity %s with version %s into table %s as it already exists", entity,
-								source.getVersion(), tableName));
+								source.getVersion(), tableCoordinates.getTableName()));
 			}
 		});
 	}
@@ -627,9 +629,9 @@ public class AsyncCassandraTemplate
 	@SuppressWarnings("unused")
 	private <T> ListenableFuture<EntityWriteResult<T>> doInsert(SimpleStatement insert, T entity,
 			AdaptibleEntity<T> source,
-			CqlIdentifier tableName) {
+			TableCoordinates tableCoordinates) {
 
-		return executeSave(entity, tableName, insert);
+		return executeSave(entity, tableCoordinates, insert);
 	}
 
 	/* (non-Javadoc)
@@ -651,40 +653,41 @@ public class AsyncCassandraTemplate
 
 		AdaptibleEntity<T> source = getEntityOperations().forEntity(entity, getConverter().getConversionService());
 		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
-		CqlIdentifier tableName = persistentEntity.getTableName();
+		TableCoordinates tableCoordinates = TableCoordinates.of(persistentEntity);
 
-		T entityToUpdate = maybeCallBeforeConvert(entity, tableName);
+		T entityToUpdate = maybeCallBeforeConvert(entity, tableCoordinates.getTableName());
 
-		return source.isVersionedEntity() ? doUpdateVersioned(entityToUpdate, options, tableName, persistentEntity)
-				: doUpdate(entityToUpdate, options, tableName, persistentEntity);
+		return source.isVersionedEntity() ? doUpdateVersioned(entityToUpdate, options, tableCoordinates, persistentEntity)
+				: doUpdate(entityToUpdate, options, tableCoordinates, persistentEntity);
 	}
 
 	private <T> ListenableFuture<EntityWriteResult<T>> doUpdateVersioned(T entity, UpdateOptions options,
-			CqlIdentifier tableName, CassandraPersistentEntity<?> persistentEntity) {
+			TableCoordinates tableCoordinates, CassandraPersistentEntity<?> persistentEntity) {
 
 		AdaptibleEntity<T> source = getEntityOperations().forEntity(entity, getConverter().getConversionService());
 		Number previousVersion = source.getVersion();
 		T toSave = source.incrementVersion();
 
-		StatementBuilder<Update> update = getStatementFactory().update(toSave, options, persistentEntity, tableName);
+		StatementBuilder<Update> update = getStatementFactory().update(toSave, options, persistentEntity, tableCoordinates);
 		source.appendVersionCondition(update, previousVersion);
 
-		return executeSave(toSave, tableName, update.build(), result -> {
+		return executeSave(toSave, tableCoordinates, update.build(), result -> {
 
 			if (!result.wasApplied()) {
 				throw new OptimisticLockingFailureException(
 						String.format("Cannot save entity %s with version %s to table %s. Has it been modified meanwhile?", toSave,
-								source.getVersion(), tableName));
+								source.getVersion(), tableCoordinates));
 			}
 		});
 	}
 
-	private <T> ListenableFuture<EntityWriteResult<T>> doUpdate(T entity, UpdateOptions options, CqlIdentifier tableName,
+	private <T> ListenableFuture<EntityWriteResult<T>> doUpdate(T entity, UpdateOptions options,
+			TableCoordinates tableCoordinates,
 			CassandraPersistentEntity<?> persistentEntity) {
 
-		StatementBuilder<Update> update = getStatementFactory().update(entity, options, persistentEntity, tableName);
+		StatementBuilder<Update> update = getStatementFactory().update(entity, options, persistentEntity, tableCoordinates);
 
-		return executeSave(entity, tableName, update.build());
+		return executeSave(entity, tableCoordinates, update.build());
 	}
 
 	/* (non-Javadoc)
@@ -706,33 +709,34 @@ public class AsyncCassandraTemplate
 
 		AdaptibleEntity<Object> source = getEntityOperations().forEntity(entity, getConverter().getConversionService());
 		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
-		CqlIdentifier tableName = persistentEntity.getTableName();
+		TableCoordinates tableCoordinates = TableCoordinates.of(persistentEntity);
 
-		return source.isVersionedEntity() ? doDeleteVersioned(entity, options, source, tableName)
-				: doDelete(entity, options, tableName);
+		return source.isVersionedEntity() ? doDeleteVersioned(entity, options, source, tableCoordinates)
+				: doDelete(entity, options, tableCoordinates);
 	}
 
 	private ListenableFuture<WriteResult> doDeleteVersioned(Object entity, QueryOptions options,
-			AdaptibleEntity<Object> source, CqlIdentifier tableName) {
+			AdaptibleEntity<Object> source, TableCoordinates tableCoordinates) {
 
-		StatementBuilder<Delete> delete = getStatementFactory().delete(entity, options, getConverter(), tableName);
+		StatementBuilder<Delete> delete = getStatementFactory().delete(entity, options, getConverter(), tableCoordinates);
 		;
 
-		return executeDelete(entity, tableName, source.appendVersionCondition(delete).build(), result -> {
+		return executeDelete(entity, tableCoordinates, source.appendVersionCondition(delete).build(), result -> {
 
 			if (!result.wasApplied()) {
 				throw new OptimisticLockingFailureException(
 						String.format("Cannot delete entity %s with version %s in table %s. Has it been modified meanwhile?",
-								entity, source.getVersion(), tableName));
+								entity, source.getVersion(), tableCoordinates));
 			}
 		});
 	}
 
-	private ListenableFuture<WriteResult> doDelete(Object entity, QueryOptions options, CqlIdentifier tableName) {
+	private ListenableFuture<WriteResult> doDelete(Object entity, QueryOptions options,
+			TableCoordinates tableCoordinates) {
 
-		StatementBuilder<Delete> delete = getStatementFactory().delete(entity, options, getConverter(), tableName);
+		StatementBuilder<Delete> delete = getStatementFactory().delete(entity, options, getConverter(), tableCoordinates);
 
-		return executeDelete(entity, tableName, delete.build(), result -> {});
+		return executeDelete(entity, tableCoordinates, delete.build(), result -> {});
 	}
 
 	/* (non-Javadoc)
@@ -766,14 +770,16 @@ public class AsyncCassandraTemplate
 
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		CqlIdentifier tableName = getTableName(entityClass);
-		Truncate truncate = QueryBuilder.truncate(tableName);
+		TableCoordinates tableCoordinates = constructTableCoordinates(entityClass);
+		Truncate truncate = QueryBuilder.truncate(tableCoordinates.getTableName());
 		SimpleStatement statement = truncate.build();
 
-		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entityClass, tableName));
+		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entityClass, tableCoordinates.getTableName()));
 
 		ListenableFuture<Boolean> future = getAsyncCqlOperations().execute(statement);
-		future.addCallback(success -> maybeEmitEvent(new AfterDeleteEvent<>(statement, entityClass, tableName)), e -> {});
+		future.addCallback(
+				success -> maybeEmitEvent(new AfterDeleteEvent<>(statement, entityClass, tableCoordinates.getTableName())),
+				e -> {});
 
 		return new MappingListenableFutureAdapter<>(future, aBoolean -> null);
 	}
@@ -782,17 +788,17 @@ public class AsyncCassandraTemplate
 	// Implementation hooks and utility methods
 	// -------------------------------------------------------------------------
 
-	private <T> ListenableFuture<EntityWriteResult<T>> executeSave(T entity, CqlIdentifier tableName,
+	private <T> ListenableFuture<EntityWriteResult<T>> executeSave(T entity, TableCoordinates tableCoordinates,
 			SimpleStatement statement) {
 
-		return executeSave(entity, tableName, statement, ignore -> {});
+		return executeSave(entity, tableCoordinates, statement, ignore -> {});
 	}
 
-	private <T> ListenableFuture<EntityWriteResult<T>> executeSave(T entity, CqlIdentifier tableName,
+	private <T> ListenableFuture<EntityWriteResult<T>> executeSave(T entity, TableCoordinates tableCoordinates,
 			SimpleStatement statement, Consumer<WriteResult> beforeAfterSaveEvent) {
-
-		maybeEmitEvent(new BeforeSaveEvent<>(entity, tableName, statement));
-		T entityToSave = maybeCallBeforeSave(entity, tableName, statement);
+		// todo leverage getKeyspaceName()
+		maybeEmitEvent(new BeforeSaveEvent<>(entity, tableCoordinates.getTableName(), statement));
+		T entityToSave = maybeCallBeforeSave(entity, tableCoordinates.getTableName(), statement);
 
 		ListenableFuture<AsyncResultSet> result = getAsyncCqlOperations().execute(new AsyncStatementCallback(statement));
 
@@ -804,16 +810,17 @@ public class AsyncCassandraTemplate
 
 			beforeAfterSaveEvent.accept(writeResult);
 
-			maybeEmitEvent(new AfterSaveEvent<>(entityToSave, tableName));
+			maybeEmitEvent(new AfterSaveEvent<>(entityToSave, tableCoordinates.getTableName()));
 
 			return writeResult;
 		});
 	}
 
-	private ListenableFuture<WriteResult> executeDelete(Object entity, CqlIdentifier tableName, SimpleStatement statement,
+	private ListenableFuture<WriteResult> executeDelete(Object entity, TableCoordinates tableCoordinates,
+			SimpleStatement statement,
 			Consumer<WriteResult> resultConsumer) {
 
-		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entity.getClass(), tableName));
+		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entity.getClass(), tableCoordinates.getTableName()));
 
 		ListenableFuture<AsyncResultSet> result = getAsyncCqlOperations().execute(new AsyncStatementCallback(statement));
 
@@ -824,7 +831,7 @@ public class AsyncCassandraTemplate
 
 			resultConsumer.accept(writeResult);
 
-			maybeEmitEvent(new AfterDeleteEvent<>(statement, entity.getClass(), tableName));
+			maybeEmitEvent(new AfterDeleteEvent<>(statement, entity.getClass(), tableCoordinates.getTableName()));
 
 			return writeResult;
 		});

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraBatchTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraBatchTemplate.java
@@ -31,6 +31,7 @@ import com.datastax.oss.driver.api.core.cql.BatchStatement;
 import com.datastax.oss.driver.api.core.cql.BatchStatementBuilder;
 import com.datastax.oss.driver.api.core.cql.BatchType;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
 
 /**
  * Default implementation for {@link CassandraBatchOperations}.
@@ -38,6 +39,7 @@ import com.datastax.oss.driver.api.core.cql.SimpleStatement;
  * @author Mark Paluch
  * @author John Blum
  * @author Anup Sabbi
+ * @author Tomasz Lelek
  * @since 1.5
  */
 class CassandraBatchTemplate implements CassandraBatchOperations {
@@ -168,7 +170,7 @@ class CassandraBatchTemplate implements CassandraBatchOperations {
 					.getRequiredPersistentEntity(entity.getClass());
 
 			SimpleStatement insertQuery = getStatementFactory()
-					.insert(entity, options, persistentEntity, persistentEntity.getTableName()).build();
+					.insert(entity, options, persistentEntity, TableCoordinates.of(persistentEntity)).build();
 
 			this.batch.addStatement(insertQuery);
 		}
@@ -213,7 +215,7 @@ class CassandraBatchTemplate implements CassandraBatchOperations {
 			CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
 
 			SimpleStatement update = getStatementFactory()
-					.update(entity, options, persistentEntity, persistentEntity.getTableName()).build();
+					.update(entity, options, persistentEntity, TableCoordinates.of(persistentEntity)).build();
 
 			this.batch.addStatement(update);
 		}
@@ -258,7 +260,7 @@ class CassandraBatchTemplate implements CassandraBatchOperations {
 			CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
 
 			SimpleStatement delete = getStatementFactory()
-					.delete(entity, options, this.getConverter(), persistentEntity.getTableName()).build();
+					.delete(entity, options, this.getConverter(), TableCoordinates.of(persistentEntity)).build();
 
 			this.batch.addStatement(delete);
 		}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
@@ -89,7 +89,8 @@ public interface CassandraOperations extends FluentCassandraOperations {
 	 * @param entityClass The entity type may be {@literal null}.
 	 * @return the {@link CqlIdentifier}
 	 */
-	@Nullable CqlIdentifier getKeyspace(Class<?> entityClass);
+	@Nullable
+	CqlIdentifier getKeyspaceName(Class<?> entityClass);
 
 	// -------------------------------------------------------------------------
 	// Methods dealing with static CQL

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
@@ -17,6 +17,7 @@ package org.springframework.data.cassandra.core;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.springframework.dao.DataAccessException;
@@ -24,7 +25,6 @@ import org.springframework.data.cassandra.core.convert.CassandraConverter;
 import org.springframework.data.cassandra.core.cql.CqlOperations;
 import org.springframework.data.cassandra.core.cql.QueryOptions;
 import org.springframework.data.cassandra.core.cql.WriteOptions;
-import org.springframework.data.cassandra.core.mapping.Embedded;
 import org.springframework.data.cassandra.core.query.CassandraPageRequest;
 import org.springframework.data.cassandra.core.query.Query;
 import org.springframework.data.cassandra.core.query.Update;
@@ -86,11 +86,11 @@ public interface CassandraOperations extends FluentCassandraOperations {
 	/**
 	 * The keyspace used for the specified class by this template.
 	 *
-	 * @param entityClass The entity type may be {@literal null}.
-	 * @return the {@link CqlIdentifier}
+	 * @param entityClass entity class, may be {@literal null}.
+	 * @return the {@link Optional<CqlIdentifier> } the keyspace to which the entity shall be persisted. If null, then
+	 *         default session-level keyspace will be used.
 	 */
-	@Nullable
-	CqlIdentifier getKeyspaceName(Class<?> entityClass);
+	Optional<CqlIdentifier> getKeyspaceName(Class<?> entityClass);
 
 	// -------------------------------------------------------------------------
 	// Methods dealing with static CQL

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraOperations.java
@@ -24,6 +24,7 @@ import org.springframework.data.cassandra.core.convert.CassandraConverter;
 import org.springframework.data.cassandra.core.cql.CqlOperations;
 import org.springframework.data.cassandra.core.cql.QueryOptions;
 import org.springframework.data.cassandra.core.cql.WriteOptions;
+import org.springframework.data.cassandra.core.mapping.Embedded;
 import org.springframework.data.cassandra.core.query.CassandraPageRequest;
 import org.springframework.data.cassandra.core.query.Query;
 import org.springframework.data.cassandra.core.query.Update;
@@ -41,6 +42,7 @@ import com.datastax.oss.driver.api.core.cql.Statement;
  * @author David Webb
  * @author Matthew Adams
  * @author Mark Paluch
+ * @author Tomasz Lelek
  * @see CassandraTemplate
  * @see CqlOperations
  * @see Statement
@@ -79,6 +81,15 @@ public interface CassandraOperations extends FluentCassandraOperations {
 	 * @return the {@link CqlIdentifier}
 	 */
 	CqlIdentifier getTableName(Class<?> entityClass);
+
+
+	/**
+	 * The keyspace used for the specified class by this template.
+	 *
+	 * @param entityClass The entity type may be {@literal null}.
+	 * @return the {@link CqlIdentifier}
+	 */
+	@Nullable CqlIdentifier getKeyspace(Class<?> entityClass);
 
 	// -------------------------------------------------------------------------
 	// Methods dealing with static CQL

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -283,11 +283,11 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 	}
 
 	/* (non-Javadoc)
-	 * @see org.springframework.data.cassandra.core.CassandraOperations#getKeyspace(java.lang.Class)
+	 * @see org.springframework.data.cassandra.core.CassandraOperations#getKeyspaceName(java.lang.Class)
 	 */
 	@Override
-	public CqlIdentifier getKeyspace(Class<?> entityClass) {
-		return getEntityOperations().getKeyspace(entityClass);
+	public CqlIdentifier getKeyspaceName(Class<?> entityClass) {
+		return getEntityOperations().getKeyspaceName(entityClass);
 	}
 
 	// -------------------------------------------------------------------------
@@ -402,7 +402,7 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doSelect(query, entityClass, getKeyspace(entityClass), getTableName(entityClass), entityClass);
+		return doSelect(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass), entityClass);
 	}
 
 	<T> List<T> doSelect(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName,
@@ -455,7 +455,7 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doStream(query, entityClass, getKeyspace(entityClass), getTableName(entityClass), entityClass);
+		return doStream(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass), entityClass);
 	}
 
 	<T> Stream<T> doStream(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName,
@@ -551,7 +551,7 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doCount(query, entityClass, getKeyspace(entityClass), getTableName(entityClass));
+		return doCount(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass));
 	}
 
 	long doCount(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName) {
@@ -575,7 +575,7 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(entityClass, "Entity type must not be null");
 
 		CassandraPersistentEntity<?> entity = getRequiredPersistentEntity(entityClass);
-		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity, entity.getKeyspace(),
+		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity, entity.getKeyspaceName(),
 				entity.getTableName());
 
 		return getCqlOperations().queryForResultSet(select.build()).one() != null;
@@ -590,7 +590,7 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doExists(query, entityClass, getKeyspace(entityClass), getTableName(entityClass));
+		return doExists(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass));
 	}
 
 	boolean doExists(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName) {
@@ -612,7 +612,7 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 
 		CassandraPersistentEntity<?> entity = getRequiredPersistentEntity(entityClass);
 		CqlIdentifier tableName = entity.getTableName();
-		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity, entity.getKeyspace(), tableName);
+		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity, entity.getKeyspaceName(), tableName);
 		Function<Row, T> mapper = getMapper(entityClass, entityClass, tableName);
 		List<T> result = getCqlOperations().query(select.build(), (row, rowNum) -> mapper.apply(row));
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -16,11 +16,13 @@
 package org.springframework.data.cassandra.core;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -123,7 +125,7 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 	 *
 	 * @param session {@link CqlSession} used to interact with Cassandra; must not be {@literal null}.
 	 * @see CassandraConverter
-	 * @see Session
+	 * @see CqlSession
 	 */
 	public CassandraTemplate(CqlSession session) {
 		this(session, newConverter());
@@ -137,7 +139,7 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 	 * @param converter {@link CassandraConverter} used to convert between Java and Cassandra types; must not be
 	 *          {@literal null}.
 	 * @see CassandraConverter
-	 * @see Session
+	 * @see CqlSession
 	 */
 	public CassandraTemplate(CqlSession session, CassandraConverter converter) {
 		this(new DefaultSessionFactory(session), converter);
@@ -165,7 +167,7 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 	 * @param converter {@link CassandraConverter} used to convert between Java and Cassandra types; must not be
 	 *          {@literal null}.
 	 * @see CassandraConverter
-	 * @see Session
+	 * @see CqlSession
 	 */
 	public CassandraTemplate(CqlOperations cqlOperations, CassandraConverter converter) {
 
@@ -286,8 +288,12 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#getKeyspaceName(java.lang.Class)
 	 */
 	@Override
-	public CqlIdentifier getKeyspaceName(Class<?> entityClass) {
+	public Optional<CqlIdentifier> getKeyspaceName(Class<?> entityClass) {
 		return getEntityOperations().getKeyspaceName(entityClass);
+	}
+
+	private TableCoordinates getTableCoordinates(Class<?> entityClass){
+		return TableCoordinates.of(getKeyspaceName(entityClass), getTableName(entityClass));
 	}
 
 	// -------------------------------------------------------------------------
@@ -402,10 +408,10 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doSelect(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass), entityClass);
+		return doSelect(query, entityClass, getTableCoordinates(entityClass), entityClass);
 	}
 
-	<T> List<T> doSelect(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName,
+	<T> List<T> doSelect(Query query, Class<?> entityClass, TableCoordinates tableCoordinates,
 			Class<T> returnType) {
 
 		CassandraPersistentEntity<?> entity = getRequiredPersistentEntity(entityClass);
@@ -414,9 +420,9 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 
 		Query queryToUse = query.columns(columns);
 
-		StatementBuilder<Select> select = getStatementFactory().select(queryToUse, entity, keyspace, tableName);
+		StatementBuilder<Select> select = getStatementFactory().select(queryToUse, entity, tableCoordinates);
 
-		Function<Row, T> mapper = getMapper(entityClass, returnType, tableName);
+		Function<Row, T> mapper = getMapper(entityClass, returnType, tableCoordinates.getTableName());
 
 		return getCqlOperations().query(select.build(), (row, rowNum) -> mapper.apply(row));
 	}
@@ -455,18 +461,18 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doStream(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass), entityClass);
+		return doStream(query, entityClass, getTableCoordinates(entityClass), entityClass);
 	}
 
-	<T> Stream<T> doStream(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName,
+	<T> Stream<T> doStream(Query query, Class<?> entityClass, TableCoordinates tableCoordinates,
 			Class<T> returnType) {
 
 		StatementBuilder<Select> select = getStatementFactory().select(query, getRequiredPersistentEntity(entityClass),
-				keyspace, tableName);
+				tableCoordinates);
 
 		ResultSet resultSet = getCqlOperations().queryForResultSet(select.build());
 
-		Function<Row, T> mapper = getMapper(entityClass, returnType, tableName);
+		Function<Row, T> mapper = getMapper(entityClass, returnType, tableCoordinates.getTableName());
 		return StreamSupport.stream(resultSet.map(mapper).spliterator(), false);
 	}
 
@@ -489,10 +495,10 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 
 	@Nullable
 	WriteResult doUpdate(Query query, org.springframework.data.cassandra.core.query.Update update, Class<?> entityClass,
-			CqlIdentifier tableName) {
+			TableCoordinates tableCoordinates) {
 
 		StatementBuilder<Update> updateStatement = getStatementFactory().update(query, update,
-				getRequiredPersistentEntity(entityClass), tableName);
+				getRequiredPersistentEntity(entityClass), tableCoordinates);
 
 		return getCqlOperations().execute(new StatementCallback(updateStatement.build()));
 	}
@@ -506,23 +512,23 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		WriteResult result = doDelete(query, entityClass, getTableName(entityClass));
+		WriteResult result = doDelete(query, entityClass, getTableCoordinates(entityClass));
 
 		return result != null && result.wasApplied();
 	}
 
 	@Nullable
-	WriteResult doDelete(Query query, Class<?> entityClass, CqlIdentifier tableName) {
+	WriteResult doDelete(Query query, Class<?> entityClass, TableCoordinates tableCoordinates) {
 
 		StatementBuilder<Delete> delete = getStatementFactory().delete(query, getRequiredPersistentEntity(entityClass),
-				tableName);
+				tableCoordinates);
 		SimpleStatement statement = delete.build();
 
-		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entityClass, tableName));
+		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entityClass, tableCoordinates.getTableName()));
 
 		WriteResult writeResult = getCqlOperations().execute(new StatementCallback(statement));
 
-		maybeEmitEvent(new AfterDeleteEvent<>(statement, entityClass, tableName));
+		maybeEmitEvent(new AfterDeleteEvent<>(statement, entityClass, tableCoordinates.getTableName()));
 
 		return writeResult;
 	}
@@ -551,13 +557,13 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doCount(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass));
+		return doCount(query, entityClass, getTableCoordinates(entityClass));
 	}
 
-	long doCount(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName) {
+	long doCount(Query query, Class<?> entityClass, TableCoordinates tableCoordinates) {
 
 		StatementBuilder<Select> countStatement = getStatementFactory().count(query,
-				getRequiredPersistentEntity(entityClass), keyspace, tableName);
+				getRequiredPersistentEntity(entityClass), tableCoordinates);
 
 		SimpleStatement statement = countStatement.build();
 		Long count = getCqlOperations().queryForObject(statement, Long.class);
@@ -575,11 +581,11 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(entityClass, "Entity type must not be null");
 
 		CassandraPersistentEntity<?> entity = getRequiredPersistentEntity(entityClass);
-		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity, entity.getKeyspaceName(),
-				entity.getTableName());
+		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity, TableCoordinates.of(entity));
 
 		return getCqlOperations().queryForResultSet(select.build()).one() != null;
 	}
+
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.cassandra.core.CassandraOperations#exists(org.springframework.data.cassandra.core.query.Query, java.lang.Class)
@@ -590,13 +596,13 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doExists(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass));
+		return doExists(query, entityClass, getTableCoordinates(entityClass));
 	}
 
-	boolean doExists(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName) {
+	boolean doExists(Query query, Class<?> entityClass, TableCoordinates tableCoordinates) {
 
 		StatementBuilder<Select> select = getStatementFactory().select(query.limit(1),
-				getRequiredPersistentEntity(entityClass), keyspace, tableName);
+				getRequiredPersistentEntity(entityClass), tableCoordinates);
 
 		return getCqlOperations().queryForResultSet(select.build()).one() != null;
 	}
@@ -611,9 +617,9 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(entityClass, "Entity type must not be null");
 
 		CassandraPersistentEntity<?> entity = getRequiredPersistentEntity(entityClass);
-		CqlIdentifier tableName = entity.getTableName();
-		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity, entity.getKeyspaceName(), tableName);
-		Function<Row, T> mapper = getMapper(entityClass, entityClass, tableName);
+		TableCoordinates tableCoordinates = TableCoordinates.of(entity);
+		StatementBuilder<Select> select = getStatementFactory().selectOneById(id, entity, tableCoordinates);
+		Function<Row, T> mapper = getMapper(entityClass, entityClass, tableCoordinates.getTableName());
 		List<T> result = getCqlOperations().query(select.build(), (row, rowNum) -> mapper.apply(row));
 
 		return result.isEmpty() ? null : result.get(0);
@@ -636,43 +642,43 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Assert.notNull(entity, "Entity must not be null");
 		Assert.notNull(options, "InsertOptions must not be null");
 
-		return doInsert(entity, options, getTableName(entity.getClass()));
+		return doInsert(entity, options, getTableCoordinates(entity.getClass()));
 	}
 
-	<T> EntityWriteResult<T> doInsert(T entity, WriteOptions options, CqlIdentifier tableName) {
+	<T> EntityWriteResult<T> doInsert(T entity, WriteOptions options, TableCoordinates tableCoordinates) {
 
-		AdaptibleEntity<T> source = getEntityOperations().forEntity(maybeCallBeforeConvert(entity, tableName),
+		AdaptibleEntity<T> source = getEntityOperations().forEntity(maybeCallBeforeConvert(entity, tableCoordinates.getTableName()),
 				getConverter().getConversionService());
 
 		T entityToUse = source.isVersionedEntity() ? source.initializeVersionProperty() : entity;
 
 		StatementBuilder<RegularInsert> builder = getStatementFactory().insert(entityToUse, options,
-				source.getPersistentEntity(), tableName);
+				source.getPersistentEntity(), tableCoordinates);
 
 		if (source.isVersionedEntity()) {
 
 			builder.apply(Insert::ifNotExists);
-			return doInsertVersioned(builder.build(), entityToUse, source, tableName);
+			return doInsertVersioned(builder.build(), entityToUse, source, tableCoordinates);
 		}
 
-		return doInsert(builder.build(), entityToUse, tableName);
+		return doInsert(builder.build(), entityToUse, tableCoordinates);
 	}
 
 	private <T> EntityWriteResult<T> doInsertVersioned(SimpleStatement insert, T entity, AdaptibleEntity<T> source,
-			CqlIdentifier tableName) {
+			TableCoordinates tableCoordinates) {
 
-		return executeSave(entity, tableName, insert, result -> {
+		return executeSave(entity, tableCoordinates, insert, result -> {
 
 			if (!result.wasApplied()) {
 				throw new OptimisticLockingFailureException(
 						String.format("Cannot insert entity %s with version %s into table %s as it already exists", entity,
-								source.getVersion(), tableName));
+								source.getVersion(), tableCoordinates.getTableName()));
 			}
 		});
 	}
 
-	private <T> EntityWriteResult<T> doInsert(SimpleStatement insert, T entity, CqlIdentifier tableName) {
-		return executeSave(entity, tableName, insert);
+	private <T> EntityWriteResult<T> doInsert(SimpleStatement insert, T entity, TableCoordinates tableCoordinates) {
+		return executeSave(entity, tableCoordinates, insert);
 	}
 
 	/* (non-Javadoc)
@@ -694,15 +700,15 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 
 		AdaptibleEntity<T> source = getEntityOperations().forEntity(entity, getConverter().getConversionService());
 		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
-		CqlIdentifier tableName = persistentEntity.getTableName();
+		TableCoordinates tableCoordinates = TableCoordinates.of(persistentEntity);
 
-		T entityToUpdate = maybeCallBeforeConvert(entity, tableName);
+		T entityToUpdate = maybeCallBeforeConvert(entity, tableCoordinates.getTableName());
 
-		return source.isVersionedEntity() ? doUpdateVersioned(entityToUpdate, options, tableName, persistentEntity)
-				: doUpdate(entityToUpdate, options, tableName, persistentEntity);
+		return source.isVersionedEntity() ? doUpdateVersioned(entityToUpdate, options, tableCoordinates, persistentEntity)
+				: doUpdate(entityToUpdate, options, tableCoordinates, persistentEntity);
 	}
 
-	private <T> EntityWriteResult<T> doUpdateVersioned(T entity, UpdateOptions options, CqlIdentifier tableName,
+	private <T> EntityWriteResult<T> doUpdateVersioned(T entity, UpdateOptions options, TableCoordinates tableCoordinates,
 			CassandraPersistentEntity<?> persistentEntity) {
 
 		AdaptibleEntity<T> source = getEntityOperations().forEntity(entity, getConverter().getConversionService());
@@ -710,25 +716,25 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 		Number previousVersion = source.getVersion();
 		T toSave = source.incrementVersion();
 
-		StatementBuilder<Update> builder = getStatementFactory().update(toSave, options, persistentEntity, tableName);
+		StatementBuilder<Update> builder = getStatementFactory().update(toSave, options, persistentEntity, tableCoordinates);
 		SimpleStatement update = source.appendVersionCondition(builder, previousVersion).build();
 
-		return executeSave(toSave, tableName, update, result -> {
+		return executeSave(toSave, tableCoordinates, update, result -> {
 
 			if (!result.wasApplied()) {
 				throw new OptimisticLockingFailureException(
 						String.format("Cannot save entity %s with version %s to table %s. Has it been modified meanwhile?", toSave,
-								source.getVersion(), tableName));
+								source.getVersion(), tableCoordinates.getTableName()));
 			}
 		});
 	}
 
-	private <T> EntityWriteResult<T> doUpdate(T entity, UpdateOptions options, CqlIdentifier tableName,
+	private <T> EntityWriteResult<T> doUpdate(T entity, UpdateOptions options, TableCoordinates tableCoordinates,
 			CassandraPersistentEntity<?> persistentEntity) {
 
-		StatementBuilder<Update> builder = getStatementFactory().update(entity, options, persistentEntity, tableName);
+		StatementBuilder<Update> builder = getStatementFactory().update(entity, options, persistentEntity, tableCoordinates);
 
-		return executeSave(entity, tableName, builder.build());
+		return executeSave(entity, tableCoordinates, builder.build());
 	}
 
 	/* (non-Javadoc)
@@ -750,31 +756,31 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 
 		AdaptibleEntity<Object> source = getEntityOperations().forEntity(entity, getConverter().getConversionService());
 		CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
-		CqlIdentifier tableName = persistentEntity.getTableName();
+		TableCoordinates tableCoordinates = TableCoordinates.of(persistentEntity);
 
-		StatementBuilder<Delete> builder = getStatementFactory().delete(entity, options, getConverter(), tableName);
+		StatementBuilder<Delete> builder = getStatementFactory().delete(entity, options, getConverter(), tableCoordinates);
 
 		return source.isVersionedEntity()
-				? doDeleteVersioned(source.appendVersionCondition(builder).build(), entity, source, tableName)
-				: doDelete(builder.build(), entity, tableName);
+				? doDeleteVersioned(source.appendVersionCondition(builder).build(), entity, source, tableCoordinates)
+				: doDelete(builder.build(), entity, tableCoordinates);
 
 	}
 
 	private WriteResult doDeleteVersioned(SimpleStatement statement, Object entity, AdaptibleEntity<Object> source,
-			CqlIdentifier tableName) {
+			TableCoordinates tableCoordinates) {
 
-		return executeDelete(entity, tableName, statement, result -> {
+		return executeDelete(entity, tableCoordinates, statement, result -> {
 
 			if (!result.wasApplied()) {
 				throw new OptimisticLockingFailureException(
 						String.format("Cannot delete entity %s with version %s in table %s. Has it been modified meanwhile?",
-								entity, source.getVersion(), tableName));
+								entity, source.getVersion(), tableCoordinates.getTableName()));
 			}
 		});
 	}
 
-	private WriteResult doDelete(SimpleStatement delete, Object entity, CqlIdentifier tableName) {
-		return executeDelete(entity, tableName, delete, result -> {});
+	private WriteResult doDelete(SimpleStatement delete, Object entity, TableCoordinates tableCoordinates) {
+		return executeDelete(entity, tableCoordinates, delete, result -> {});
 	}
 
 	/* (non-Javadoc)
@@ -860,34 +866,36 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 	// Implementation hooks and utility methods
 	// -------------------------------------------------------------------------
 
-	private <T> EntityWriteResult<T> executeSave(T entity, CqlIdentifier tableName, SimpleStatement statement) {
-		return executeSave(entity, tableName, statement, ignore -> {});
+	private <T> EntityWriteResult<T> executeSave(T entity, TableCoordinates tableCoordinates, SimpleStatement statement) {
+		return executeSave(entity, tableCoordinates, statement, ignore -> {});
 	}
 
-	private <T> EntityWriteResult<T> executeSave(T entity, CqlIdentifier tableName, SimpleStatement statement,
+	private <T> EntityWriteResult<T> executeSave(T entity, TableCoordinates tableCoordinates, SimpleStatement statement,
 			Consumer<WriteResult> resultConsumer) {
 
-		maybeEmitEvent(new BeforeSaveEvent<>(entity, tableName, statement));
-		T entityToSave = maybeCallBeforeSave(entity, tableName, statement);
+		// todo leverage tableCoordinates
+		maybeEmitEvent(new BeforeSaveEvent<>(entity, tableCoordinates.getTableName(), statement));
+		T entityToSave = maybeCallBeforeSave(entity, tableCoordinates.getTableName(), statement);
 
 		WriteResult result = getCqlOperations().execute(new StatementCallback(statement));
 		resultConsumer.accept(result);
 
-		maybeEmitEvent(new AfterSaveEvent<>(entityToSave, tableName));
+		maybeEmitEvent(new AfterSaveEvent<>(entityToSave, tableCoordinates.getTableName()));
 
 		return EntityWriteResult.of(result, entityToSave);
 	}
 
-	private WriteResult executeDelete(Object entity, CqlIdentifier tableName, SimpleStatement statement,
+	private WriteResult executeDelete(Object entity, TableCoordinates tableCoordinates, SimpleStatement statement,
 			Consumer<WriteResult> resultConsumer) {
+		// todo leverage tableCoordinates
 
-		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entity.getClass(), tableName));
+		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entity.getClass(), tableCoordinates.getTableName()));
 
 		WriteResult result = getCqlOperations().execute(new StatementCallback(statement));
 
 		resultConsumer.accept(result);
 
-		maybeEmitEvent(new AfterDeleteEvent<>(statement, entity.getClass(), tableName));
+		maybeEmitEvent(new AfterDeleteEvent<>(statement, entity.getClass(), tableCoordinates.getTableName()));
 
 		return result;
 	}
@@ -916,6 +924,7 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 	}
 
 	@SuppressWarnings("unchecked")
+	// todo should the mapper be per TableCoordinates, or only tableName?
 	private <T> Function<Row, T> getMapper(Class<?> entityType, Class<T> targetType, CqlIdentifier tableName) {
 
 		Class<?> typeToRead = resolveTypeToRead(entityType, targetType);

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -815,15 +815,16 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		CqlIdentifier tableName = getTableName(entityClass);
-		Truncate truncate = QueryBuilder.truncate(tableName);
+		TableCoordinates tableCoordinates = getTableCoordinates(entityClass);
+		Truncate truncate = QueryBuilder.truncate(tableCoordinates.getKeyspaceName().orElse(null),
+				tableCoordinates.getTableName());
 		SimpleStatement statement = truncate.build();
 
-		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entityClass, tableName));
+		maybeEmitEvent(new BeforeDeleteEvent<>(statement, entityClass, tableCoordinates.getTableName()));
 
 		getCqlOperations().execute(statement);
 
-		maybeEmitEvent(new AfterDeleteEvent<>(statement, entityClass, tableName));
+		maybeEmitEvent(new AfterDeleteEvent<>(statement, entityClass, tableCoordinates.getTableName()));
 	}
 
 	// -------------------------------------------------------------------------

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/EntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/EntityOperations.java
@@ -36,6 +36,7 @@ import com.datastax.oss.driver.api.querybuilder.update.Update;
  *
  * @author Mark Paluch
  * @author John Blum
+ * @author Tomasz Lelek
  * @see CassandraTemplate
  * @see AsyncCassandraTemplate
  * @see ReactiveCassandraTemplate
@@ -98,6 +99,19 @@ class EntityOperations {
 	CqlIdentifier getTableName(Class<?> entityClass) {
 		return getRequiredPersistentEntity(entityClass).getTableName();
 	}
+
+	/**
+	 * Returns the kespace to which the entity shall be persisted.
+	 *
+	 * @param entityClass entity class, may be {@literal null}.
+	 * @return the keyspace to which the entity shall be persisted.
+	 * If null, then default session-level keyspace will be used.
+	 */
+	@Nullable
+	CqlIdentifier getKeyspace(Class<?> entityClass) {
+		return getRequiredPersistentEntity(entityClass).getKeyspace();
+	}
+
 
 
 	protected MappingContext<? extends CassandraPersistentEntity<?>, CassandraPersistentProperty> getMappingContext() {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/EntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/EntityOperations.java
@@ -108,8 +108,8 @@ class EntityOperations {
 	 * If null, then default session-level keyspace will be used.
 	 */
 	@Nullable
-	CqlIdentifier getKeyspace(Class<?> entityClass) {
-		return getRequiredPersistentEntity(entityClass).getKeyspace();
+	CqlIdentifier getKeyspaceName(Class<?> entityClass) {
+		return getRequiredPersistentEntity(entityClass).getKeyspaceName();
 	}
 
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/EntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/EntityOperations.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.cassandra.core;
 
+import java.util.Optional;
+
 import org.springframework.core.convert.ConversionService;
 import org.springframework.data.cassandra.core.cql.util.StatementBuilder;
 import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
@@ -101,14 +103,13 @@ class EntityOperations {
 	}
 
 	/**
-	 * Returns the kespace to which the entity shall be persisted.
+	 * Returns the keyspace to which the entity shall be persisted.
 	 *
 	 * @param entityClass entity class, may be {@literal null}.
 	 * @return the keyspace to which the entity shall be persisted.
 	 * If null, then default session-level keyspace will be used.
 	 */
-	@Nullable
-	CqlIdentifier getKeyspaceName(Class<?> entityClass) {
+	Optional<CqlIdentifier> getKeyspaceName(Class<?> entityClass) {
 		return getRequiredPersistentEntity(entityClass).getKeyspaceName();
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableDeleteOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableDeleteOperation.java
@@ -39,6 +39,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * </pre>
  *
  * @author Mark Paluch
+ * @author Tomasz Lelek
  * @since 2.1
  */
 public interface ExecutableDeleteOperation {
@@ -88,6 +89,23 @@ public interface ExecutableDeleteOperation {
 		 * @see DeleteWithQuery
 		 */
 		DeleteWithQuery inTable(CqlIdentifier table);
+
+		/**
+		 * Explicitly set the {@link CqlIdentifier keyspace} and the {@link CqlIdentifier name} of the table on which to
+		 * execute the delete.
+		 * <p>
+		 * Skip this step to use the default table derived from the {@link Class domain type}. Skip this step to use the
+		 * default session-level keyspace.
+		 *
+		 * @param table {@link CqlIdentifier name} of the table; must not be {@literal null}.
+		 * @param keyspace {@link CqlIdentifier keyspace} of the table; if set to {@literal null}, the default session-level
+		 *          keyspace will be used.
+		 * @return new instance of {@link DeleteWithQuery}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier table} is {@literal null}.
+		 * @see com.datastax.oss.driver.api.core.CqlIdentifier
+		 * @see DeleteWithQuery
+		 */
+		DeleteWithQuery inTable(CqlIdentifier keyspace, CqlIdentifier table);
 
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableInsertOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableInsertOperation.java
@@ -37,6 +37,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  *
  * @author Mark Paluch
  * @author John Blum
+ * @author Tomasz Lelek
  * @since 2.1
  */
 public interface ExecutableInsertOperation {
@@ -85,6 +86,23 @@ public interface ExecutableInsertOperation {
 		 * @see InsertWithOptions
 		 */
 		InsertWithOptions<T> inTable(CqlIdentifier table);
+
+		/**
+		 * Explicitly set the {@link CqlIdentifier keyspace} and the {@link CqlIdentifier name} of the table on which to
+		 * perform the insert.
+		 * <p>
+		 * Skip this step to use the default table derived from the {@link Class domain type}. Skip this step to use the
+		 * default session-level keyspace.
+		 *
+		 * @param table {@link CqlIdentifier name} of the table; must not be {@literal null}.
+		 * @param keyspace {@link CqlIdentifier keyspace} of the table; if set to {@literal null}, the default session-level
+		 *          keyspace will be used.
+		 * @return new instance of {@link InsertWithOptions}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier table} is {@literal null}.
+		 * @see com.datastax.oss.driver.api.core.CqlIdentifier
+		 * @see InsertWithOptions
+		 */
+		InsertWithOptions<T> inTable(CqlIdentifier keyspace, CqlIdentifier table);
 
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperation.java
@@ -117,10 +117,7 @@ public interface ExecutableSelectOperation {
 		 * @see com.datastax.oss.driver.api.core.CqlIdentifier
 		 * @see SelectWithProjection
 		 */
-		default SelectWithProjection<T> inTable(@Nullable CqlIdentifier keyspace, CqlIdentifier table){
-			// todo can we leave this without default method?
-			return inTable(table);
-		}
+		SelectWithProjection<T> inTable(@Nullable CqlIdentifier keyspace, CqlIdentifier table);
 
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperation.java
@@ -102,6 +102,26 @@ public interface ExecutableSelectOperation {
 		 */
 		SelectWithProjection<T> inTable(CqlIdentifier table);
 
+		/**
+		 * Explicitly set the {@link CqlIdentifier keyspace} and the {@link CqlIdentifier name} of the table on which to
+		 * execute the query.
+		 * <p>
+		 * Skip this step to use the default table derived from the {@link Class domain type}. Skip this step to use the
+		 * default session-level keyspace.
+		 *
+		 * @param table {@link CqlIdentifier name} of the table; must not be {@literal null}.
+		 * @param keyspace {@link CqlIdentifier keyspace} of the table; if set to {@literal null}, the default session-level
+		 *          keyspace will be used.
+		 * @return new instance of {@link SelectWithProjection}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier table} is {@literal null}.
+		 * @see com.datastax.oss.driver.api.core.CqlIdentifier
+		 * @see SelectWithProjection
+		 */
+		default SelectWithProjection<T> inTable(@Nullable CqlIdentifier keyspace, CqlIdentifier table){
+			// todo can we leave this without default method?
+			return inTable(table);
+		}
+
 	}
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperationSupport.java
@@ -130,7 +130,7 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		 */
 		@Override
 		public long count() {
-			return this.template.doCount(this.query, this.domainType, getKeyspace(), getTableName());
+			return this.template.doCount(this.query, this.domainType, getKeyspaceName(), getTableName());
 		}
 
 		/* (non-Javadoc)
@@ -138,7 +138,7 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		 */
 		@Override
 		public boolean exists() {
-			return this.template.doExists(this.query, this.domainType, getKeyspace(), getTableName());
+			return this.template.doExists(this.query, this.domainType, getKeyspaceName(), getTableName());
 		}
 
 		/* (non-Javadoc)
@@ -147,7 +147,7 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		@Override
 		public T firstValue() {
 
-			List<T> result = this.template.doSelect(this.query.limit(1), this.domainType, getKeyspace(), getTableName(),
+			List<T> result = this.template.doSelect(this.query.limit(1), this.domainType, getKeyspaceName(), getTableName(),
 					this.returnType);
 
 			return ObjectUtils.isEmpty(result) ? null : result.iterator().next();
@@ -159,7 +159,7 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		@Override
 		public T oneValue() {
 
-			List<T> result = this.template.doSelect(this.query.limit(2), this.domainType, getKeyspace(), getTableName(),
+			List<T> result = this.template.doSelect(this.query.limit(2), this.domainType, getKeyspaceName(), getTableName(),
 					this.returnType);
 
 			if (ObjectUtils.isEmpty(result)) {
@@ -179,7 +179,7 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		 */
 		@Override
 		public List<T> all() {
-			return this.template.doSelect(this.query, this.domainType, getKeyspace(), getTableName(), this.returnType);
+			return this.template.doSelect(this.query, this.domainType, getKeyspaceName(), getTableName(), this.returnType);
 		}
 
 		/* (non-Javadoc)
@@ -187,15 +187,15 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		 */
 		@Override
 		public Stream<T> stream() {
-			return this.template.doStream(this.query, this.domainType, getKeyspace(), getTableName(), this.returnType);
+			return this.template.doStream(this.query, this.domainType, getKeyspaceName(), getTableName(), this.returnType);
 		}
 
 		private CqlIdentifier getTableName() {
 			return this.tableName != null ? this.tableName : this.template.getTableName(this.domainType);
 		}
 
-		private @Nullable CqlIdentifier getKeyspace() {
-			return this.keyspace != null ? this.keyspace : this.template.getKeyspace(this.domainType);
+		private @Nullable CqlIdentifier getKeyspaceName() {
+			return this.keyspace != null ? this.keyspace : this.template.getKeyspaceName(this.domainType);
 		}
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableSelectOperationSupport.java
@@ -30,6 +30,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * Implementation of {@link ExecutableSelectOperation}.
  *
  * @author Mark Paluch
+ * @author Tomasz Lelek
  * @see org.springframework.data.cassandra.core.ExecutableSelectOperation
  * @see org.springframework.data.cassandra.core.query.Query
  * @since 2.1
@@ -50,7 +51,7 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 
 		Assert.notNull(domainType, "DomainType must not be null");
 
-		return new ExecutableSelectSupport<>(this.template, domainType, domainType, Query.empty(), null);
+		return new ExecutableSelectSupport<>(this.template, domainType, domainType, Query.empty(), null, null);
 	}
 
 	static class ExecutableSelectSupport<T> implements ExecutableSelect<T> {
@@ -63,14 +64,16 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 
 		private final Query query;
 
+		private final @Nullable CqlIdentifier keyspace;
 		private final @Nullable CqlIdentifier tableName;
 
 		public ExecutableSelectSupport(CassandraTemplate template, Class<?> domainType, Class<T> returnType, Query query,
-				CqlIdentifier tableName) {
+				@Nullable CqlIdentifier keyspace, @Nullable CqlIdentifier tableName) {
 			this.template = template;
 			this.domainType = domainType;
 			this.returnType = returnType;
 			this.query = query;
+			this.keyspace = keyspace;
 			this.tableName = tableName;
 		}
 
@@ -82,7 +85,20 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 
 			Assert.notNull(tableName, "Table name must not be null");
 
-			return new ExecutableSelectSupport<>(this.template, this.domainType, this.returnType, this.query, tableName);
+			return new ExecutableSelectSupport<>(this.template, this.domainType, this.returnType, this.query, null,
+					tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ExecutableSelectOperation.SelectWithTable#inTable(CqlIdentifier, CqlIdentifier)
+		 */
+		@Override
+		public SelectWithProjection<T> inTable(@Nullable CqlIdentifier keyspace, CqlIdentifier tableName) {
+
+			Assert.notNull(tableName, "Table name must not be null");
+
+			return new ExecutableSelectSupport<>(this.template, this.domainType, this.returnType, this.query, keyspace,
+					tableName);
 		}
 
 		/* (non-Javadoc)
@@ -93,7 +109,8 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 
 			Assert.notNull(returnType, "ReturnType must not be null");
 
-			return new ExecutableSelectSupport<>(this.template, this.domainType, returnType, this.query, this.tableName);
+			return new ExecutableSelectSupport<>(this.template, this.domainType, returnType, this.query, this.keyspace,
+					this.tableName);
 		}
 
 		/* (non-Javadoc)
@@ -104,7 +121,8 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 
 			Assert.notNull(query, "Query must not be null");
 
-			return new ExecutableSelectSupport<>(this.template, this.domainType, this.returnType, query, this.tableName);
+			return new ExecutableSelectSupport<>(this.template, this.domainType, this.returnType, query, this.keyspace,
+					this.tableName);
 		}
 
 		/* (non-Javadoc)
@@ -112,7 +130,7 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		 */
 		@Override
 		public long count() {
-			return this.template.doCount(this.query, this.domainType, getTableName());
+			return this.template.doCount(this.query, this.domainType, getKeyspace(), getTableName());
 		}
 
 		/* (non-Javadoc)
@@ -120,7 +138,7 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		 */
 		@Override
 		public boolean exists() {
-			return this.template.doExists(this.query, this.domainType, getTableName());
+			return this.template.doExists(this.query, this.domainType, getKeyspace(), getTableName());
 		}
 
 		/* (non-Javadoc)
@@ -129,7 +147,8 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		@Override
 		public T firstValue() {
 
-			List<T> result = this.template.doSelect(this.query.limit(1), this.domainType, getTableName(), this.returnType);
+			List<T> result = this.template.doSelect(this.query.limit(1), this.domainType, getKeyspace(), getTableName(),
+					this.returnType);
 
 			return ObjectUtils.isEmpty(result) ? null : result.iterator().next();
 		}
@@ -140,7 +159,8 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		@Override
 		public T oneValue() {
 
-			List<T> result = this.template.doSelect(this.query.limit(2), this.domainType, getTableName(), this.returnType);
+			List<T> result = this.template.doSelect(this.query.limit(2), this.domainType, getKeyspace(), getTableName(),
+					this.returnType);
 
 			if (ObjectUtils.isEmpty(result)) {
 				return null;
@@ -159,7 +179,7 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		 */
 		@Override
 		public List<T> all() {
-			return this.template.doSelect(this.query, this.domainType, getTableName(), this.returnType);
+			return this.template.doSelect(this.query, this.domainType, getKeyspace(), getTableName(), this.returnType);
 		}
 
 		/* (non-Javadoc)
@@ -167,11 +187,15 @@ class ExecutableSelectOperationSupport implements ExecutableSelectOperation {
 		 */
 		@Override
 		public Stream<T> stream() {
-			return this.template.doStream(this.query, this.domainType, getTableName(), this.returnType);
+			return this.template.doStream(this.query, this.domainType, getKeyspace(), getTableName(), this.returnType);
 		}
 
 		private CqlIdentifier getTableName() {
 			return this.tableName != null ? this.tableName : this.template.getTableName(this.domainType);
+		}
+
+		private @Nullable CqlIdentifier getKeyspace() {
+			return this.keyspace != null ? this.keyspace : this.template.getKeyspace(this.domainType);
 		}
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableUpdateOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableUpdateOperation.java
@@ -43,6 +43,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  *
  * @author Mark Paluch
  * @author John Blum
+ * @author Tomasz Lelek
  * @see org.springframework.data.cassandra.core.ExecutableUpdateOperation
  * @see org.springframework.data.cassandra.core.query.Query
  * @see org.springframework.data.cassandra.core.query.Update
@@ -94,6 +95,23 @@ public interface ExecutableUpdateOperation {
 		 * @see UpdateWithQuery
 		 */
 		UpdateWithQuery inTable(CqlIdentifier table);
+
+		/**
+		 * Explicitly set the {@link CqlIdentifier keyspace} and the {@link CqlIdentifier name} of the table on which to
+		 * execute the update.
+		 * <p>
+		 * Skip this step to use the default table derived from the {@link Class domain type}. Skip this step to use the
+		 * default session-level keyspace.
+		 *
+		 * @param table {@link CqlIdentifier name} of the table; must not be {@literal null}.
+		 * @param keyspace {@link CqlIdentifier keyspace} of the table; if set to {@literal null}, the default session-level
+		 *          keyspace will be used.
+		 * @return new instance of {@link UpdateWithQuery}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier table} is {@literal null}.
+		 * @see com.datastax.oss.driver.api.core.CqlIdentifier
+		 * @see UpdateWithQuery
+		 */
+		UpdateWithQuery inTable(CqlIdentifier keyspace, CqlIdentifier table);
 
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraBatchTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraBatchTemplate.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.cassandra.core;
 
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -22,8 +25,6 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import org.springframework.data.cassandra.core.convert.CassandraConverter;
 import org.springframework.data.cassandra.core.convert.UpdateMapper;
 import org.springframework.data.cassandra.core.cql.WriteOptions;
@@ -38,12 +39,14 @@ import com.datastax.oss.driver.api.core.cql.BatchStatementBuilder;
 import com.datastax.oss.driver.api.core.cql.BatchType;
 import com.datastax.oss.driver.api.core.cql.BatchableStatement;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
 
 /**
  * Default implementation for {@link ReactiveCassandraBatchOperations}.
  *
  * @author Oleh Dokuka
  * @author Mark Paluch
+ * @author Tomasz Lelek
  * @since 2.1
  */
 class ReactiveCassandraBatchTemplate implements ReactiveCassandraBatchOperations {
@@ -231,7 +234,7 @@ class ReactiveCassandraBatchTemplate implements ReactiveCassandraBatchOperations
 					.getRequiredPersistentEntity(entity.getClass());
 
 			SimpleStatement insertQuery = getStatementFactory()
-					.insert(entity, options, persistentEntity, persistentEntity.getTableName()).build();
+					.insert(entity, options, persistentEntity, TableCoordinates.of(persistentEntity)).build();
 
 			insertQueries.add(insertQuery);
 		}
@@ -309,7 +312,7 @@ class ReactiveCassandraBatchTemplate implements ReactiveCassandraBatchOperations
 			CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
 
 			SimpleStatement update = getStatementFactory()
-					.update(entity, options, persistentEntity, persistentEntity.getTableName()).build();
+					.update(entity, options, persistentEntity, TableCoordinates.of(persistentEntity)).build();
 
 			updateQueries.add(update);
 		}
@@ -387,7 +390,7 @@ class ReactiveCassandraBatchTemplate implements ReactiveCassandraBatchOperations
 			CassandraPersistentEntity<?> persistentEntity = getRequiredPersistentEntity(entity.getClass());
 
 			SimpleStatement delete = getStatementFactory()
-					.delete(entity, options, getConverter(), persistentEntity.getTableName()).build();
+					.delete(entity, options, getConverter(), TableCoordinates.of(persistentEntity)).build();
 
 			deleteQueries.add(delete);
 		}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
@@ -281,8 +281,8 @@ public class ReactiveCassandraTemplate
 	}
 
 	@Nullable
-	CqlIdentifier getKeyspace(Class<?> entityClass) {
-		return getRequiredPersistentEntity(entityClass).getKeyspace();
+	CqlIdentifier getKeyspaceName(Class<?> entityClass) {
+		return getRequiredPersistentEntity(entityClass).getKeyspaceName();
 	}
 
 	// -------------------------------------------------------------------------
@@ -371,7 +371,7 @@ public class ReactiveCassandraTemplate
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doSelect(query, entityClass, getKeyspace(entityClass), getTableName(entityClass), entityClass);
+		return doSelect(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass), entityClass);
 	}
 
 	<T> Flux<T> doSelect(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName,
@@ -477,7 +477,7 @@ public class ReactiveCassandraTemplate
 
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doCount(Query.empty(), entityClass, getKeyspace(entityClass), getTableName(entityClass));
+		return doCount(Query.empty(), entityClass, getKeyspaceName(entityClass), getTableName(entityClass));
 	}
 
 	/* (non-Javadoc)
@@ -489,7 +489,7 @@ public class ReactiveCassandraTemplate
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doCount(query, entityClass, getKeyspace(entityClass), getTableName(entityClass));
+		return doCount(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass));
 	}
 
 	Mono<Long> doCount(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName) {
@@ -510,7 +510,7 @@ public class ReactiveCassandraTemplate
 		Assert.notNull(entityClass, "Entity type must not be null");
 
 		CassandraPersistentEntity<?> entity = getRequiredPersistentEntity(entityClass);
-		StatementBuilder<Select> builder = getStatementFactory().selectOneById(id, entity, entity.getKeyspace(),
+		StatementBuilder<Select> builder = getStatementFactory().selectOneById(id, entity, entity.getKeyspaceName(),
 				entity.getTableName());
 
 		return getReactiveCqlOperations().queryForRows(builder.build()).hasElements();
@@ -525,7 +525,7 @@ public class ReactiveCassandraTemplate
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		return doExists(query, entityClass, getKeyspace(entityClass), getTableName(entityClass));
+		return doExists(query, entityClass, getKeyspaceName(entityClass), getTableName(entityClass));
 	}
 
 	Mono<Boolean> doExists(Query query, Class<?> entityClass, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName) {
@@ -546,7 +546,7 @@ public class ReactiveCassandraTemplate
 		Assert.notNull(entityClass, "Entity type must not be null");
 
 		StatementBuilder<Select> builder = getStatementFactory().selectOneById(id, getRequiredPersistentEntity(entityClass),
-				getKeyspace(entityClass), getTableName(entityClass));
+				getKeyspaceName(entityClass), getTableName(entityClass));
 
 		return selectOne(builder.build(), entityClass);
 	}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveCassandraTemplate.java
@@ -759,14 +759,14 @@ public class ReactiveCassandraTemplate
 
 		Assert.notNull(entityClass, "Entity type must not be null");
 
-		CqlIdentifier tableName = getTableName(entityClass);
-		Truncate truncate = QueryBuilder.truncate(tableName);
+		TableCoordinates tableCoordinates = getTableCoordinates(entityClass);
+		Truncate truncate = QueryBuilder.truncate(tableCoordinates.getKeyspaceName().orElse(null), tableCoordinates.getTableName());
 		SimpleStatement statement = truncate.build();
 
 		Mono<Boolean> result = getReactiveCqlOperations().execute(statement)
-				.doOnSubscribe(it -> maybeEmitEvent(new BeforeDeleteEvent<>(statement, entityClass, tableName)));
+				.doOnSubscribe(it -> maybeEmitEvent(new BeforeDeleteEvent<>(statement, entityClass, tableCoordinates.getTableName())));
 
-		return result.doOnNext(it -> maybeEmitEvent(new AfterDeleteEvent<>(statement, entityClass, tableName))).then();
+		return result.doOnNext(it -> maybeEmitEvent(new AfterDeleteEvent<>(statement, entityClass, tableCoordinates.getTableName()))).then();
 	}
 
 	// -------------------------------------------------------------------------

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveDeleteOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveDeleteOperation.java
@@ -42,6 +42,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  *
  * @author Mark Paluch
  * @author John Blum
+ * @author Tomasz Lelek
  * @see org.springframework.data.cassandra.core.query.Query
  * @since 2.1
  */
@@ -92,6 +93,23 @@ public interface ReactiveDeleteOperation {
 		 * @see DeleteWithQuery
 		 */
 		DeleteWithQuery inTable(CqlIdentifier table);
+
+		/**
+		 * Explicitly set the {@link CqlIdentifier keyspace} and the {@link CqlIdentifier name} of the table on which to
+		 * perform the delete.
+		 * <p>
+		 * Skip this step to use the default table derived from the {@link Class domain type}. Skip this step to use the
+		 * default session-level keyspace.
+		 *
+		 * @param table {@link CqlIdentifier name} of the table; must not be {@literal null}.
+		 * @param keyspace {@link CqlIdentifier keyspace} of the table; if set to {@literal null}, the default session-level
+		 *          keyspace will be used.
+		 * @return new instance of {@link DeleteWithQuery}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier table} is {@literal null}.
+		 * @see com.datastax.oss.driver.api.core.CqlIdentifier
+		 * @see DeleteWithQuery
+		 */
+		DeleteWithQuery inTable(CqlIdentifier keyspace, CqlIdentifier table);
 	}
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveInsertOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveInsertOperation.java
@@ -39,6 +39,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  *
  * @author Mark Paluch
  * @author John Blum
+ * @author Tomasz Lelek
  * @since 2.1
  */
 public interface ReactiveInsertOperation {
@@ -89,6 +90,24 @@ public interface ReactiveInsertOperation {
 		 * @see InsertWithOptions
 		 */
 		InsertWithOptions<T> inTable(CqlIdentifier table);
+
+
+		/**
+		 * Explicitly set the {@link CqlIdentifier keyspace} and the {@link CqlIdentifier name} of the table on which to
+		 * perform the insert.
+		 * <p>
+		 * Skip this step to use the default table derived from the {@link Class domain type}. Skip this step to use the
+		 * default session-level keyspace.
+		 *
+		 * @param table {@link CqlIdentifier name} of the table; must not be {@literal null}.
+		 * @param keyspace {@link CqlIdentifier keyspace} of the table; if set to {@literal null}, the default session-level
+		 *          keyspace will be used.
+		 * @return new instance of {@link InsertWithOptions}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier table} is {@literal null}.
+		 * @see com.datastax.oss.driver.api.core.CqlIdentifier
+		 * @see InsertWithOptions
+		 */
+		InsertWithOptions<T> inTable(CqlIdentifier keyspace, CqlIdentifier table);
 
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveInsertOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveInsertOperationSupport.java
@@ -17,6 +17,8 @@ package org.springframework.data.cassandra.core;
 
 import reactor.core.publisher.Mono;
 
+import java.util.Optional;
+
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -26,6 +28,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * Implementation of {@link ReactiveInsertOperation}.
  *
  * @author Mark Paluch
+ * @author Tomasz Lelek
  * @since 2.1
  */
 class ReactiveInsertOperationSupport implements ReactiveInsertOperation {
@@ -44,7 +47,7 @@ class ReactiveInsertOperationSupport implements ReactiveInsertOperation {
 
 		Assert.notNull(domainType, "DomainType must not be null");
 
-		return new ReactiveInsertSupport<>(this.template, domainType, InsertOptions.empty(), null);
+		return new ReactiveInsertSupport<>(this.template, domainType, InsertOptions.empty(), null, null);
 	}
 
 	static class ReactiveInsertSupport<T> implements ReactiveInsert<T> {
@@ -55,25 +58,37 @@ class ReactiveInsertOperationSupport implements ReactiveInsertOperation {
 
 		private final InsertOptions insertOptions;
 
+		private final @Nullable CqlIdentifier keyspaceName;
 		private final @Nullable CqlIdentifier tableName;
 
 		public ReactiveInsertSupport(ReactiveCassandraTemplate template, Class<T> domainType, InsertOptions insertOptions,
-				CqlIdentifier tableName) {
+				@Nullable CqlIdentifier keyspaceName, @Nullable CqlIdentifier tableName) {
 			this.template = template;
 			this.domainType = domainType;
 			this.insertOptions = insertOptions;
+			this.keyspaceName = keyspaceName;
 			this.tableName = tableName;
 		}
 
 		/* (non-Javadoc)
-		 * @see org.springframework.data.cassandra.core.ReactiveInsertOperation.InsertWithTable#inTable(org.springframework.data.cassandra.core.cql.CqlIdentifier)
+		 * @see org.springframework.data.cassandra.core.ReactiveInsertOperation.InsertWithTable#inTable(com.datastax.oss.driver.api.core.CqlIdentifier)
 		 */
 		@Override
 		public InsertWithOptions<T> inTable(CqlIdentifier tableName) {
 
 			Assert.notNull(tableName, "Table name must not be null");
 
-			return new ReactiveInsertSupport<>(this.template, this.domainType, this.insertOptions, tableName);
+			return new ReactiveInsertSupport<>(this.template, this.domainType, this.insertOptions, null, tableName);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.ReactiveInsertOperation.InsertWithTable#inTable(com.datastax.oss.driver.api.core.CqlIdentifier. com.datastax.oss.driver.api.core.CqlIdentifier)
+		 */
+		@Override
+		public InsertWithOptions<T> inTable(CqlIdentifier keyspaceName, CqlIdentifier tableName) {
+			Assert.notNull(tableName, "Table name must not be null");
+
+			return new ReactiveInsertSupport<>(this.template, this.domainType, this.insertOptions, keyspaceName, tableName);
 		}
 
 		/* (non-Javadoc)
@@ -84,7 +99,8 @@ class ReactiveInsertOperationSupport implements ReactiveInsertOperation {
 
 			Assert.notNull(insertOptions, "InsertOptions must not be null");
 
-			return new ReactiveInsertSupport<>(this.template, this.domainType, insertOptions, this.tableName);
+			return new ReactiveInsertSupport<>(this.template, this.domainType, insertOptions, this.keyspaceName,
+					this.tableName);
 		}
 
 		/* (non-Javadoc)
@@ -95,11 +111,20 @@ class ReactiveInsertOperationSupport implements ReactiveInsertOperation {
 
 			Assert.notNull(object, "Object must not be null");
 
-			return this.template.doInsert(object, this.insertOptions, getTableName());
+			return this.template.doInsert(object, this.insertOptions, getTableCoordinates());
 		}
 
 		private CqlIdentifier getTableName() {
 			return this.tableName != null ? this.tableName : this.template.getTableName(this.domainType);
+		}
+
+		private Optional<CqlIdentifier> getKeyspaceName() {
+			return this.keyspaceName != null ? Optional.of(this.keyspaceName)
+					: this.template.getKeyspaceName(this.domainType);
+		}
+
+		private TableCoordinates getTableCoordinates() {
+			return TableCoordinates.of(getKeyspaceName(), getTableName());
 		}
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveSelectOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveSelectOperation.java
@@ -118,11 +118,7 @@ public interface ReactiveSelectOperation {
 		 * @see com.datastax.oss.driver.api.core.CqlIdentifier
 		 * @see SelectWithProjection
 		 */
-		default SelectWithProjection<T> inTable(@Nullable CqlIdentifier keyspace, CqlIdentifier table){
-			// todo can we leave this without default method?
-			return inTable(table);
-		}
-
+		SelectWithProjection<T> inTable(@Nullable CqlIdentifier keyspace, CqlIdentifier table);
 
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveSelectOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveSelectOperation.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.cassandra.core;
 
+import org.springframework.data.cassandra.core.mapping.Embedded;
+import org.springframework.lang.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -48,6 +50,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  *
  * @author Mark Paluch
  * @author John Blum
+ * @author Tomasz Lelek
  * @see org.springframework.data.cassandra.core.query.Query
  * @since 2.1
  */
@@ -99,6 +102,27 @@ public interface ReactiveSelectOperation {
 		 * @see SelectWithProjection
 		 */
 		SelectWithProjection<T> inTable(CqlIdentifier table);
+
+		/**
+		 * Explicitly set the {@link CqlIdentifier keyspace} and the {@link CqlIdentifier name} of the table on which to
+		 * perform the query.
+		 * <p>
+		 * Skip this step to use the default table derived from the {@link Class domain type}. Skip this step to use the
+		 * default session-level keyspace.
+		 *
+		 * @param table {@link CqlIdentifier name} of the table; must not be {@literal null}.
+		 * @param keyspace {@link CqlIdentifier keyspace} of the table; if set to {@literal null}, the default session-level
+		 *          keyspace will be used.
+		 * @return new instance of {@link SelectWithProjection}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier table} is {@literal null}.
+		 * @see com.datastax.oss.driver.api.core.CqlIdentifier
+		 * @see SelectWithProjection
+		 */
+		default SelectWithProjection<T> inTable(@Nullable CqlIdentifier keyspace, CqlIdentifier table){
+			// todo can we leave this without default method?
+			return inTable(table);
+		}
+
 
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveSelectOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveSelectOperationSupport.java
@@ -125,7 +125,7 @@ class ReactiveSelectOperationSupport implements ReactiveSelectOperation {
 		 */
 		@Override
 		public Mono<Long> count() {
-			return this.template.doCount(this.query, this.domainType, getKeyspace(), getTableName());
+			return this.template.doCount(this.query, this.domainType, getKeyspaceName(), getTableName());
 		}
 
 		/* (non-Javadoc)
@@ -133,7 +133,7 @@ class ReactiveSelectOperationSupport implements ReactiveSelectOperation {
 		 */
 		@Override
 		public Mono<Boolean> exists() {
-			return this.template.doExists(this.query, this.domainType, getKeyspace(), getTableName());
+			return this.template.doExists(this.query, this.domainType, getKeyspaceName(), getTableName());
 		}
 
 		/* (non-Javadoc)
@@ -142,7 +142,7 @@ class ReactiveSelectOperationSupport implements ReactiveSelectOperation {
 		@Override
 		public Mono<T> first() {
 			return this.template
-					.doSelect(this.query.limit(1), this.domainType, getKeyspace(), getTableName(), this.returnType).next();
+					.doSelect(this.query.limit(1), this.domainType, getKeyspaceName(), getTableName(), this.returnType).next();
 		}
 
 		/* (non-Javadoc)
@@ -151,7 +151,7 @@ class ReactiveSelectOperationSupport implements ReactiveSelectOperation {
 		@Override
 		public Mono<T> one() {
 
-			Flux<T> result = this.template.doSelect(this.query.limit(2), this.domainType, getKeyspace(), getTableName(),
+			Flux<T> result = this.template.doSelect(this.query.limit(2), this.domainType, getKeyspaceName(), getTableName(),
 					this.returnType);
 
 			return result.collectList() //
@@ -175,11 +175,11 @@ class ReactiveSelectOperationSupport implements ReactiveSelectOperation {
 		 */
 		@Override
 		public Flux<T> all() {
-			return this.template.doSelect(this.query, this.domainType, getKeyspace(), getTableName(), this.returnType);
+			return this.template.doSelect(this.query, this.domainType, getKeyspaceName(), getTableName(), this.returnType);
 		}
 
-		private @Nullable CqlIdentifier getKeyspace() {
-			return this.keyspace != null ? this.keyspace : this.template.getKeyspace(this.domainType);
+		private @Nullable CqlIdentifier getKeyspaceName() {
+			return this.keyspace != null ? this.keyspace : this.template.getKeyspaceName(this.domainType);
 		}
 
 		private CqlIdentifier getTableName() {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveUpdateOperation.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ReactiveUpdateOperation.java
@@ -19,6 +19,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.data.cassandra.core.query.Query;
 import org.springframework.data.cassandra.core.query.Update;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
@@ -46,6 +47,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  *
  * @author Mark Paluch
  * @author John Blum
+ * @author Tomasz Lelek
  * @see org.springframework.data.cassandra.core.query.Query
  * @see org.springframework.data.cassandra.core.query.Update
  * @since 2.1
@@ -93,10 +95,27 @@ public interface ReactiveUpdateOperation {
 		 * @param table {@link CqlIdentifier name} of the table; must not be {@literal null}.
 		 * @return new instance of {@link UpdateWithQuery}.
 		 * @throws IllegalArgumentException if {@link CqlIdentifier table} is {@literal null}.
-		 * @see com.datastax.oss.driver.api.core.CqlIdentifier
+		 * @see CqlIdentifier
 		 * @see UpdateWithQuery
 		 */
 		UpdateWithQuery inTable(CqlIdentifier table);
+
+		/**
+		 * Explicitly set the {@link CqlIdentifier keyspace} and the {@link CqlIdentifier name} of the table on which to
+		 * perform the update.
+		 * <p>
+		 * Skip this step to use the default table derived from the {@link Class domain type}. Skip this step to use the
+		 * default session-level keyspace.
+		 *
+		 * @param table {@link CqlIdentifier name} of the table; must not be {@literal null}.
+		 * @param keyspace {@link CqlIdentifier keyspace} of the table; if set to {@literal null}, the default session-level
+		 *          keyspace will be used.
+		 * @return new instance of {@link UpdateWithQuery}.
+		 * @throws IllegalArgumentException if {@link CqlIdentifier table} is {@literal null}.
+		 * @see CqlIdentifier
+		 * @see UpdateWithQuery
+		 */
+		UpdateWithQuery inTable(@Nullable CqlIdentifier keyspace, CqlIdentifier table);
 
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/StatementFactory.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/StatementFactory.java
@@ -181,7 +181,8 @@ public class StatementFactory {
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(persistentEntity, "CassandraPersistentEntity must not be null");
 
-		return count(query, persistentEntity, persistentEntity.getKeyspaceName(), persistentEntity.getTableName());
+		return count(query, persistentEntity,
+				TableCoordinates.of(persistentEntity));
 	}
 
 	/**
@@ -189,18 +190,18 @@ public class StatementFactory {
 	 *
 	 * @param query user-defined count {@link Query} to execute; must not be {@literal null}.
 	 * @param entity {@link CassandraPersistentEntity entity} to count; must not be {@literal null}.
-	 * @param tableName must not be {@literal null}.
+	 * @param tableCoordinates must not be {@literal null}.
 	 * @return the select builder.
 	 * @since 2.1
 	 */
 	public StatementBuilder<Select> count(Query query, CassandraPersistentEntity<?> entity,
-			@Nullable CqlIdentifier keyspace, CqlIdentifier tableName) {
+			TableCoordinates tableCoordinates) {
 
 		Filter filter = getQueryMapper().getMappedObject(query, entity);
 
 		List<Selector> selectors = Collections.singletonList(FunctionCall.from("COUNT", 1L));
 
-		return createSelect(query, entity, filter, selectors, keyspace, tableName);
+		return createSelect(query, entity, filter, selectors, tableCoordinates);
 	}
 
 	/**
@@ -209,18 +210,18 @@ public class StatementFactory {
 	 *
 	 * @param id must not be {@literal null}.
 	 * @param persistentEntity must not be {@literal null}.
-	 * @param keyspace
-	 * @param tableName must not be {@literal null}.
+	 * @param tableCoordinates must not be {@literal null}.
 	 * @return the select builder.
 	 */
 	StatementBuilder<Select> selectOneById(Object id, CassandraPersistentEntity<?> persistentEntity,
-			@Nullable CqlIdentifier keyspace, CqlIdentifier tableName) {
+			TableCoordinates tableCoordinates) {
 
 		Where where = new Where();
 
 		cassandraConverter.write(id, where, persistentEntity);
 
-		return StatementBuilder.of(QueryBuilder.selectFrom(keyspace, tableName).all().limit(1))
+		return StatementBuilder.of(QueryBuilder
+				.selectFrom(tableCoordinates.getKeyspaceName().orElse(null), tableCoordinates.getTableName()).all().limit(1))
 				.bind((statement, factory) -> statement.where(toRelations(where, factory)));
 	}
 
@@ -236,7 +237,8 @@ public class StatementFactory {
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(persistentEntity, "CassandraPersistentEntity must not be null");
 
-		return select(query, persistentEntity, persistentEntity.getKeyspaceName(), persistentEntity.getTableName());
+		return select(query, persistentEntity,
+				TableCoordinates.of(persistentEntity));
 	}
 
 	/**
@@ -244,12 +246,12 @@ public class StatementFactory {
 	 *
 	 * @param query must not be {@literal null}.
 	 * @param persistentEntity must not be {@literal null}.
-	 * @param tableName must not be {@literal null}.
+	 * @param tableCoordinates must not be {@literal null}.
 	 * @return the select builder.
 	 * @since 2.1
 	 */
 	public StatementBuilder<Select> select(Query query, CassandraPersistentEntity<?> persistentEntity,
-			@Nullable CqlIdentifier keyspace, CqlIdentifier tableName) {
+			TableCoordinates tableCoordinates) {
 
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(persistentEntity, "CassandraPersistentEntity must not be null");
@@ -259,7 +261,7 @@ public class StatementFactory {
 
 		List<Selector> selectors = getQueryMapper().getMappedSelectors(query.getColumns(), persistentEntity);
 
-		return createSelect(query, persistentEntity, filter, selectors, keyspace, tableName);
+		return createSelect(query, persistentEntity, filter, selectors, tableCoordinates);
 	}
 
 	/**
@@ -277,25 +279,25 @@ public class StatementFactory {
 
 		CassandraPersistentEntity<?> persistentEntity = cassandraConverter.getMappingContext()
 				.getRequiredPersistentEntity(objectToInsert.getClass());
-		return insert(objectToInsert, options, persistentEntity, persistentEntity.getTableName());
+		return insert(objectToInsert, options, persistentEntity,
+				TableCoordinates.of(persistentEntity));
 	}
 
 	/**
 	 * Creates a Query Object for an insert.
 	 *
-	 * @param tableName the table name, must not be empty and not {@literal null}.
+	 * @param tableCoordinates the table coordinates, must not be {@literal null}.
 	 * @param objectToInsert the object to save, must not be {@literal null}.
 	 * @param options optional {@link WriteOptions} to apply to the {@link Insert} statement, may be {@literal null}.
 	 * @param persistentEntity the {@link CassandraPersistentEntity} to write insert values.
 	 * @return the select builder.
 	 */
 	StatementBuilder<RegularInsert> insert(Object objectToInsert, WriteOptions options,
-			CassandraPersistentEntity<?> persistentEntity, CqlIdentifier tableName) {
+			CassandraPersistentEntity<?> persistentEntity, TableCoordinates tableCoordinates) {
 
-		Assert.notNull(tableName, "TableName must not be null");
+		Assert.notNull(tableCoordinates.getTableName(), "TableName must not be null");
 		Assert.notNull(objectToInsert, "Object to insert must not be null");
 		Assert.notNull(persistentEntity, "CassandraPersistentEntity must not be null");
-		Assert.notNull(tableName, "Table name must not be null");
 
 		boolean insertNulls;
 		if (options instanceof InsertOptions) {
@@ -310,7 +312,9 @@ public class StatementFactory {
 		cassandraConverter.write(objectToInsert, object, persistentEntity);
 
 		StatementBuilder<RegularInsert> builder = StatementBuilder
-				.of(QueryBuilder.insertInto(tableName).valuesByIds(Collections.emptyMap())).bind((statement, factory) -> {
+				.of(QueryBuilder.insertInto(tableCoordinates.getKeyspaceName().orElse(null), tableCoordinates.getTableName())
+						.valuesByIds(Collections.emptyMap()))
+				.bind((statement, factory) -> {
 
 					Map<CqlIdentifier, Term> values = createTerms(insertNulls, object, factory);
 
@@ -351,7 +355,8 @@ public class StatementFactory {
 		Assert.notNull(update, "Update must not be null");
 		Assert.notNull(persistentEntity, "CassandraPersistentEntity must not be null");
 
-		return update(query, update, persistentEntity, persistentEntity.getTableName());
+		return update(query, update, persistentEntity,
+				TableCoordinates.of(persistentEntity));
 	}
 
 	/**
@@ -360,23 +365,25 @@ public class StatementFactory {
 	 * @param query must not be {@literal null}.
 	 * @param update must not be {@literal null}.
 	 * @param persistentEntity must not be {@literal null}.
-	 * @param tableName must not be {@literal null}.
+	 * @param tableCoordinates must not be {@literal null}.
 	 * @return the update builder.
 	 * @since 2.1
 	 */
 	StatementBuilder<com.datastax.oss.driver.api.querybuilder.update.Update> update(Query query, Update update,
-			CassandraPersistentEntity<?> persistentEntity, CqlIdentifier tableName) {
+			CassandraPersistentEntity<?> persistentEntity, TableCoordinates tableCoordinates) {
 
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(update, "Update must not be null");
 		Assert.notNull(persistentEntity, "CassandraPersistentEntity must not be null");
-		Assert.notNull(tableName, "Table name must not be null");
+		Assert.notNull(tableCoordinates, "TableCoordinates must not be null");
+		Assert.notNull(tableCoordinates.getTableName(), "Table name must not be null");
 
 		Filter filter = getQueryMapper().getMappedObject(query, persistentEntity);
 
 		Update mappedUpdate = getUpdateMapper().getMappedObject(update, persistentEntity);
 
-		StatementBuilder<com.datastax.oss.driver.api.querybuilder.update.Update> builder = update(tableName, mappedUpdate,
+		StatementBuilder<com.datastax.oss.driver.api.querybuilder.update.Update> builder = update(tableCoordinates,
+				mappedUpdate,
 				filter);
 
 		query.getQueryOptions().filter(UpdateOptions.class::isInstance).map(UpdateOptions.class::cast)
@@ -410,7 +417,8 @@ public class StatementFactory {
 		CassandraPersistentEntity<?> persistentEntity = cassandraConverter.getMappingContext()
 				.getRequiredPersistentEntity(objectToUpdate.getClass());
 
-		return update(objectToUpdate, options, persistentEntity, persistentEntity.getTableName());
+		return update(objectToUpdate, options, persistentEntity,
+				TableCoordinates.of(persistentEntity));
 	}
 
 	/**
@@ -420,13 +428,14 @@ public class StatementFactory {
 	 * @param objectToUpdate must not be {@literal null}.
 	 * @param options must not be {@literal null}.
 	 * @param entity must not be {@literal null}.
-	 * @param tableName must not be {@literal null}.
+	 * @param tableCoordinates must not be {@literal null}.
 	 * @return the update builder.
 	 */
 	StatementBuilder<com.datastax.oss.driver.api.querybuilder.update.Update> update(Object objectToUpdate,
-			WriteOptions options, CassandraPersistentEntity<?> entity, CqlIdentifier tableName) {
+			WriteOptions options, CassandraPersistentEntity<?> entity, TableCoordinates tableCoordinates) {
 
-		Assert.notNull(tableName, "TableName must not be null");
+		Assert.notNull(tableCoordinates, "TableCoordinates must not be null");
+		Assert.notNull(tableCoordinates.getTableName(), "TableName must not be null");
 		Assert.notNull(objectToUpdate, "Object to builder must not be null");
 		Assert.notNull(options, "WriteOptions must not be null");
 		Assert.notNull(entity, "CassandraPersistentEntity must not be null");
@@ -439,7 +448,8 @@ public class StatementFactory {
 		where.forEach((cqlIdentifier, o) -> object.remove(cqlIdentifier));
 
 		StatementBuilder<com.datastax.oss.driver.api.querybuilder.update.Update> builder = StatementBuilder
-				.of(QueryBuilder.update(tableName).set().where())
+				.of(QueryBuilder.update(tableCoordinates.getKeyspaceName().orElse(null), tableCoordinates.getTableName()).set()
+						.where())
 				.bind((statement, factory) -> ((UpdateWithAssignments) statement).set(toAssignments(object, factory))
 						.where(toRelations(where, factory)))
 				.apply(update -> addWriteOptions(update, options));
@@ -485,7 +495,7 @@ public class StatementFactory {
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(persistentEntity, "CassandraPersistentEntity must not be null");
 
-		return delete(query, persistentEntity, persistentEntity.getTableName());
+		return delete(query, persistentEntity, TableCoordinates.of(persistentEntity));
 	}
 
 	/**
@@ -493,21 +503,22 @@ public class StatementFactory {
 	 *
 	 * @param query must not be {@literal null}.
 	 * @param persistentEntity must not be {@literal null}.
-	 * @param tableName must not be {@literal null}.
+	 * @param tableCoordinates must not be {@literal null}.
 	 * @return the delete builder.
 	 * @see 2.1
 	 */
 	public StatementBuilder<Delete> delete(Query query, CassandraPersistentEntity<?> persistentEntity,
-			CqlIdentifier tableName) {
+			TableCoordinates tableCoordinates) {
 
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(persistentEntity, "CassandraPersistentEntity must not be null");
-		Assert.notNull(tableName, "Table name must not be null");
+		Assert.notNull(tableCoordinates, "TableCoordinates name must not be null");
+		Assert.notNull(tableCoordinates.getTableName(), "Table name must not be null");
 
 		Filter filter = getQueryMapper().getMappedObject(query, persistentEntity);
 		List<CqlIdentifier> columnNames = getQueryMapper().getMappedColumnNames(query.getColumns(), persistentEntity);
 
-		StatementBuilder<Delete> builder = delete(columnNames, tableName, filter);
+		StatementBuilder<Delete> builder = delete(columnNames, tableCoordinates, filter);
 
 		query.getQueryOptions().filter(DeleteOptions.class::isInstance).map(DeleteOptions.class::cast)
 				.map(DeleteOptions::getIfCondition)
@@ -529,20 +540,21 @@ public class StatementFactory {
 	 * @param entity must not be {@literal null}.
 	 * @param options must not be {@literal null}.
 	 * @param entityWriter must not be {@literal null}.
-	 * @param tableName must not be {@literal null}.
+	 * @param tableCoordinates must not be {@literal null}.
 	 * @return the delete builder.
 	 */
 	StatementBuilder<Delete> delete(Object entity, QueryOptions options, EntityWriter<Object, Object> entityWriter,
-			CqlIdentifier tableName) {
-
-		Assert.notNull(tableName, "TableName must not be null");
+			TableCoordinates tableCoordinates) {
+		Assert.notNull(tableCoordinates, "TableCoordinates must not be null");
+		Assert.notNull(tableCoordinates.getTableName(), "TableName must not be null");
 		Assert.notNull(entity, "Object to builder must not be null");
 		Assert.notNull(entityWriter, "EntityWriter must not be null");
 
 		Where where = new Where();
 		entityWriter.write(entity, where);
 
-		StatementBuilder<Delete> builder = StatementBuilder.of(QueryBuilder.deleteFrom(tableName).where())
+		StatementBuilder<Delete> builder = StatementBuilder.of(QueryBuilder
+				.deleteFrom(tableCoordinates.getKeyspaceName().orElse(null), tableCoordinates.getTableName()).where())
 				.bind((statement, factory) -> statement.where(toRelations(where, factory)));
 
 		Optional.of(options).filter(WriteOptions.class::isInstance).map(WriteOptions.class::cast)
@@ -595,12 +607,12 @@ public class StatementFactory {
 	}
 
 	private StatementBuilder<Select> createSelect(Query query, CassandraPersistentEntity<?> entity, Filter filter,
-			List<Selector> selectors, @Nullable CqlIdentifier keyspace, CqlIdentifier tableName) {
+			List<Selector> selectors, TableCoordinates tableCoordinates) {
 
 		Sort sort = Optional.of(query.getSort()).map(querySort -> getQueryMapper().getMappedSort(querySort, entity))
 				.orElse(Sort.unsorted());
 
-		StatementBuilder<Select> select = createSelectAndOrder(selectors, keyspace, tableName, filter, sort);
+		StatementBuilder<Select> select = createSelectAndOrder(selectors, tableCoordinates, filter, sort);
 
 		if (query.getLimit() > 0) {
 			select.apply(it -> it.limit(Math.toIntExact(query.getLimit())));
@@ -619,13 +631,13 @@ public class StatementFactory {
 	}
 
 	private static StatementBuilder<Select> createSelectAndOrder(List<Selector> selectors,
-			@Nullable CqlIdentifier keyspace, CqlIdentifier from,
+			TableCoordinates from,
 			Filter filter, Sort sort) {
 
 		Select select;
 
 		if (selectors.isEmpty()) {
-			select = QueryBuilder.selectFrom(keyspace, from).all();
+			select = QueryBuilder.selectFrom(from.getKeyspaceName().orElse(null), from.getTableName()).all();
 		} else {
 
 			List<com.datastax.oss.driver.api.querybuilder.select.Selector> mappedSelectors = selectors.stream()
@@ -633,7 +645,8 @@ public class StatementFactory {
 							.orElseGet(() -> getSelection(selector)))
 					.collect(Collectors.toList());
 
-			select = QueryBuilder.selectFrom(keyspace, from).selectors(mappedSelectors);
+			select = QueryBuilder.selectFrom(from.getKeyspaceName().orElse(null), from.getTableName())
+					.selectors(mappedSelectors);
 		}
 
 		StatementBuilder<Select> builder = StatementBuilder.of(select);
@@ -678,10 +691,12 @@ public class StatementFactory {
 				.column(CqlIdentifier.fromInternal(selector.getExpression()));
 	}
 
-	private static StatementBuilder<com.datastax.oss.driver.api.querybuilder.update.Update> update(CqlIdentifier table,
+	private static StatementBuilder<com.datastax.oss.driver.api.querybuilder.update.Update> update(
+			TableCoordinates tableCoordinates,
 			Update mappedUpdate, Filter filter) {
 
-		UpdateStart updateStart = QueryBuilder.update(table);
+		UpdateStart updateStart = QueryBuilder.update(tableCoordinates.getKeyspaceName().orElse(null),
+				tableCoordinates.getTableName());
 
 		return StatementBuilder.of((com.datastax.oss.driver.api.querybuilder.update.Update) updateStart)
 				.bind((statement, factory) -> {
@@ -831,9 +846,9 @@ public class StatementFactory {
 		return Assignment.append(updateOp.toCqlIdentifier(), termFactory.create(updateOp.getValue()));
 	}
 
-	private StatementBuilder<Delete> delete(List<CqlIdentifier> columnNames, CqlIdentifier from, Filter filter) {
+	private StatementBuilder<Delete> delete(List<CqlIdentifier> columnNames, TableCoordinates from, Filter filter) {
 
-		DeleteSelection select = QueryBuilder.deleteFrom(from);
+		DeleteSelection select = QueryBuilder.deleteFrom(from.getKeyspaceName().orElse(null), from.getTableName());
 
 		for (CqlIdentifier columnName : columnNames) {
 			select = select.column(columnName);

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/StatementFactory.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/StatementFactory.java
@@ -181,7 +181,7 @@ public class StatementFactory {
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(persistentEntity, "CassandraPersistentEntity must not be null");
 
-		return count(query, persistentEntity, persistentEntity.getKeyspace(), persistentEntity.getTableName());
+		return count(query, persistentEntity, persistentEntity.getKeyspaceName(), persistentEntity.getTableName());
 	}
 
 	/**
@@ -236,7 +236,7 @@ public class StatementFactory {
 		Assert.notNull(query, "Query must not be null");
 		Assert.notNull(persistentEntity, "CassandraPersistentEntity must not be null");
 
-		return select(query, persistentEntity, persistentEntity.getKeyspace(), persistentEntity.getTableName());
+		return select(query, persistentEntity, persistentEntity.getKeyspaceName(), persistentEntity.getTableName());
 	}
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/TableCoordinates.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/TableCoordinates.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.core;
+
+import java.util.Optional;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import org.springframework.data.cassandra.core.mapping.BasicCassandraPersistentEntity;
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
+
+/**
+ * The coordinates that are defining optional keyspace and non-optional table. They will be used when constructing and
+ * executing CQL queries.
+ * 
+ * @author Tomasz Lelek
+ */
+public class TableCoordinates {
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType") private final Optional<CqlIdentifier> keyspaceName;
+	private final CqlIdentifier tableName;
+
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	private TableCoordinates(Optional<CqlIdentifier> keyspaceName, CqlIdentifier tableName) {
+		this.keyspaceName = keyspaceName;
+		this.tableName = tableName;
+	}
+
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	public static TableCoordinates of(Optional<CqlIdentifier> keyspaceName, CqlIdentifier tableName) {
+		return new TableCoordinates(keyspaceName, tableName);
+	}
+
+	public static TableCoordinates of(BasicCassandraPersistentEntity<?> persistentEntity) {
+		return new TableCoordinates(persistentEntity.getKeyspaceName(), persistentEntity.getTableName());
+	}
+
+	public static TableCoordinates of(CassandraPersistentEntity<?> persistentEntity) {
+		return new TableCoordinates(persistentEntity.getKeyspaceName(), persistentEntity.getTableName());
+	}
+
+	public Optional<CqlIdentifier> getKeyspaceName() {
+		return keyspaceName;
+	}
+
+	public CqlIdentifier getTableName() {
+		return tableName;
+	}
+
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
@@ -59,6 +59,8 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 
 	private @Nullable StandardEvaluationContext spelContext;
 
+	private @Nullable CqlIdentifier keyspaceName;
+
 	/**
 	 * Create a new {@link BasicCassandraPersistentEntity} given {@link TypeInformation}.
 	 *
@@ -212,6 +214,7 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 		Assert.notNull(namingStrategy, "NamingStrategy must not be null");
 
 		this.namingStrategy = namingStrategy;
+		setKeyspaceName(namingStrategy.getKeyspaceName(this).orElse(null));
 	}
 
 	NamingStrategy getNamingStrategy() {
@@ -229,7 +232,12 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 	@Nullable
 	@Override
 	public CqlIdentifier getKeyspaceName() {
-		return namingStrategy.getKeyspaceName(this).orElse(null);
+		return keyspaceName;
+	}
+
+	@Override
+	public void setKeyspaceName(@Nullable CqlIdentifier keyspaceName) {
+		this.keyspaceName = keyspaceName;
 	}
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
@@ -58,7 +58,6 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 	private NamingStrategy namingStrategy = NamingStrategy.INSTANCE;
 
 	private @Nullable StandardEvaluationContext spelContext;
-	private @Nullable CqlIdentifier keyspace;
 
 	/**
 	 * Create a new {@link BasicCassandraPersistentEntity} given {@link TypeInformation}.
@@ -202,11 +201,6 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 		this.tableName = tableName;
 	}
 
-	@Override
-	public void setKeyspace(@Nullable CqlIdentifier keyspace) {
-		this.keyspace = keyspace;
-	}
-
 	/**
 	 * Set the {@link NamingStrategy} to use.
 	 *
@@ -235,7 +229,7 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 	@Nullable
 	@Override
 	public CqlIdentifier getKeyspace() {
-		return keyspace;
+		return namingStrategy.getKeyspace(this).orElse(null);
 	}
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
@@ -228,8 +228,8 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 
 	@Nullable
 	@Override
-	public CqlIdentifier getKeyspace() {
-		return namingStrategy.getKeyspace(this).orElse(null);
+	public CqlIdentifier getKeyspaceName() {
+		return namingStrategy.getKeyspaceName(this).orElse(null);
 	}
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
@@ -43,6 +43,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * @author Matthew T. Adams
  * @author John Blum
  * @author Mark Paluch
+ * @author Tomasz Lelek
  */
 public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, CassandraPersistentProperty>
 		implements CassandraPersistentEntity<T>, ApplicationContextAware {
@@ -59,7 +60,7 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 
 	private @Nullable StandardEvaluationContext spelContext;
 
-	private @Nullable CqlIdentifier keyspaceName;
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType") private Optional<CqlIdentifier> keyspaceName;
 
 	/**
 	 * Create a new {@link BasicCassandraPersistentEntity} given {@link TypeInformation}.
@@ -214,7 +215,7 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 		Assert.notNull(namingStrategy, "NamingStrategy must not be null");
 
 		this.namingStrategy = namingStrategy;
-		setKeyspaceName(namingStrategy.getKeyspaceName(this).orElse(null));
+		setKeyspaceName(namingStrategy.getKeyspaceName(this));
 	}
 
 	NamingStrategy getNamingStrategy() {
@@ -229,14 +230,13 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 		return Optional.ofNullable(this.tableName).orElseGet(this::determineTableName);
 	}
 
-	@Nullable
 	@Override
-	public CqlIdentifier getKeyspaceName() {
+	public Optional<CqlIdentifier> getKeyspaceName() {
 		return keyspaceName;
 	}
 
 	@Override
-	public void setKeyspaceName(@Nullable CqlIdentifier keyspaceName) {
+	public void setKeyspaceName(Optional<CqlIdentifier> keyspaceName) {
 		this.keyspaceName = keyspaceName;
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
@@ -60,7 +60,7 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 
 	private @Nullable StandardEvaluationContext spelContext;
 
-	@SuppressWarnings("OptionalUsedAsFieldOrParameterType") private Optional<CqlIdentifier> keyspaceName;
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType") private Optional<CqlIdentifier> keyspaceName = Optional.empty();
 
 	/**
 	 * Create a new {@link BasicCassandraPersistentEntity} given {@link TypeInformation}.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntity.java
@@ -58,6 +58,7 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 	private NamingStrategy namingStrategy = NamingStrategy.INSTANCE;
 
 	private @Nullable StandardEvaluationContext spelContext;
+	private @Nullable CqlIdentifier keyspace;
 
 	/**
 	 * Create a new {@link BasicCassandraPersistentEntity} given {@link TypeInformation}.
@@ -201,6 +202,11 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 		this.tableName = tableName;
 	}
 
+	@Override
+	public void setKeyspace(@Nullable CqlIdentifier keyspace) {
+		this.keyspace = keyspace;
+	}
+
 	/**
 	 * Set the {@link NamingStrategy} to use.
 	 *
@@ -224,6 +230,12 @@ public class BasicCassandraPersistentEntity<T> extends BasicPersistentEntity<T, 
 	@Override
 	public CqlIdentifier getTableName() {
 		return Optional.ofNullable(this.tableName).orElseGet(this::determineTableName);
+	}
+
+	@Nullable
+	@Override
+	public CqlIdentifier getKeyspace() {
+		return keyspace;
 	}
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContext.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContext.java
@@ -278,10 +278,6 @@ public class CassandraMappingContext
 		this.namingStrategy = namingStrategy;
 	}
 
-	public void setKeyspace(@Nullable CqlIdentifier keyspace){
-		this.keyspace = keyspace;
-	}
-
 	/**
 	 * Sets the {@link TupleTypeFactory}.
 	 *
@@ -387,7 +383,6 @@ public class CassandraMappingContext
 				: new BasicCassandraPersistentEntity<>(typeInformation, getVerifier());
 
 		entity.setNamingStrategy(this.namingStrategy);
-		entity.setKeyspace(this.keyspace);
 		Optional.ofNullable(this.applicationContext).ifPresent(entity::setApplicationContext);
 
 		return entity;

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContext.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContext.java
@@ -73,9 +73,7 @@ public class CassandraMappingContext
 	private Mapping mapping = new Mapping();
 
 	private NamingStrategy namingStrategy = NamingStrategy.INSTANCE;
-
-	private @Nullable CqlIdentifier keyspace;
-
+	
 	private @Deprecated @Nullable UserTypeResolver userTypeResolver;
 
 	private @Deprecated CodecRegistry codecRegistry = CodecRegistry.DEFAULT;

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContext.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContext.java
@@ -56,6 +56,7 @@ import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
  * @author John Blum
  * @author Jens Schauder
  * @author Vagif Zeynalov
+ * @author Toamsz Lelek
  */
 public class CassandraMappingContext
 		extends AbstractMappingContext<BasicCassandraPersistentEntity<?>, CassandraPersistentProperty>
@@ -72,6 +73,8 @@ public class CassandraMappingContext
 	private Mapping mapping = new Mapping();
 
 	private NamingStrategy namingStrategy = NamingStrategy.INSTANCE;
+
+	private @Nullable CqlIdentifier keyspace;
 
 	private @Deprecated @Nullable UserTypeResolver userTypeResolver;
 
@@ -275,6 +278,10 @@ public class CassandraMappingContext
 		this.namingStrategy = namingStrategy;
 	}
 
+	public void setKeyspace(@Nullable CqlIdentifier keyspace){
+		this.keyspace = keyspace;
+	}
+
 	/**
 	 * Sets the {@link TupleTypeFactory}.
 	 *
@@ -380,6 +387,7 @@ public class CassandraMappingContext
 				: new BasicCassandraPersistentEntity<>(typeInformation, getVerifier());
 
 		entity.setNamingStrategy(this.namingStrategy);
+		entity.setKeyspace(this.keyspace);
 		Optional.ofNullable(this.applicationContext).ifPresent(entity::setApplicationContext);
 
 		return entity;

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
@@ -15,8 +15,9 @@
  */
 package org.springframework.data.cassandra.core.mapping;
 
+import java.util.Optional;
+
 import org.springframework.data.mapping.PersistentEntity;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
@@ -54,17 +55,18 @@ public interface CassandraPersistentEntity<T> extends PersistentEntity<T, Cassan
 
 
 	/**
-	 * Returns the keyspace to which the entity shall be persisted.
+	 * Returns the keyspace to which the entity shall be persisted. It returns {@code Optional.empty()} if there is no
+	 * keyspace explicitly set
 	 */
-	@Nullable
-	CqlIdentifier getKeyspaceName();
+	Optional<CqlIdentifier> getKeyspaceName();
 
 	/**
 	 * Sets the CQL table name.
 	 *
-	 * @param keyspaceName if set to {@literal null}, then session level keyspace will be used.
+	 * @param keyspaceName if is {@code Optional.empty()}, then session level keyspace will be used.
 	 */
-	void setKeyspaceName(@Nullable CqlIdentifier keyspaceName);
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	void setKeyspaceName(Optional<CqlIdentifier> keyspaceName);
 
 	/**
 	 * Sets the CQL table name.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
@@ -62,6 +62,13 @@ public interface CassandraPersistentEntity<T> extends PersistentEntity<T, Cassan
 	/**
 	 * Sets the CQL table name.
 	 *
+	 * @param keyspaceName if set to {@literal null}, then session level keyspace will be used.
+	 */
+	void setKeyspaceName(@Nullable CqlIdentifier keyspaceName);
+
+	/**
+	 * Sets the CQL table name.
+	 *
 	 * @param tableName must not be {@literal null}.
 	 * @deprecated since 3.0, use {@link #setTableName(CqlIdentifier)} instead.
 	 */

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
@@ -56,7 +56,8 @@ public interface CassandraPersistentEntity<T> extends PersistentEntity<T, Cassan
 	/**
 	 * Returns the keyspace to which the entity shall be persisted.
 	 */
-	@Nullable CqlIdentifier getKeyspace();
+	@Nullable
+	CqlIdentifier getKeyspaceName();
 
 	/**
 	 * Sets the CQL table name.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
@@ -16,6 +16,7 @@
 package org.springframework.data.cassandra.core.mapping;
 
 import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
@@ -26,6 +27,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * @author Alex Shvid
  * @author Matthew T. Adams
  * @author Mark Paluch
+ * @author Tomasz Lelek
  */
 public interface CassandraPersistentEntity<T> extends PersistentEntity<T, CassandraPersistentProperty> {
 
@@ -50,6 +52,12 @@ public interface CassandraPersistentEntity<T> extends PersistentEntity<T, Cassan
 	 */
 	CqlIdentifier getTableName();
 
+
+	/**
+	 * Returns the keyspace to which the entity shall be persisted.
+	 */
+	@Nullable CqlIdentifier getKeyspace();
+
 	/**
 	 * Sets the CQL table name.
 	 *
@@ -69,6 +77,13 @@ public interface CassandraPersistentEntity<T> extends PersistentEntity<T, Cassan
 	 * @param tableName must not be {@literal null}.
 	 */
 	void setTableName(CqlIdentifier tableName);
+
+	/**
+	 * Sets the keyspace name.
+	 *
+	 * @param keyspace must not be {@literal null}.
+	 */
+	void setKeyspace(CqlIdentifier keyspace);
 
 	/**
 	 * @return {@literal true} if the type is a mapped tuple type.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
@@ -78,12 +78,6 @@ public interface CassandraPersistentEntity<T> extends PersistentEntity<T, Cassan
 	 */
 	void setTableName(CqlIdentifier tableName);
 
-	/**
-	 * Sets the keyspace name.
-	 *
-	 * @param keyspace must not be {@literal null}.
-	 */
-	void setKeyspace(CqlIdentifier keyspace);
 
 	/**
 	 * @return {@literal true} if the type is a mapped tuple type.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
@@ -118,11 +118,6 @@ public class EmbeddedEntityOperations {
 		}
 
 		@Override
-		public void setKeyspace(CqlIdentifier keyspace) {
-			delegate.setKeyspace(keyspace);
-		}
-
-		@Override
 		public boolean isTupleType() {
 			return delegate.isTupleType();
 		}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
@@ -107,6 +107,11 @@ public class EmbeddedEntityOperations {
 		}
 
 		@Override
+		public void setKeyspaceName(@Nullable CqlIdentifier keyspaceName) {
+			delegate.setKeyspaceName(keyspaceName);
+		}
+
+		@Override
 		@Deprecated
 		public void setTableName(org.springframework.data.cassandra.core.cql.CqlIdentifier tableName) {
 			delegate.setTableName(tableName);

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Spliterator;
 import java.util.function.Consumer;
 
@@ -41,6 +42,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * Support methods to obtain {@link PersistentProperty} and {@link PersistentEntity} for embedded properties.
  *
  * @author Christoph Strobl
+ * @author Tomasz Lelek
  * @since 3.0
  * @see Embedded
  */
@@ -102,12 +104,12 @@ public class EmbeddedEntityOperations {
 		}
 
 		@Override
-		public CqlIdentifier getKeyspaceName() {
+		public Optional<CqlIdentifier> getKeyspaceName() {
 			return delegate.getKeyspaceName();
 		}
 
 		@Override
-		public void setKeyspaceName(@Nullable CqlIdentifier keyspaceName) {
+		public void setKeyspaceName(Optional<CqlIdentifier> keyspaceName) {
 			delegate.setKeyspaceName(keyspaceName);
 		}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
@@ -102,6 +102,11 @@ public class EmbeddedEntityOperations {
 		}
 
 		@Override
+		public CqlIdentifier getKeyspace() {
+			return delegate.getKeyspace();
+		}
+
+		@Override
 		@Deprecated
 		public void setTableName(org.springframework.data.cassandra.core.cql.CqlIdentifier tableName) {
 			delegate.setTableName(tableName);
@@ -110,6 +115,11 @@ public class EmbeddedEntityOperations {
 		@Override
 		public void setTableName(CqlIdentifier tableName) {
 			delegate.setTableName(tableName);
+		}
+
+		@Override
+		public void setKeyspace(CqlIdentifier keyspace) {
+			delegate.setKeyspace(keyspace);
 		}
 
 		@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
@@ -102,8 +102,8 @@ public class EmbeddedEntityOperations {
 		}
 
 		@Override
-		public CqlIdentifier getKeyspace() {
-			return delegate.getKeyspace();
+		public CqlIdentifier getKeyspaceName() {
+			return delegate.getKeyspaceName();
 		}
 
 		@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/NamingStrategy.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/NamingStrategy.java
@@ -15,8 +15,10 @@
  */
 package org.springframework.data.cassandra.core.mapping;
 
+import java.util.Optional;
 import java.util.function.UnaryOperator;
 
+import com.datastax.oss.driver.api.core.CqlIdentifier;
 import org.springframework.util.Assert;
 
 /**
@@ -51,6 +53,11 @@ public interface NamingStrategy {
 		Assert.notNull(entity, "CassandraPersistentEntity must not be null");
 
 		return entity.getType().getSimpleName();
+	}
+
+	default Optional<CqlIdentifier> getKeyspace(CassandraPersistentEntity<?> entity) {
+		Assert.notNull(entity, "CassandraPersistentEntity must not be null");
+		return Optional.empty();
 	}
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/NamingStrategy.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/NamingStrategy.java
@@ -55,7 +55,7 @@ public interface NamingStrategy {
 		return entity.getType().getSimpleName();
 	}
 
-	default Optional<CqlIdentifier> getKeyspace(CassandraPersistentEntity<?> entity) {
+	default Optional<CqlIdentifier> getKeyspaceName(CassandraPersistentEntity<?> entity) {
 		Assert.notNull(entity, "CassandraPersistentEntity must not be null");
 		return Optional.empty();
 	}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/StatementFactoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/StatementFactoryUnitTests.java
@@ -21,13 +21,11 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.datastax.oss.driver.api.core.CqlIdentifier;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.cassandra.core.convert.CassandraConverter;
 import org.springframework.data.cassandra.core.convert.MappingCassandraConverter;
@@ -39,6 +37,7 @@ import org.springframework.data.cassandra.core.cql.util.StatementBuilder.Paramet
 import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
 import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.NamingStrategy;
 import org.springframework.data.cassandra.core.query.Columns;
 import org.springframework.data.cassandra.core.query.Criteria;
 import org.springframework.data.cassandra.core.query.Query;
@@ -46,6 +45,7 @@ import org.springframework.data.cassandra.core.query.Update;
 import org.springframework.data.cassandra.domain.Group;
 import org.springframework.data.domain.Sort;
 
+import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.querybuilder.delete.Delete;
@@ -618,14 +618,17 @@ class StatementFactoryUnitTests {
 	@Test // DATACASS-751
 	void shouldConstructQueryWithKeyspace() {
 		CassandraMappingContext cassandraMappingContext = new CassandraMappingContext();
-		cassandraMappingContext.setKeyspace(CqlIdentifier.fromCql("ks1"));
+		cassandraMappingContext.setNamingStrategy(new NamingStrategy() {
+			@Override
+			public Optional<CqlIdentifier> getKeyspace(CassandraPersistentEntity<?> entity) {
+				return Optional.of(CqlIdentifier.fromCql("ks1"));
+			}
+		});
 
 		CassandraConverter converter = new MappingCassandraConverter();
 		UpdateMapper updateMapper = new UpdateMapper(converter);
 		StatementFactory statementFactory = new StatementFactory(updateMapper, updateMapper);
 
-
-		converter.getMappingContext().setKeyspace(CqlIdentifier.fromCql("ks1"));
 
 		StatementBuilder<Select> select = statementFactory.select(Query.empty(),
 				converter.getMappingContext().getRequiredPersistentEntity(Group.class));

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/StatementFactoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/StatementFactoryUnitTests.java
@@ -620,7 +620,7 @@ class StatementFactoryUnitTests {
 		CassandraMappingContext cassandraMappingContext = new CassandraMappingContext();
 		cassandraMappingContext.setNamingStrategy(new NamingStrategy() {
 			@Override
-			public Optional<CqlIdentifier> getKeyspace(CassandraPersistentEntity<?> entity) {
+			public Optional<CqlIdentifier> getKeyspaceName(CassandraPersistentEntity<?> entity) {
 				return Optional.of(CqlIdentifier.fromCql("ks1"));
 			}
 		});

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/StatementFactoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/StatementFactoryUnitTests.java
@@ -625,7 +625,7 @@ class StatementFactoryUnitTests {
 			}
 		});
 
-		CassandraConverter converter = new MappingCassandraConverter();
+		CassandraConverter converter = new MappingCassandraConverter(cassandraMappingContext);
 		UpdateMapper updateMapper = new UpdateMapper(converter);
 		StatementFactory statementFactory = new StatementFactory(updateMapper, updateMapper);
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
@@ -180,7 +180,7 @@ class BasicCassandraPersistentEntityUnitTests {
 		BasicCassandraPersistentEntity<Notification> entity = new BasicCassandraPersistentEntity<>(
 				ClassTypeInformation.from(Notification.class));
 
-		assertThat(entity.getKeyspaceName()).isNull();
+		assertThat(entity.getKeyspaceName().isPresent()).isFalse();
 
 		entity.setNamingStrategy(new NamingStrategy() {
 			@Override
@@ -189,7 +189,7 @@ class BasicCassandraPersistentEntityUnitTests {
 			}
 		});
 
-		assertThat(entity.getKeyspaceName()).isEqualTo(CqlIdentifier.fromCql("ks1"));
+		assertThat(entity.getKeyspaceName().get()).isEqualTo(CqlIdentifier.fromCql("ks1"));
 	}
 
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
@@ -23,12 +23,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.AliasFor;
@@ -181,7 +182,12 @@ class BasicCassandraPersistentEntityUnitTests {
 
 		assertThat(entity.getKeyspace()).isNull();
 
-		entity.setKeyspace(CqlIdentifier.fromCql("ks1"));
+		entity.setNamingStrategy(new NamingStrategy() {
+			@Override
+			public Optional<CqlIdentifier> getKeyspace(CassandraPersistentEntity<?> entity) {
+				return Optional.of(CqlIdentifier.fromCql("ks1"));
+			}
+		});
 
 		assertThat(entity.getKeyspace()).isEqualTo(CqlIdentifier.fromCql("ks1"));
 	}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
@@ -180,16 +180,16 @@ class BasicCassandraPersistentEntityUnitTests {
 		BasicCassandraPersistentEntity<Notification> entity = new BasicCassandraPersistentEntity<>(
 				ClassTypeInformation.from(Notification.class));
 
-		assertThat(entity.getKeyspace()).isNull();
+		assertThat(entity.getKeyspaceName()).isNull();
 
 		entity.setNamingStrategy(new NamingStrategy() {
 			@Override
-			public Optional<CqlIdentifier> getKeyspace(CassandraPersistentEntity<?> entity) {
+			public Optional<CqlIdentifier> getKeyspaceName(CassandraPersistentEntity<?> entity) {
 				return Optional.of(CqlIdentifier.fromCql("ks1"));
 			}
 		});
 
-		assertThat(entity.getKeyspace()).isEqualTo(CqlIdentifier.fromCql("ks1"));
+		assertThat(entity.getKeyspaceName()).isEqualTo(CqlIdentifier.fromCql("ks1"));
 	}
 
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
@@ -175,7 +175,7 @@ class BasicCassandraPersistentEntityUnitTests {
 	}
 
 
-	@Test //DATACASS-751
+	@Test // DATACASS-751
 	void shouldSetKeyspace(){
 		BasicCassandraPersistentEntity<Notification> entity = new BasicCassandraPersistentEntity<>(
 				ClassTypeInformation.from(Notification.class));

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
@@ -173,6 +173,20 @@ class BasicCassandraPersistentEntityUnitTests {
 		verifyZeroInteractions(handlerMock);
 	}
 
+
+	@Test //DATACASS-751
+	void shouldSetKeyspace(){
+		BasicCassandraPersistentEntity<Notification> entity = new BasicCassandraPersistentEntity<>(
+				ClassTypeInformation.from(Notification.class));
+
+		assertThat(entity.getKeyspace()).isNull();
+
+		entity.setKeyspace(CqlIdentifier.fromCql("ks1"));
+
+		assertThat(entity.getKeyspace()).isEqualTo(CqlIdentifier.fromCql("ks1"));
+	}
+
+
 	@Table("messages")
 	static class Message {}
 


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACASS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

todo:
- [ ] adapt Events (i.e `BeforeDeleteEvent`, `BeforeSaveEvent`, `AfterSaveEvent`, etc) to `TableCoordinates`
- [ ] cover `TableCoordinates` with keyspace with more IT and UnitTests
- [ ] consider `CassandraTemplate#getMapper` to work per `TableCoordinates` (not only `tableName`)
- [ ] consider moving TableCoordinates to `CassandraPersistentEntity#getTableCoordinates()` AND `BasicCassandraPersistentEntity` 
