### PR TITLE
fix flaky test in CriteriaUnitTests

### DIFF
--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/query/CriteriaUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/query/CriteriaUnitTests.java
@@ -20,6 +20,7 @@ import static org.springframework.data.cassandra.core.query.SerializationUtils.*
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 import org.junit.jupiter.api.Test;
 
@@ -113,7 +114,7 @@ class CriteriaUnitTests {
 	@Test // DATACASS-343
 	void shouldCreateIsInSet() {
 
-		CriteriaDefinition criteria = Criteria.where("foo").in(new HashSet<>(Arrays.asList("a", "b", "c")));
+		CriteriaDefinition criteria = Criteria.where("foo").in(new LinkedHashSet<>(Arrays.asList("a", "b", "c")));
 
 		assertThat(serializeToCqlSafely(criteria)).isEqualTo("foo IN {'a','b','c'}");
 	}


### PR DESCRIPTION
In `org.springframework.data.cassandra.core.query.CriteriaUnitTests`, the tests `shouldCreateIsInSet()` is  flaky due to the non-deterministic property of `HashSet` (please refer [document](https://docs.oracle.com/javase/7/docs/api/java/util/HashSet.html)).I fixed by changing the `HashSet` to `LinkedHashSet`, which guarantees the order of value added into the `set` and eliminates the flakiness of this test.
