### PR TITLE
Implementing keyspace qualification for particular entities 

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/CassandraConnectionFailureException.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/CassandraConnectionFailureException.java
@@ -17,9 +17,14 @@ package org.springframework.data.cassandra;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.util.CollectionUtils;
 
 import com.datastax.oss.driver.api.core.metadata.Node;
 
@@ -32,14 +37,26 @@ public class CassandraConnectionFailureException extends DataAccessResourceFailu
 
 	private static final long serialVersionUID = 6299912054261646552L;
 
-	private final Map<Node, Throwable> messagesByHost = new HashMap<>();
+	private final Map<Node, List<Throwable>> messagesByHost = new HashMap<>();
 
 	public CassandraConnectionFailureException(Map<Node, Throwable> map, String msg, Throwable cause) {
+		super(msg, cause);
+		map.forEach((node, throwable) -> messagesByHost.put(node, Collections.singletonList(throwable)));
+	}
+
+	public CassandraConnectionFailureException(String msg, Map<Node, List<Throwable>> map, Throwable cause) {
 		super(msg, cause);
 		this.messagesByHost.putAll(map);
 	}
 
+	@Deprecated(forRemoval = true)
 	public Map<Node, Throwable> getMessagesByHost() {
+		HashMap<Node, Throwable> singleMessageByHost = new HashMap<>();
+		this.messagesByHost.forEach((node, throwables) -> singleMessageByHost.put(node, CollectionUtils.firstElement(throwables)));
+		return singleMessageByHost;
+	}
+
+	public Map<Node, List<Throwable>> getAllMessagesByHost() {
 		return Collections.unmodifiableMap(messagesByHost);
 	}
 }

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/CassandraTemplate.java
@@ -586,7 +586,7 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 	boolean doExists(Query query, Class<?> entityClass, CqlIdentifier tableName) {
 
 		StatementBuilder<Select> select = getStatementFactory().select(query.limit(1),
-				getRequiredPersistentEntity(entityClass), tableName);
+				getRequiredPersistentEntity(entityClass), tableName, getEntityOperations().getCustomKeyspaceName(entityClass));
 
 		return doQueryForResultSet(select.build()).one() != null;
 	}
@@ -915,12 +915,10 @@ public class CassandraTemplate implements CassandraOperations, ApplicationEventP
 			return statement.getPageSize();
 		}
 
-		if (getCqlOperations() instanceof CassandraAccessor) {
+		if (getCqlOperations() instanceof CassandraAccessor cassandraAccessor) {
 
-			CassandraAccessor accessor = (CassandraAccessor) getCqlOperations();
-
-			if (accessor.getFetchSize() != -1) {
-				return accessor.getFetchSize();
+			if (cassandraAccessor.getPageSize() != -1) {
+				return cassandraAccessor.getPageSize();
 			}
 		}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/EntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/EntityOperations.java
@@ -114,6 +114,20 @@ class EntityOperations {
 	}
 
 	/**
+	 * Returns custom keyspace defined (if any) where the table for entity {@code entityClass} should be persisted.
+	 * If the keyspace is not overridden in {@link org.springframework.data.cassandra.core.mapping.Table} annotation,
+	 * then {@code null} is returned, signaling that default keyspace of {@link com.datastax.oss.driver.api.core.CqlSession}
+	 * should be used
+	 *
+	 * @param entityClass entity class, must not be {@literal null}.
+	 * @return custom keyspace defined (if any)
+	 */
+	@Nullable
+	CqlIdentifier getCustomKeyspaceName(Class<?> entityClass) {
+		return getRequiredPersistentEntity(entityClass).getCustomKeyspace();
+	}
+
+	/**
 	 * Introspect the given {@link Class result type} in the context of the {@link Class entity type} whether the returned
 	 * type is a projection and what property paths are participating in the projection.
 	 *

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableInsertOperationSupport.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/ExecutableInsertOperationSupport.java
@@ -55,7 +55,7 @@ class ExecutableInsertOperationSupport implements ExecutableInsertOperation {
 		@Nullable private final CqlIdentifier tableName;
 
 		public ExecutableInsertSupport(CassandraTemplate template, Class<T> domainType, InsertOptions insertOptions,
-				CqlIdentifier tableName) {
+				@Nullable CqlIdentifier tableName) {
 			this.template = template;
 			this.domainType = domainType;
 			this.insertOptions = insertOptions;

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CassandraExceptionTranslator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CassandraExceptionTranslator.java
@@ -71,7 +71,6 @@ import com.datastax.oss.driver.api.core.servererrors.WriteType;
  * @author Matthew T. Adams
  * @author Mark Paluch
  */
-@SuppressWarnings("unchecked")
 public class CassandraExceptionTranslator implements CqlExceptionTranslator {
 
 	private static final Set<String> CONNECTION_FAILURE_TYPES = new HashSet<>(
@@ -101,37 +100,33 @@ public class CassandraExceptionTranslator implements CqlExceptionTranslator {
 		// superclass would match before the subclass!
 
 		if (exception instanceof AuthenticationException) {
-			return new CassandraAuthenticationException(((AuthenticationException) exception).getEndPoint(), message,
-					exception);
+			return new CassandraAuthenticationException(((AuthenticationException) exception).getEndPoint(), message, exception);
 		}
 
 		if (exception instanceof ReadTimeoutException) {
 			return new CassandraReadTimeoutException(((ReadTimeoutException) exception).wasDataPresent(), message, exception);
 		}
 
-		if (exception instanceof WriteTimeoutException) {
+		if (exception instanceof WriteTimeoutException writeTimeoutException) {
 
-			WriteType writeType = ((WriteTimeoutException) exception).getWriteType();
-			return new CassandraWriteTimeoutException(writeType == null ? null : writeType.name(), message, exception);
+			WriteType writeType = writeTimeoutException.getWriteType();
+			return new CassandraWriteTimeoutException(writeType.name(), message, exception);
 		}
 
 		if (exception instanceof TruncateException) {
 			return new CassandraTruncateException(message, exception);
 		}
 
-		if (exception instanceof UnavailableException) {
-
-			UnavailableException ux = (UnavailableException) exception;
-			return new CassandraInsufficientReplicasAvailableException(ux.getRequired(), ux.getAlive(), message, exception);
+		if (exception instanceof UnavailableException unavailableException) {
+			return new CassandraInsufficientReplicasAvailableException(unavailableException.getRequired(), unavailableException.getAlive(), message, exception);
 		}
 
 		if (exception instanceof OverloadedException || exception instanceof BootstrappingException) {
 			return new TransientDataAccessResourceException(message, exception);
 		}
-		if (exception instanceof AlreadyExistsException) {
 
-			AlreadyExistsException aex = (AlreadyExistsException) exception;
-			return new CassandraSchemaElementExistsException(aex.getMessage(), aex);
+		if (exception instanceof AlreadyExistsException alreadyExistsException) {
+			return new CassandraSchemaElementExistsException(alreadyExistsException.getMessage(), alreadyExistsException);
 		}
 
 		if (exception instanceof InvalidConfigurationInQueryException) {
@@ -150,9 +145,8 @@ public class CassandraExceptionTranslator implements CqlExceptionTranslator {
 			return new CassandraUnauthorizedException(message, exception);
 		}
 
-		if (exception instanceof AllNodesFailedException) {
-			return new CassandraConnectionFailureException(((AllNodesFailedException) exception).getErrors(), message,
-					exception);
+		if (exception instanceof AllNodesFailedException allNodesFailedException) {
+			return new CassandraConnectionFailureException(message, allNodesFailedException.getAllErrors(), exception);
 		}
 
 		String exceptionType = ClassUtils.getShortName(ClassUtils.getUserClass(exception.getClass()));
@@ -161,8 +155,7 @@ public class CassandraExceptionTranslator implements CqlExceptionTranslator {
 
 			Map<Node, Throwable> errorMap = Collections.emptyMap();
 
-			if (exception instanceof CoordinatorException) {
-				CoordinatorException cx = (CoordinatorException) exception;
+			if (exception instanceof CoordinatorException cx) {
 				errorMap = Collections.singletonMap(cx.getCoordinator(), exception);
 			}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/legacy/AsyncCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/legacy/AsyncCassandraTemplate.java
@@ -881,14 +881,13 @@ public class AsyncCassandraTemplate
 			return statement.getPageSize();
 		}
 
-		if (getAsyncCqlOperations() instanceof CassandraAccessor) {
+		if (getAsyncCqlOperations() instanceof CassandraAccessor cassandraAccessor) {
 
-			CassandraAccessor accessor = (CassandraAccessor) getAsyncCqlOperations();
-
-			if (accessor.getFetchSize() != -1) {
-				return accessor.getFetchSize();
+			if (cassandraAccessor.getPageSize() != -1) {
+				return cassandraAccessor.getPageSize();
 			}
 		}
+
 		class GetConfiguredPageSize implements AsyncSessionCallback<Integer>, CqlProvider {
 			@Override
 			public ListenableFuture<Integer> doInSession(CqlSession session) {

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/legacy/AsyncCassandraTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/legacy/AsyncCassandraTemplate.java
@@ -904,7 +904,6 @@ public class AsyncCassandraTemplate
 		return getAsyncCqlOperations().execute(new GetConfiguredPageSize()).completable().join();
 	}
 
-	@SuppressWarnings("unchecked")
 	private <T> Function<Row, T> getMapper(Class<?> entityType, Class<T> targetType, CqlIdentifier tableName) {
 
 		EntityProjection<T, ?> projection = entityOperations.introspectProjection(targetType, entityType);

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContext.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraMappingContext.java
@@ -355,6 +355,8 @@ public class CassandraMappingContext
 	@Override
 	protected <T> BasicCassandraPersistentEntity<T> createPersistentEntity(TypeInformation<T> typeInformation) {
 
+
+
 		BasicCassandraPersistentEntity<T> entity = isUserDefinedType(typeInformation)
 				? new CassandraUserTypePersistentEntity<>(typeInformation, getVerifier())
 				: isTuple(typeInformation) ? new BasicCassandraPersistentTupleEntity<>(typeInformation)
@@ -363,6 +365,7 @@ public class CassandraMappingContext
 		if (this.namingStrategy != null) {
 			entity.setNamingStrategy(this.namingStrategy);
 		}
+
 		Optional.ofNullable(this.applicationContext).ifPresent(entity::setApplicationContext);
 
 		return entity;

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CassandraPersistentEntity.java
@@ -16,6 +16,7 @@
 package org.springframework.data.cassandra.core.mapping;
 
 import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
@@ -49,6 +50,12 @@ public interface CassandraPersistentEntity<T> extends PersistentEntity<T, Cassan
 	 * Returns the table name to which the entity shall be persisted.
 	 */
 	CqlIdentifier getTableName();
+
+	/**
+	 * Returns the custom keyspace (if any) name that is defined for this table
+	 */
+	@Nullable
+	CqlIdentifier getCustomKeyspace();
 
 	/**
 	 * Sets the CQL table name.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CompositeCassandraPersistentEntityMetadataVerifier.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/CompositeCassandraPersistentEntityMetadataVerifier.java
@@ -31,7 +31,7 @@ import org.springframework.util.Assert;
  */
 public class CompositeCassandraPersistentEntityMetadataVerifier implements CassandraPersistentEntityMetadataVerifier {
 
-	private Collection<CassandraPersistentEntityMetadataVerifier> verifiers;
+	private final Collection<CassandraPersistentEntityMetadataVerifier> verifiers;
 
 	/**
 	 * Create a new {@link CompositeCassandraPersistentEntityMetadataVerifier} using default entity and primary key

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/EmbeddedEntityOperations.java
@@ -114,9 +114,8 @@ public class EmbeddedEntityOperations {
 		}
 
 		@Override
-		@Deprecated
-		public void setTableName(org.springframework.data.cassandra.core.cql.CqlIdentifier tableName) {
-			delegate.setTableName(tableName);
+		public CqlIdentifier getCustomKeyspace() {
+			return this.delegate.getCustomKeyspace();
 		}
 
 		@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/Table.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/Table.java
@@ -51,4 +51,9 @@ public @interface Table {
 	 */
 	@Deprecated
 	boolean forceQuote() default false;
+
+	/**
+	 * Keyspace where this table is located
+	 */
+	String keyspace() default "";
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/AsyncCqlTemplateUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/AsyncCqlTemplateUnitTests.java
@@ -797,7 +797,7 @@ class AsyncCqlTemplateUnitTests {
 		template.setSession(this.session);
 
 		if (fetchSize != null) {
-			template.setFetchSize(fetchSize);
+			template.setPageSize(fetchSize);
 		}
 
 		if (consistencyLevel != null) {

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/CqlTemplateUnitTests.java
@@ -770,7 +770,7 @@ class CqlTemplateUnitTests {
 		template.setSession(this.session);
 
 		if (fetchSize != null) {
-			template.setFetchSize(fetchSize);
+			template.setPageSize(fetchSize);
 		}
 
 		if (consistencyLevel != null) {

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/legacy/AsyncCqlTemplateUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/legacy/AsyncCqlTemplateUnitTests.java
@@ -794,7 +794,7 @@ class AsyncCqlTemplateUnitTests {
 		template.setSession(this.session);
 
 		if (fetchSize != null) {
-			template.setFetchSize(fetchSize);
+			template.setPageSize(fetchSize);
 		}
 
 		if (consistencyLevel != null) {

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentEntityUnitTests.java
@@ -89,14 +89,13 @@ class BasicCassandraPersistentEntityUnitTests {
 	@Test
 	void setForceQuoteCallsSetTableName() {
 
-		BasicCassandraPersistentEntity<Message> entitySpy = spy(
-				new BasicCassandraPersistentEntity<>(TypeInformation.of(Message.class)));
+		BasicCassandraPersistentEntity<Message> entitySpy = spy(new BasicCassandraPersistentEntity<>(TypeInformation.of(Message.class)));
 
 		DirectFieldAccessor directFieldAccessor = new DirectFieldAccessor(entitySpy);
 
 		entitySpy.setTableName(CqlIdentifier.fromCql("Messages"));
 
-		assertThat(directFieldAccessor.getPropertyValue("forceQuote")).isNull();
+		assertThat((Boolean) directFieldAccessor.getPropertyValue("forceQuote")).isFalse();
 
 		entitySpy.setForceQuote(true);
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/EntityWithKeyspace.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/domain/EntityWithKeyspace.java
@@ -1,0 +1,11 @@
+package org.springframework.data.cassandra.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.core.mapping.Table;
+
+@Table(value = "entity_with_keyspace", keyspace = "custom")
+public record EntityWithKeyspace(
+  @Id String id,
+  String name,
+  String type
+){}


### PR DESCRIPTION
Hello @mp911de @schauder !
I ahve implemented #921 feature. I have assumed the following behavoir: 

1. There is a possibility to specify a keyspace for an entity in the `@Table` annotation. If it is specified, then for each query we just pass to `QueryBuilder` keyspace specified by user. The goal again is not to mutate _CqlSession_ and avoid creating _CqlSession_ for each keyspace. 
2. On the other hand, if keyspace is omitted or empty, we assume the entity's corresponding table is in the **default for current _CqlSession_** namespace.

I hope it makes sence to you as well. Any suggestions/improvements will be highly appretiated. Thanks! 