### PR TITLE
fix flaky test in PartTreeCassandraQueryUnitTests

### DIFF
--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQueryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/PartTreeCassandraQueryUnitTests.java
@@ -150,7 +150,8 @@ class PartTreeCassandraQueryUnitTests {
 
 		String query = deriveQueryFromMethod("findPersonProjectedByNickname", "foo");
 
-		assertThat(query).isEqualTo("SELECT lastname,firstname FROM person WHERE nickname='foo'");
+		assertThat(query.equals("SELECT lastname,firstname FROM person WHERE nickname='foo'")
+				|| query.equals("SELECT firstname,lastname FROM person WHERE nickname='foo'")).isTrue();
 	}
 
 	@Test // DATACASS-357


### PR DESCRIPTION
In `org.springframework.data.cassandra.repository.query.PartTreeCassandraQueryUnitTests`, the test `usesProjectionQueryHiddenField()` is flaky due to the non-deterministic property of `HashMap` (please refer [document](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html)). it is internally invoked by `createQuery()` in method `deriveQueryFromMethod()`. I fixed by comparing the generated actual string with all possible order of query strings, if it satisfies either one of the possible solution, it will pass the test.