### PR TITLE
DATACASS-814 - MapPreparedStatementCache.CacheKey uses

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/support/MapPreparedStatementCache.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/support/MapPreparedStatementCache.java
@@ -34,6 +34,7 @@ import com.datastax.oss.driver.api.core.cql.SimpleStatement;
  * {@code cql} text. Statement options (idempotency, timeouts) apply from the statement that was initially prepared.
  *
  * @author Mark Paluch
+ * @author Aldo Bongio
  * @since 2.0
  */
 public class MapPreparedStatementCache implements PreparedStatementCache {
@@ -84,7 +85,7 @@ public class MapPreparedStatementCache implements PreparedStatementCache {
 	public PreparedStatement getPreparedStatement(CqlSession session, SimpleStatement statement,
 			Supplier<PreparedStatement> preparer) {
 
-		CacheKey cacheKey = new CacheKey(session, statement.toString());
+		CacheKey cacheKey = new CacheKey(session, statement.getQuery());
 
 		return getCache().computeIfAbsent(cacheKey, key -> preparer.get());
 	}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/support/CachedPreparedStatementCreatorUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/support/CachedPreparedStatementCreatorUnitTests.java
@@ -39,6 +39,7 @@ import com.datastax.oss.driver.api.querybuilder.update.Assignment;
  * Unit tests for {@link CachedPreparedStatementCreator}.
  *
  * @author Mark Paluch
+ * @author Aldo Bongio
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -182,4 +183,17 @@ class CachedPreparedStatementCreatorUnitTests {
 		verify(session).prepare(firstStatement);
 		verify(session).prepare(secondStatement);
 	}
+
+    @Test // DATACASS-814
+    void shouldUseCqlTextInCacheKey() {
+
+        String cql = "SELECT foo FROM users;";
+
+        MapPreparedStatementCache cache = MapPreparedStatementCache.create();
+        CachedPreparedStatementCreator creator = CachedPreparedStatementCreator.of(cache, cql);
+        creator.createPreparedStatement(session);
+
+        MapPreparedStatementCache.CacheKey cacheKey = cache.getCache().keySet().iterator().next();
+        assertThat(cacheKey.cql).isSameAs(cql);
+    }
 }


### PR DESCRIPTION
DefaultSimpleStatement.toString() inherited from Object.toString()

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACASS).
- [ X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ X] You submit test cases (unit or integration tests) that back your changes.
- [ X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
