### PR TITLE
Fix flaky test in ReactivePartTreeCassandraQueryUnitTests

### DIFF
--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQueryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/query/ReactivePartTreeCassandraQueryUnitTests.java
@@ -109,7 +109,8 @@ class ReactivePartTreeCassandraQueryUnitTests {
 
 		String query = deriveQueryFromMethod("findDynamicallyProjectedBy", PersonProjection.class);
 
-		assertThat(query).isEqualTo("SELECT lastname,firstname FROM person");
+		assertThat(query.equals("SELECT lastname,firstname FROM person")
+				|| query.equals("SELECT firstname,lastname FROM person")).isTrue();
 	}
 
 	@Test // DATACASS-146


### PR DESCRIPTION
In `org.springframework.data.cassandra.repository.query.ReactivePartTreeCassandraQueryUnitTests`, the test `usesDynamicProjection()` is flaky due to the non-deterministic property of `HashMap` (please refer [document](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html)). it is internally invoked by `createQuery()` in method `deriveQueryFromMethod()`. I fixed by comparing the generated actual string with all possible order of query strings, if it satisfies either one of the possible solution, it will pass the test. This PR is similar to [pull/1200](https://github.com/spring-projects/spring-data-cassandra/pull/1200).
