### PR TITLE
Fix example code in documentation

### DIFF
--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/example/CassandraConfig.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/example/CassandraConfig.java
@@ -58,17 +58,16 @@ public class CassandraConfig {
 	}
 
 	@Bean
-	public CassandraMappingContext mappingContext(CqlSession cqlSession) {
-
-		CassandraMappingContext mappingContext = new CassandraMappingContext();
-		mappingContext.setUserTypeResolver(new SimpleUserTypeResolver(cqlSession));
-
-		return mappingContext;
+	public CassandraMappingContext mappingContext() {
+		return new CassandraMappingContext();
 	}
 
 	@Bean
-	public CassandraConverter converter(CassandraMappingContext mappingContext) {
-		return new MappingCassandraConverter(mappingContext);
+	public CassandraConverter converter(CqlSession cqlSession, CassandraMappingContext mappingContext) {
+		MappingCassandraConverter cassandraConverter = new MappingCassandraConverter(mappingContext);
+		cassandraConverter.setUserTypeResolver(new SimpleUserTypeResolver(cqlSession));
+		
+		return cassandraConverter;
 	}
 
 	@Bean


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).


hi,
From existing example code
- https://docs.spring.io/spring-data/cassandra/docs/current/reference/html/#cassandra.cassandra-java-config  
    - Example 56

<img width="676" alt="스크린샷 2022-09-06 오후 9 05 50" src="https://user-images.githubusercontent.com/26921986/188630827-c06a42e4-69fe-41e6-b4dd-b990d660ca51.png">

found `mappingContext.setUserTypeResolver(..)`which is `Deprecated`
so i suggest to change like to create bean like this.