### PR TITLE
Defer non-constant assert messages to improve performance

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverter.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/MappingCassandraConverter.java
@@ -25,7 +25,6 @@ import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.context.ApplicationContext;
@@ -85,6 +84,7 @@ import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
  * @author Antoine Toulme
  * @author John Blum
  * @author Christoph Strobl
+ * @author Frank Spitulski
  */
 public class MappingCassandraConverter extends AbstractCassandraConverter
 		implements ApplicationContextAware, BeanClassLoaderAware {
@@ -521,7 +521,7 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 
 		Object id = extractId(source, entity);
 
-		Assert.notNull(id, String.format("No Id value found in object %s", source));
+		Assert.notNull(id, () -> String.format("No Id value found in object %s", source));
 
 		CassandraPersistentProperty idProperty = entity.getIdProperty();
 		CassandraPersistentProperty compositeIdProperty = null;
@@ -600,7 +600,7 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 	private void writeWhere(ConvertingPropertyAccessor<?> accessor, Where sink, CassandraPersistentEntity<?> entity) {
 
 		Assert.isTrue(entity.isCompositePrimaryKey(),
-				String.format("Entity [%s] is not a composite primary key", entity.getName()));
+				() -> String.format("Entity [%s] is not a composite primary key", entity.getName()));
 
 		for (CassandraPersistentProperty property : entity) {
 			TypeCodec<Object> codec = getCodec(property);
@@ -684,7 +684,7 @@ public class MappingCassandraConverter extends AbstractCassandraConverter
 		ConvertingPropertyAccessor<?> propertyAccessor = newConvertingPropertyAccessor(object, entity);
 
 		Assert.isTrue(entity.getType().isAssignableFrom(object.getClass()),
-				String.format("Given instance of type [%s] is not compatible with expected type [%s]",
+				() -> String.format("Given instance of type [%s] is not compatible with expected type [%s]",
 						object.getClass().getName(), entity.getType().getName()));
 
 		if (object instanceof MapIdentifiable) {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/RowReader.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/RowReader.java
@@ -35,6 +35,7 @@ import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
  * Helpful class to read a column's value from a row, with possible type conversion.
  *
  * @author Mark Paluch
+ * @author Frank Spitulski
  * @since 3.0
  */
 class RowReader {
@@ -165,7 +166,7 @@ class RowReader {
 
 		int index = columns.firstIndexOf(columnName);
 
-		Assert.isTrue(index > -1, String.format("Column [%s] does not exist in table", columnName));
+		Assert.isTrue(index > -1, () -> String.format("Column [%s] does not exist in table", columnName));
 
 		return index;
 	}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/generator/AlterUserTypeCqlGenerator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/generator/AlterUserTypeCqlGenerator.java
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
  *
  * @author Fabio J. Mendes
  * @author Mark Paluch
+ * @author Frank Spitulski
  * @since 1.5
  * @see AlterUserTypeSpecification
  * @see AddColumnSpecification
@@ -58,7 +59,7 @@ public class AlterUserTypeCqlGenerator extends UserTypeNameCqlGenerator<AlterUse
 		Assert.notNull(getSpecification().getName(), "User type name must not be null");
 
 		Assert.isTrue(!getSpecification().getChanges().isEmpty(),
-				String.format("User type [%s] does not contain fields", getSpecification().getName()));
+				() -> String.format("User type [%s] does not contain fields", getSpecification().getName()));
 
 		return changesCql(preambleCql(cql)).append(";");
 	}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/generator/CreateUserTypeCqlGenerator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/generator/CreateUserTypeCqlGenerator.java
@@ -24,6 +24,7 @@ import org.springframework.util.Assert;
  *
  * @author Fabio J. Mendes
  * @author Mark Paluch
+ * @author Frank Spitulski
  * @since 1.5
  * @see CreateUserTypeSpecification
  */
@@ -52,7 +53,7 @@ public class CreateUserTypeCqlGenerator extends UserTypeNameCqlGenerator<CreateU
 		Assert.notNull(getSpecification().getName(), "User type name must not be null");
 
 		Assert.isTrue(!getSpecification().getFields().isEmpty(),
-				String.format("User type [%s] does not contain fields", getSpecification().getName().asCql(true)));
+				() -> String.format("User type [%s] does not contain fields", getSpecification().getName().asCql(true)));
 
 		return columns(preambleCql(cql)).append(";");
 	}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentTupleProperty.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentTupleProperty.java
@@ -27,6 +27,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * Cassandra Tuple specific {@link CassandraPersistentProperty} implementation.
  *
  * @author Mark Paluch
+ * @author Frank Spitulski
  * @since 2.1
  * @see Element
  */
@@ -68,7 +69,8 @@ public class BasicCassandraPersistentTupleProperty extends BasicCassandraPersist
 		}
 
 		Assert.isTrue(ordinal >= 0,
-				String.format("Element ordinal must be greater or equal to zero for property [%s] in entity [%s]", getName(),
+				() -> String.format("Element ordinal must be greater or equal to zero for property [%s] in entity [%s]",
+						getName(),
 						getOwner().getName()));
 
 		return ordinal;

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentProperty.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentProperty.java
@@ -35,6 +35,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * @author Mark Paluch
  * @author John Blum
  * @author Christoph Strobl
+ * @author Frank Spitulski
  */
 public interface CassandraPersistentProperty
 		extends PersistentProperty<CassandraPersistentProperty>, ApplicationContextAware {
@@ -81,8 +82,8 @@ public interface CassandraPersistentProperty
 
 		CqlIdentifier columnName = getColumnName();
 
-		Assert.state(columnName != null, String.format("No column name available for this persistent property [%1$s.%2$s]",
-				getOwner().getName(), getName()));
+		Assert.state(columnName != null, () -> String
+				.format("No column name available for this persistent property [%1$s.%2$s]", getOwner().getName(), getName()));
 
 		return columnName;
 	}
@@ -115,7 +116,7 @@ public interface CassandraPersistentProperty
 
 		Integer ordinal = getOrdinal();
 
-		Assert.state(ordinal != null, String.format("No ordinal available for this persistent property [%1$s.%2$s]",
+		Assert.state(ordinal != null, () -> String.format("No ordinal available for this persistent property [%1$s.%2$s]",
 				getOwner().getName(), getName()));
 
 		return ordinal;


### PR DESCRIPTION
I have observed a 40-50% reduction in CPU usage at 600 queries per second by deferring the string format operation.
There are no functional changes so I haven't changed the tests.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
