### PR TITLE
Add exception translation for `DriverTimeoutException`

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/CassandraDriverTimeOutException.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/CassandraDriverTimeOutException.java
@@ -1,0 +1,15 @@
+package org.springframework.data.cassandra;
+
+import org.springframework.dao.QueryTimeoutException;
+
+/**
+ * This exception is thrown when driver have timed out during any interation with cassandra coordinator node
+ *
+ * @author Mikhail Polivakha
+ */
+public class CassandraDriverTimeOutException extends QueryTimeoutException {
+
+    public CassandraDriverTimeOutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CassandraExceptionTranslator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CassandraExceptionTranslator.java
@@ -23,10 +23,12 @@ import java.util.Set;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.QueryTimeoutException;
 import org.springframework.dao.TransientDataAccessResourceException;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 import org.springframework.data.cassandra.CassandraAuthenticationException;
 import org.springframework.data.cassandra.CassandraConnectionFailureException;
+import org.springframework.data.cassandra.CassandraDriverTimeOutException;
 import org.springframework.data.cassandra.CassandraInsufficientReplicasAvailableException;
 import org.springframework.data.cassandra.CassandraInvalidConfigurationInQueryException;
 import org.springframework.data.cassandra.CassandraInvalidQueryException;
@@ -43,6 +45,7 @@ import org.springframework.util.StringUtils;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.DriverTimeoutException;
 import com.datastax.oss.driver.api.core.auth.AuthenticationException;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException;
@@ -70,6 +73,7 @@ import com.datastax.oss.driver.api.core.servererrors.WriteType;
  * @author Alex Shvid
  * @author Matthew T. Adams
  * @author Mark Paluch
+ * @author Mikhail Polivakha
  */
 @SuppressWarnings("unchecked")
 public class CassandraExceptionTranslator implements CqlExceptionTranslator {
@@ -103,6 +107,10 @@ public class CassandraExceptionTranslator implements CqlExceptionTranslator {
 		if (exception instanceof AuthenticationException) {
 			return new CassandraAuthenticationException(((AuthenticationException) exception).getEndPoint(), message,
 					exception);
+		}
+
+		if (exception instanceof DriverTimeoutException driverTimeoutException) {
+			return new CassandraDriverTimeOutException(driverTimeoutException.getMessage(), driverTimeoutException);
 		}
 
 		if (exception instanceof ReadTimeoutException) {
@@ -178,7 +186,6 @@ public class CassandraExceptionTranslator implements CqlExceptionTranslator {
 			// unknown or unhandled exception
 			return new CassandraUncategorizedException(message, exception);
 		}
-
 		return null;
 	}
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CassandraExceptionTranslatorUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CassandraExceptionTranslatorUnitTests.java
@@ -28,6 +28,7 @@ import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.TransientDataAccessResourceException;
 import org.springframework.data.cassandra.CassandraAuthenticationException;
 import org.springframework.data.cassandra.CassandraConnectionFailureException;
+import org.springframework.data.cassandra.CassandraDriverTimeOutException;
 import org.springframework.data.cassandra.CassandraInsufficientReplicasAvailableException;
 import org.springframework.data.cassandra.CassandraInvalidConfigurationInQueryException;
 import org.springframework.data.cassandra.CassandraInvalidQueryException;
@@ -40,6 +41,7 @@ import org.springframework.data.cassandra.CassandraUncategorizedException;
 import org.springframework.data.cassandra.CassandraWriteTimeoutException;
 
 import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
+import com.datastax.oss.driver.api.core.DriverTimeoutException;
 import com.datastax.oss.driver.api.core.NoNodeAvailableException;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.UnsupportedProtocolVersionException;
@@ -72,6 +74,7 @@ import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
  *
  * @author Matthew T. Adams
  * @author Mark Paluch
+ * @author Mikhail Polivakha
  */
 class CassandraExceptionTranslatorUnitTests {
 
@@ -115,6 +118,14 @@ class CassandraExceptionTranslatorUnitTests {
 
 		assertThat(result).isInstanceOf(CassandraInvalidConfigurationInQueryException.class)
 				.hasMessageStartingWith("message").hasCauseInstanceOf(InvalidConfigurationInQueryException.class);
+	}
+
+	@Test
+	void shouldRecognizeDriverTimeoutException() {
+		DataAccessException dataAccessException = sut.translateExceptionIfPossible(new DriverTimeoutException("message"));
+
+		assertThat(dataAccessException).isInstanceOf(CassandraDriverTimeOutException.class).hasMessageStartingWith("message")
+				.hasCauseInstanceOf(DriverTimeoutException.class);
 	}
 
 	@Test // DATACASS-402


### PR DESCRIPTION
Cassandra spring-data module does not recogize the `DriverTimeoutException`, which essentially means that driver has timed out during interaction with cluster in general. 
 
Maybe we should consider to not throw `QueryTimeoutException`, but create a separate one, specifically for this case.

@mp911de @schauder please, take a look. 