### PR TITLE
Prevent NullPointerException when User Defined Type is not found.

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/DefaultColumnTypeResolver.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/convert/DefaultColumnTypeResolver.java
@@ -444,16 +444,14 @@ class DefaultColumnTypeResolver implements ColumnTypeResolver {
 	}
 
 	private DataType getUserType(CassandraPersistentEntity<?> persistentEntity, boolean frozen) {
-
 		CqlIdentifier identifier = persistentEntity.getTableName();
-		com.datastax.oss.driver.api.core.type.UserDefinedType userType = userTypeResolver.resolveType(identifier)
-				.copy(frozen);
+		com.datastax.oss.driver.api.core.type.UserDefinedType userType = userTypeResolver.resolveType(identifier);
 
 		if (userType == null) {
 			throw new MappingException(String.format("User type [%s] not found", identifier));
 		}
 
-		return userType;
+		return userType.copy(frozen);
 	}
 
 	private Class<?> resolveToJavaType(DataType dataType) {


### PR DESCRIPTION
Bug introduced by:
>  Introduces @Frozen annotation to mark schema elements as Frozen. (17adf20a143727a7a86a5954fa3a4a3cd9b985a7)

Discussed in #1084

@mp911de: I'm not sure how to test it. Probably something in `ColumnTypeResolverUnitTests` like the following, but could you please give me how to get a UDT CassandraType? (Or directly write the test)

```java
	@Test // DATACASS-743
	void shouldReportMissingType() {
		CassandraType annotation;

		assertThatThrownBy(() -> resolver.resolve(annotation)).isInstanceOf(MappingException.class);
	}
```