### PR TITLE
Extend supported fields for query options

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/DeleteOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/DeleteOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.cassandra.core;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
@@ -35,6 +36,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  *
  * @author Mark Paluch
  * @author Tomasz Lelek
+ * @author Sam Lightfoot
  * @since 2.2
  */
 public class DeleteOptions extends WriteOptions {
@@ -48,10 +50,11 @@ public class DeleteOptions extends WriteOptions {
 	private DeleteOptions(@Nullable ConsistencyLevel consistencyLevel, ExecutionProfileResolver executionProfileResolver,
 			@Nullable CqlIdentifier keyspace, @Nullable Integer pageSize, @Nullable ConsistencyLevel serialConsistencyLevel,
 			Duration timeout, Duration ttl, @Nullable Long timestamp, @Nullable Boolean tracing, boolean ifExists,
-			@Nullable Filter ifCondition) {
+			@Nullable Filter ifCondition, @Nullable Boolean idempotent, @Nullable CqlIdentifier routingKeyspace,
+			@Nullable ByteBuffer routingKey) {
 
 		super(consistencyLevel, executionProfileResolver, keyspace, pageSize, serialConsistencyLevel, timeout, ttl,
-				timestamp, tracing);
+				timestamp, tracing, idempotent, routingKeyspace, routingKey);
 
 		this.ifExists = ifExists;
 		this.ifCondition = ifCondition;
@@ -290,6 +293,16 @@ public class DeleteOptions extends WriteOptions {
 		}
 
 		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.WriteOptions.WriteOptionsBuilder#idempotent(boolean)
+		 */
+		@Override
+		public DeleteOptionsBuilder idempotent(boolean idempotent) {
+
+			super.idempotent(idempotent);
+			return this;
+		}
+
+		/* (non-Javadoc)
 		 * @see org.springframework.data.cassandra.core.cql.WriteOptions.WriteOptionsBuilder#ttl(int)
 		 */
 		public DeleteOptionsBuilder ttl(int ttl) {
@@ -318,6 +331,25 @@ public class DeleteOptions extends WriteOptions {
 			return this;
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.QueryOptions.QueryOptionsBuilder#routingKeyspace(com.datastax.oss.driver.api.core.CqlIdentifier)
+		 */
+		@Override
+		public DeleteOptionsBuilder routingKeyspace(CqlIdentifier routingKeyspace) {
+
+			super.routingKeyspace(routingKeyspace);
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.QueryOptions.QueryOptionsBuilder#routingKeyspace(java.nio.ByteBuffer)
+		 */
+		@Override
+		public DeleteOptionsBuilder routingKey(ByteBuffer routingKey) {
+
+			super.routingKey(routingKey);
+			return this;
+		}
 
 		/**
 		 * Use light-weight transactions by applying {@code IF EXISTS}. Replaces a previous {@link #ifCondition(Filter)}.
@@ -382,7 +414,7 @@ public class DeleteOptions extends WriteOptions {
 
 			return new DeleteOptions(this.consistencyLevel, this.executionProfileResolver, this.keyspace, this.pageSize,
 					this.serialConsistencyLevel, this.timeout, this.ttl, this.timestamp, this.tracing, this.ifExists,
-					this.ifCondition);
+					this.ifCondition, this.idempotent, this.routingKeyspace, this.routingKey);
 		}
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/InsertOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/InsertOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.cassandra.core;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
@@ -32,6 +33,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * @author Mark Paluch
  * @author Lukasz Antoniak
  * @author Tomasz Lelek
+ * @author Sam Lightfoot
  * @since 2.0
  */
 public class InsertOptions extends WriteOptions {
@@ -45,10 +47,11 @@ public class InsertOptions extends WriteOptions {
 	private InsertOptions(@Nullable ConsistencyLevel consistencyLevel, ExecutionProfileResolver executionProfileResolver,
 			@Nullable CqlIdentifier keyspace, @Nullable Integer pageSize, @Nullable ConsistencyLevel serialConsistencyLevel,
 			Duration timeout, Duration ttl, @Nullable Long timestamp, @Nullable Boolean tracing, boolean ifNotExists,
-			boolean insertNulls) {
+			boolean insertNulls, @Nullable Boolean idempotent, @Nullable CqlIdentifier routingKeyspace,
+			@Nullable ByteBuffer routingKey) {
 
 		super(consistencyLevel, executionProfileResolver, keyspace, pageSize, serialConsistencyLevel, timeout, ttl,
-				timestamp, tracing);
+				timestamp, tracing, idempotent, routingKeyspace, routingKey);
 
 		this.ifNotExists = ifNotExists;
 		this.insertNulls = insertNulls;
@@ -317,6 +320,36 @@ public class InsertOptions extends WriteOptions {
 			return this;
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.QueryOptions.QueryOptionsBuilder#idempotent(boolean)
+		 */
+		@Override
+		public InsertOptionsBuilder idempotent(boolean idempotent) {
+
+			super.idempotent(idempotent);
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.QueryOptions.QueryOptionsBuilder#routingKeyspace(com.datastax.oss.driver.api.core.CqlIdentifier)
+		 */
+		@Override
+		public InsertOptionsBuilder routingKeyspace(CqlIdentifier routingKeyspace) {
+
+			super.routingKeyspace(routingKeyspace);
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.QueryOptions.QueryOptionsBuilder#routingKeyspace(java.nio.ByteBuffer)
+		 */
+		@Override
+		public InsertOptionsBuilder routingKey(ByteBuffer routingKey) {
+
+			super.routingKey(routingKey);
+			return this;
+		}
+
 		/**
 		 * Use light-weight transactions by applying {@code IF NOT EXISTS}.
 		 *
@@ -375,7 +408,7 @@ public class InsertOptions extends WriteOptions {
 		public InsertOptions build() {
 			return new InsertOptions(this.consistencyLevel, this.executionProfileResolver, this.keyspace, this.pageSize,
 					this.serialConsistencyLevel, this.timeout, this.ttl, this.timestamp, this.tracing, this.ifNotExists,
-					this.insertNulls);
+					this.insertNulls, this.idempotent, this.routingKeyspace, this.routingKey);
 		}
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/UpdateOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/UpdateOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.cassandra.core;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +37,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * @author Mark Paluch
  * @author Lukasz Antoniak
  * @author Tomasz Lelek
+ * @author Sam Lightfoot
  * @since 2.0
  */
 public class UpdateOptions extends WriteOptions {
@@ -49,10 +51,11 @@ public class UpdateOptions extends WriteOptions {
 	private UpdateOptions(@Nullable ConsistencyLevel consistencyLevel, ExecutionProfileResolver executionProfileResolver,
 			@Nullable CqlIdentifier keyspace, @Nullable Integer pageSize, @Nullable ConsistencyLevel serialConsistencyLevel,
 			Duration timeout, Duration ttl, @Nullable Long timestamp, @Nullable Boolean tracing, boolean ifExists,
-			@Nullable Filter ifCondition) {
+			@Nullable Filter ifCondition, @Nullable Boolean idempotent, @Nullable CqlIdentifier routingKeyspace,
+			@Nullable ByteBuffer routingKey) {
 
 		super(consistencyLevel, executionProfileResolver, keyspace, pageSize, serialConsistencyLevel, timeout, ttl,
-				timestamp, tracing);
+				timestamp, tracing, idempotent, routingKeyspace, routingKey);
 
 		this.ifExists = ifExists;
 		this.ifCondition = ifCondition;
@@ -297,6 +300,16 @@ public class UpdateOptions extends WriteOptions {
 		}
 
 		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.WriteOptions.WriteOptionsBuilder#idempotent(boolean)
+		 */
+		@Override
+		public UpdateOptionsBuilder idempotent(boolean idempotent) {
+
+			super.idempotent(idempotent);
+			return this;
+		}
+
+		/* (non-Javadoc)
 		 * @see org.springframework.data.cassandra.core.cql.WriteOptions.WriteOptionsBuilder#ttl(int)
 		 */
 		public UpdateOptionsBuilder ttl(int ttl) {
@@ -322,6 +335,26 @@ public class UpdateOptions extends WriteOptions {
 		public UpdateOptionsBuilder timestamp(Instant timestamp) {
 
 			super.timestamp(timestamp);
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.QueryOptions.QueryOptionsBuilder#routingKeyspace(com.datastax.oss.driver.api.core.CqlIdentifier)
+		 */
+		@Override
+		public UpdateOptionsBuilder routingKeyspace(CqlIdentifier routingKeyspace) {
+
+			super.routingKeyspace(routingKeyspace);
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.QueryOptions.QueryOptionsBuilder#routingKeyspace(java.nio.ByteBuffer)
+		 */
+		@Override
+		public UpdateOptionsBuilder routingKey(ByteBuffer routingKey) {
+
+			super.routingKey(routingKey);
 			return this;
 		}
 
@@ -389,7 +422,7 @@ public class UpdateOptions extends WriteOptions {
 		public UpdateOptions build() {
 			return new UpdateOptions(this.consistencyLevel, this.executionProfileResolver, this.keyspace, this.pageSize,
 					this.serialConsistencyLevel, this.timeout, this.ttl, this.timestamp, this.tracing, this.ifExists,
-					this.ifCondition);
+					this.ifCondition, this.idempotent, this.routingKeyspace, this.routingKey);
 		}
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/QueryOptionsUtil.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/QueryOptionsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import com.datastax.oss.driver.api.querybuilder.update.UpdateStart;
  * @author Mark Paluch
  * @author Lukasz Antoniak
  * @author Tomasz Lelek
+ * @author Sam Lightfoot
  * @since 2.0
  */
 public abstract class QueryOptionsUtil {
@@ -77,6 +78,19 @@ public abstract class QueryOptionsUtil {
 			// statement wrapped in the conditional null check to avoid additional garbage and added GC pressure.
 			statementToUse = statementToUse.setTracing(Boolean.TRUE.equals(queryOptions.getTracing()));
 		}
+
+		if (queryOptions.isIdempotent() != null) {
+			statementToUse = statementToUse.setIdempotent(queryOptions.isIdempotent());
+		}
+
+		if (queryOptions.getRoutingKeyspace() != null) {
+			statementToUse = statementToUse.setRoutingKeyspace(queryOptions.getRoutingKeyspace());
+		}
+
+		if (queryOptions.getRoutingKey() != null) {
+			statementToUse = statement.setRoutingKey(queryOptions.getRoutingKey());
+		}
+
 		if (queryOptions.getKeyspace() != null) {
 			if (statementToUse instanceof BoundStatement) {
 				throw new IllegalArgumentException("Keyspace cannot be set for a BoundStatement");

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/WriteOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/WriteOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.cassandra.core.cql;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +35,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  * @author Mark Paluch
  * @author Lukasz Antoniak
  * @author Tomasz Lelek
+ * @author Sam Lightfoot
  * @see QueryOptions
  */
 public class WriteOptions extends QueryOptions {
@@ -46,10 +48,10 @@ public class WriteOptions extends QueryOptions {
 
 	protected WriteOptions(@Nullable ConsistencyLevel consistencyLevel, ExecutionProfileResolver executionProfileResolver,
 			@Nullable CqlIdentifier keyspace, @Nullable Integer pageSize, @Nullable ConsistencyLevel serialConsistencyLevel,
-			Duration timeout, Duration ttl,
-			@Nullable Long timestamp, @Nullable Boolean tracing) {
+			Duration timeout, Duration ttl, @Nullable Long timestamp, @Nullable Boolean tracing, @Nullable Boolean idempotent,
+			@Nullable CqlIdentifier routingKeyspace, @Nullable ByteBuffer routingKey) {
 
-		super(consistencyLevel, executionProfileResolver, keyspace, pageSize, serialConsistencyLevel, timeout, tracing);
+		super(consistencyLevel, executionProfileResolver, keyspace, pageSize, serialConsistencyLevel, timeout, tracing, idempotent, routingKeyspace, routingKey);
 
 		this.ttl = ttl;
 		this.timestamp = timestamp;
@@ -285,6 +287,36 @@ public class WriteOptions extends QueryOptions {
 			return this;
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.QueryOptions.QueryOptionsBuilder#idempotent(boolean)
+		 */
+		@Override
+		public WriteOptionsBuilder idempotent(boolean idempotent) {
+
+			super.idempotent(idempotent);
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.QueryOptions.QueryOptionsBuilder#routingKeyspace(com.datastax.oss.driver.api.core.CqlIdentifier)
+		 */
+		@Override
+		public WriteOptionsBuilder routingKeyspace(CqlIdentifier routingKeyspace) {
+
+			super.routingKeyspace(routingKeyspace);
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.cassandra.core.cql.QueryOptions.QueryOptionsBuilder#routingKeyspace(java.nio.ByteBuffer)
+		 */
+		@Override
+		public WriteOptionsBuilder routingKey(ByteBuffer routingKey) {
+
+			super.routingKey(routingKey);
+			return this;
+		}
+
 		/**
 		 * Sets the time to live in seconds for write operations.
 		 *
@@ -357,7 +389,8 @@ public class WriteOptions extends QueryOptions {
 		 */
 		public WriteOptions build() {
 			return new WriteOptions(this.consistencyLevel, this.executionProfileResolver, this.keyspace, this.pageSize,
-					this.serialConsistencyLevel, this.timeout, this.ttl, this.timestamp, this.tracing);
+					this.serialConsistencyLevel, this.timeout, this.ttl, this.timestamp, this.tracing, this.idempotent,
+					this.routingKeyspace, this.routingKey);
 		}
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/QueryOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/QueryOptionsUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.data.cassandra.core.cql;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
  *
  * @author Mark Paluch
  * @author Tomasz Lelek
+ * @author Sam Lightfoot
  */
 class QueryOptionsUnitTests {
 
@@ -41,6 +43,9 @@ class QueryOptionsUnitTests {
 				.pageSize(10) //
 				.tracing(true) //
 				.keyspace(CqlIdentifier.fromCql("ks1")) //
+				.idempotent(true)
+				.routingKeyspace(CqlIdentifier.fromCql("rksl"))
+				.routingKey(ByteBuffer.allocate(1))
 				.build();
 
 		assertThat(queryOptions.getClass()).isEqualTo(QueryOptions.class);
@@ -49,6 +54,9 @@ class QueryOptionsUnitTests {
 		assertThat(queryOptions.getPageSize()).isEqualTo(10);
 		assertThat(queryOptions.getTracing()).isTrue();
 		assertThat(queryOptions.getKeyspace()).isEqualTo(CqlIdentifier.fromCql("ks1"));
+		assertThat(queryOptions.isIdempotent()).isEqualTo(true);
+		assertThat(queryOptions.getRoutingKeyspace()).isEqualTo(CqlIdentifier.fromCql("rksl"));
+		assertThat(queryOptions.getRoutingKey()).isNotNull();
 	}
 
 	@Test // DATACASS-56
@@ -60,6 +68,9 @@ class QueryOptionsUnitTests {
 				.pageSize(10) //
 				.tracing(true) //
 				.keyspace(CqlIdentifier.fromCql("ks1")) //
+				.idempotent(true)
+				.routingKeyspace(CqlIdentifier.fromCql("rksl"))
+				.routingKey(ByteBuffer.allocate(1))
 				.build();
 
 		QueryOptions mutated = queryOptions.mutate().timeout(Duration.ofSeconds(5)).build();
@@ -71,5 +82,8 @@ class QueryOptionsUnitTests {
 		assertThat(mutated.getPageSize()).isEqualTo(10);
 		assertThat(mutated.getTracing()).isTrue();
 		assertThat(mutated.getKeyspace()).isEqualTo(CqlIdentifier.fromCql("ks1"));
+		assertThat(mutated.isIdempotent()).isEqualTo(true);
+		assertThat(mutated.getRoutingKeyspace()).isEqualTo(CqlIdentifier.fromCql("rksl"));
+		assertThat(mutated.getRoutingKey()).isNotNull();
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/QueryOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/QueryOptionsUnitTests.java
@@ -56,7 +56,7 @@ class QueryOptionsUnitTests {
 		assertThat(queryOptions.getKeyspace()).isEqualTo(CqlIdentifier.fromCql("ks1"));
 		assertThat(queryOptions.isIdempotent()).isEqualTo(true);
 		assertThat(queryOptions.getRoutingKeyspace()).isEqualTo(CqlIdentifier.fromCql("rksl"));
-		assertThat(queryOptions.getRoutingKey()).isNotNull();
+		assertThat(queryOptions.getRoutingKey()).isEqualTo(ByteBuffer.allocate(1));
 	}
 
 	@Test // DATACASS-56
@@ -84,6 +84,6 @@ class QueryOptionsUnitTests {
 		assertThat(mutated.getKeyspace()).isEqualTo(CqlIdentifier.fromCql("ks1"));
 		assertThat(mutated.isIdempotent()).isEqualTo(true);
 		assertThat(mutated.getRoutingKeyspace()).isEqualTo(CqlIdentifier.fromCql("rksl"));
-		assertThat(mutated.getRoutingKey()).isNotNull();
+		assertThat(mutated.getRoutingKey()).isEqualTo(ByteBuffer.allocate(1));
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/QueryOptionsUtilUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/QueryOptionsUtilUnitTests.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2016-2021 the original author or authors.
+ *  Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.data.cassandra.core.cql;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
@@ -38,6 +39,7 @@ import com.datastax.oss.driver.api.core.cql.SimpleStatement;
  * @author John Blum
  * @author Mark Paluch
  * @author Tomasz Lelek
+ * @author Sam Lightfoot
  */
 @ExtendWith(MockitoExtension.class)
 class QueryOptionsUtilUnitTests {
@@ -82,11 +84,17 @@ class QueryOptionsUtilUnitTests {
 		when(simpleStatement.setPageSize(anyInt())).thenReturn(simpleStatement);
 		when(simpleStatement.setTimeout(any())).thenReturn(simpleStatement);
 		when(simpleStatement.setTracing(anyBoolean())).thenReturn(simpleStatement);
+		when(simpleStatement.setIdempotent(anyBoolean())).thenReturn(simpleStatement);
+		when(simpleStatement.setRoutingKeyspace(any(CqlIdentifier.class))).thenReturn(simpleStatement);
+		when(simpleStatement.setRoutingKey(any(ByteBuffer.class))).thenReturn(simpleStatement);
 
 		QueryOptions queryOptions = QueryOptions.builder() //
 				.pageSize(10) //
 				.readTimeout(1, TimeUnit.MINUTES) //
 				.withTracing() //
+				.idempotent(true)
+				.routingKeyspace(CqlIdentifier.fromCql("routing_ks"))
+				.routingKey(ByteBuffer.allocate(1))
 				.build();
 
 		QueryOptionsUtil.addQueryOptions(simpleStatement, queryOptions);
@@ -94,6 +102,9 @@ class QueryOptionsUtilUnitTests {
 		verify(simpleStatement).setTimeout(Duration.ofMinutes(1));
 		verify(simpleStatement).setPageSize(10);
 		verify(simpleStatement).setTracing(true);
+		verify(simpleStatement).setIdempotent(true);
+		verify(simpleStatement).setRoutingKeyspace(CqlIdentifier.fromCql("routing_ks"));
+		verify(simpleStatement).setRoutingKey(ByteBuffer.allocate(1));
 	}
 
 	@Test // DATACASS-767

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/WriteOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/WriteOptionsUnitTests.java
@@ -62,7 +62,7 @@ class WriteOptionsUnitTests {
 		assertThat(writeOptions.isIdempotent()).isEqualTo(true);
 		assertThat(writeOptions.getRoutingKeyspace()).isEqualTo(
 				CqlIdentifier.fromCql("routing_keyspace"));
-		assertThat(writeOptions.getRoutingKey()).isNotNull();
+		assertThat(writeOptions.getRoutingKey()).isEqualTo(ByteBuffer.allocate(1));
 	}
 
 	@Test // DATACASS-202
@@ -104,6 +104,6 @@ class WriteOptionsUnitTests {
 		assertThat(writeOptions.isIdempotent()).isEqualTo(true);
 		assertThat(writeOptions.getRoutingKeyspace()).isEqualTo(
 				CqlIdentifier.fromCql("routing_keyspace"));
-		assertThat(writeOptions.getRoutingKey()).isNotNull();
+		assertThat(writeOptions.getRoutingKey()).isEqualTo(ByteBuffer.allocate(1));
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/WriteOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/WriteOptionsUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.data.cassandra.core.cql;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -31,6 +32,7 @@ import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
  * Unit tests for {@link WriteOptions}.
  *
  * @author Mark Paluch
+ * @author Sam Lightfoot
  */
 class WriteOptionsUnitTests {
 
@@ -44,7 +46,11 @@ class WriteOptionsUnitTests {
 				.readTimeout(1) //
 				.pageSize(10) //
 				.withTracing() //
-				.keyspace(CqlIdentifier.fromCql("my_keyspace")).build();
+				.keyspace(CqlIdentifier.fromCql("my_keyspace"))
+				.idempotent(true)
+				.routingKeyspace(CqlIdentifier.fromCql("routing_keyspace"))
+				.routingKey(ByteBuffer.allocate(1))
+				.build();
 
 		assertThat(writeOptions.getTtl()).isEqualTo(Duration.ofSeconds(123));
 		assertThat(writeOptions.getTimestamp()).isEqualTo(1519000753);
@@ -53,6 +59,10 @@ class WriteOptionsUnitTests {
 		assertThat(writeOptions.getPageSize()).isEqualTo(10);
 		assertThat(writeOptions.getTracing()).isTrue();
 		assertThat(writeOptions.getKeyspace()).isEqualTo(CqlIdentifier.fromCql("my_keyspace"));
+		assertThat(writeOptions.isIdempotent()).isEqualTo(true);
+		assertThat(writeOptions.getRoutingKeyspace()).isEqualTo(
+				CqlIdentifier.fromCql("routing_keyspace"));
+		assertThat(writeOptions.getRoutingKey()).isNotNull();
 	}
 
 	@Test // DATACASS-202
@@ -76,6 +86,9 @@ class WriteOptionsUnitTests {
 				.readTimeout(1) //
 				.pageSize(10) //
 				.withTracing() //
+				.idempotent(true)
+				.routingKeyspace(CqlIdentifier.fromCql("routing_keyspace"))
+				.routingKey(ByteBuffer.allocate(1))
 				.build();
 
 		WriteOptions mutated = writeOptions.mutate().timeout(Duration.ofMillis(100)).build();
@@ -88,5 +101,9 @@ class WriteOptionsUnitTests {
 		assertThat(mutated.getTimeout()).isEqualTo(Duration.ofMillis(100));
 		assertThat(mutated.getPageSize()).isEqualTo(10);
 		assertThat(mutated.getTracing()).isTrue();
+		assertThat(writeOptions.isIdempotent()).isEqualTo(true);
+		assertThat(writeOptions.getRoutingKeyspace()).isEqualTo(
+				CqlIdentifier.fromCql("routing_keyspace"));
+		assertThat(writeOptions.getRoutingKey()).isNotNull();
 	}
 }


### PR DESCRIPTION
QueryOptions and sub-classes extended with
- idempotent(boolean)
- routingKeyspace(CqlIdentifier)
- routingKey(ByteBuffer)

There are still more properties that can be added, but this is a stepping stone towards supporting them all.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
