### PR TITLE
fix flaky test in ColumnsUnitTests

### DIFF
--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/query/ColumnsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/query/ColumnsUnitTests.java
@@ -48,8 +48,7 @@ class ColumnsUnitTests {
 	void shouldCreateFromColumns() {
 
 		Columns columns = Columns.from("asc", "bar");
-
-		assertThat(columns.toString()).isEqualTo("asc, bar");
+		assertThat(columns.toString()).contains("asc").contains("bar");
 	}
 
 	@Test // DATACASS-343


### PR DESCRIPTION
In `org.springframework.data.cassandra.core.query.ColumnsUnitTests`, the test `shouldCreateFromColumns()` is flaky due to the non-deterministic property of `HashMap` (please refer [document](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html)). it is internally invoked by `Columns.from()`. I fixed it checking whether it contains the name of these two columns instead of comparing the whole string, which doesn't affected by the order of string generated by non-determined `Columns.from()`.
