### PR TITLE
Allow WriterOptionsBuilder to set ttl to 0.

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/WriteOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/WriteOptions.java
@@ -145,6 +145,7 @@ public class WriteOptions extends QueryOptions {
 	 * @author Mark Paluch
 	 * @author Lukasz Antoniak
 	 * @author Thomas Strau&szlig;
+	 * @author Tudor Marc
 	 * @since 1.5
 	 */
 	public static class WriteOptionsBuilder extends QueryOptionsBuilder {
@@ -288,7 +289,7 @@ public class WriteOptions extends QueryOptions {
 		public WriteOptionsBuilder ttl(Duration ttl) {
 
 			Assert.notNull(ttl, "TTL must not be null");
-			Assert.isTrue(!ttl.isNegative() && !ttl.isZero(), "TTL must be greater than equal to zero");
+			Assert.isTrue(!ttl.isNegative(), "TTL must be greater than equal to zero");
 
 			this.ttl = ttl;
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/WriteOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/WriteOptionsUnitTests.java
@@ -35,6 +35,7 @@ import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
  * @author Mark Paluch
  * @author Sam Lightfoot
  * @author Thomas Strau&szlig;
+ * @author Tudor Marc
  */
 class WriteOptionsUnitTests {
 
@@ -108,15 +109,17 @@ class WriteOptionsUnitTests {
 	}
 
 	@Test // GH-1248
-	void buildWriteOptionsWithTtlDurationZero() {
-		assertThatIllegalArgumentException().isThrownBy(() -> WriteOptions.builder().ttl(0));
-		assertThatIllegalArgumentException().isThrownBy(() -> WriteOptions.builder().ttl(Duration.ZERO));
-	}
-
-	@Test // GH-1248
 	void buildWriteOptionsWithTtlNegativeDuration() {
 		assertThatIllegalArgumentException().isThrownBy(() -> WriteOptions.builder().ttl(-1));
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> WriteOptions.builder().ttl(Duration.of(-1, ChronoUnit.MICROS)));
+	}
+
+	@Test // GH-1262
+	void buildZeroDurationTtlWriterOptions() {
+
+		WriteOptions writeOptions = WriteOptions.builder().ttl(0).build();
+
+		assertThat(writeOptions.getTtl()).isEqualTo(Duration.ZERO);
 	}
 }


### PR DESCRIPTION
Allow WriterOptionsBuilder to set ttl to 0.

Value 0 tells the Cassandra driver to disable the ttl.

Closes #1262

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
