### PR TITLE
Added schema validation on context startup

### DIFF
--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -233,6 +233,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-test</artifactId>
+			<version>3.1.6</version>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/CassandraKeyspaceDoesNotExistsException.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/CassandraKeyspaceDoesNotExistsException.java
@@ -1,0 +1,15 @@
+package org.springframework.data.cassandra;
+
+import org.springframework.dao.NonTransientDataAccessException;
+
+/**
+ * The exception to be thrown when keyspace that expected to be present is missing in the cluster
+ *
+ * @author Mikhail Polivakha
+ */
+public class CassandraKeyspaceDoesNotExistsException extends NonTransientDataAccessException {
+
+    public CassandraKeyspaceDoesNotExistsException(String keyspace) {
+        super("Keyspace %s does not exists in the cluster".formatted(keyspace));
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/CassandraNoActiveKeyspaceSetForCqlSessionException.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/CassandraNoActiveKeyspaceSetForCqlSessionException.java
@@ -1,0 +1,18 @@
+package org.springframework.data.cassandra;
+
+import org.springframework.dao.NonTransientDataAccessException;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+
+/**
+ * Exception that is thrown in case {@link CqlSession} has no active keyspace set. This should not
+ * typically happen. This exception means some misconfiguration within framework.
+ *
+ * @author Mikhail Polivakha
+ */
+public class CassandraNoActiveKeyspaceSetForCqlSessionException extends NonTransientDataAccessException {
+
+    public CassandraNoActiveKeyspaceSetForCqlSessionException() {
+        super("There is no active keyspace set for CqlSession");
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/CassandraSchemaValidationException.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/CassandraSchemaValidationException.java
@@ -1,0 +1,16 @@
+package org.springframework.data.cassandra;
+
+import org.springframework.dao.NonTransientDataAccessException;
+
+/**
+ * The exception that is thrown in case cassandra schema in the particular keyspace does not match
+ * the configuration of the entities inside application.
+ *
+ * @author Mikhail Polivakha
+ */
+public class CassandraSchemaValidationException extends NonTransientDataAccessException {
+
+    public CassandraSchemaValidationException(String message) {
+        super(message);
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraSchemaValidationProfile.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraSchemaValidationProfile.java
@@ -1,0 +1,47 @@
+package org.springframework.data.cassandra.config;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Class that encapsulates all the problems encountered during cassandra schema validation
+ *
+ * @author Mikhail Polivakha
+ */
+public class CassandraSchemaValidationProfile {
+
+    private final List<ValidationError> validationErrors;
+
+    public CassandraSchemaValidationProfile(List<ValidationError> validationErrors) {
+        this.validationErrors = validationErrors;
+    }
+
+    public static CassandraSchemaValidationProfile empty() {
+        return new CassandraSchemaValidationProfile(new LinkedList<>());
+    }
+
+    public void addValidationErrors(List<String> message) {
+        if (!CollectionUtils.isEmpty(message)) {
+            this.validationErrors.addAll(message.stream().map(ValidationError::new).collect(Collectors.toSet()));
+        }
+    }
+
+    public record ValidationError(String errorMessage) { }
+
+    public boolean validationFailed() {
+        return !validationErrors.isEmpty();
+    }
+
+    public String renderExceptionMessage() {
+
+        Assert.state(validationFailed(), "Schema validation was successful but error message rendering requested");
+
+        StringBuilder constructedMessage = new StringBuilder("The following errors were encountered during cassandra schema validation:\n");
+        validationErrors.forEach(validationError -> constructedMessage.append("\t- %s\n".formatted(validationError.errorMessage())));
+        return constructedMessage.toString();
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraSchemaValidator.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/config/CassandraSchemaValidator.java
@@ -1,0 +1,181 @@
+package org.springframework.data.cassandra.config;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.data.cassandra.CassandraKeyspaceDoesNotExistsException;
+import org.springframework.data.cassandra.CassandraNoActiveKeyspaceSetForCqlSessionException;
+import org.springframework.data.cassandra.CassandraSchemaValidationException;
+import org.springframework.data.cassandra.core.mapping.BasicCassandraPersistentEntity;
+import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentEntity;
+import org.springframework.data.cassandra.core.mapping.CassandraPersistentProperty;
+import org.springframework.data.cassandra.core.mapping.CassandraSimpleTypeHolder;
+import org.springframework.data.mapping.PropertyHandler;
+import org.springframework.util.Assert;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
+import com.datastax.oss.driver.api.core.type.DataType;
+
+/**
+ * Class that is responsible to validate cassandra schema inside {@link CqlSession} keyspace.
+ *
+ * @author Mikhail Polivakha
+ */
+public class CassandraSchemaValidator implements SmartInitializingSingleton {
+
+    private static final Log logger = LogFactory.getLog(CassandraSchemaValidator.class);
+
+    private final CqlSessionFactoryBean cqlSessionFactoryBean;
+
+    private final CassandraMappingContext cassandraMappingContext;
+
+    private final boolean strictValidation;
+
+    public CassandraSchemaValidator(
+      CqlSessionFactoryBean cqlSessionFactoryBean,
+      CassandraMappingContext cassandraMappingContext,
+      boolean strictValidation
+    ) {
+        this.strictValidation = strictValidation;
+        this.cqlSessionFactoryBean = cqlSessionFactoryBean;
+        this.cassandraMappingContext = cassandraMappingContext;
+    }
+
+    /**
+     * Here, we only consider {@link CqlSession#getKeyspace() current session keyspace},
+     * because for now there is no way to customize keyspace for {@link CassandraPersistentEntity}.
+     * <p>
+     * See <a href="https://github.com/spring-projects/spring-data-cassandra/issues/921">related issue</a>
+     */
+    @Override
+    public void afterSingletonsInstantiated() {
+        CqlSession session = cqlSessionFactoryBean.getSession();
+
+        CqlIdentifier activeKeyspace = session
+          .getKeyspace()
+          .orElseThrow(CassandraNoActiveKeyspaceSetForCqlSessionException::new);
+
+        KeyspaceMetadata keyspaceMetadata = session
+          .getMetadata()
+          .getKeyspace(activeKeyspace)
+          .orElseThrow(() -> new CassandraKeyspaceDoesNotExistsException(activeKeyspace.asInternal()));
+
+        Collection<BasicCassandraPersistentEntity<?>> persistentEntities = cassandraMappingContext.getPersistentEntities();
+
+        CassandraSchemaValidationProfile validationProfile = CassandraSchemaValidationProfile.empty();
+
+        for (BasicCassandraPersistentEntity<?> persistentEntity : persistentEntities) {
+            validationProfile.addValidationErrors(validatePersistentEntity(keyspaceMetadata, persistentEntity));
+        }
+
+        evaluateValidationResult(validationProfile);
+    }
+
+    private void evaluateValidationResult(CassandraSchemaValidationProfile validationProfile) {
+        if (validationProfile.validationFailed()) {
+            if (strictValidation) {
+                throw new CassandraSchemaValidationException(validationProfile.renderExceptionMessage());
+            } else {
+                if (logger.isErrorEnabled()) {
+                    logger.error(validationProfile.renderExceptionMessage());
+                }
+            }
+        } else {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Cassandra schema validation completed successfully");
+            }
+        }
+    }
+
+    private List<String> validatePersistentEntity(
+      KeyspaceMetadata keyspaceMetadata,
+      BasicCassandraPersistentEntity<?> entity
+    ) {
+
+        if (entity.isTupleType() || entity.isUserDefinedType()) {
+            return List.of();
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Validating persistent entity '%s'".formatted(keyspaceMetadata.getName()));
+        }
+
+        Optional<TableMetadata> table = keyspaceMetadata.getTable(entity.getTableName());
+
+        if (table.isPresent()) {
+            return this.validateProperties(table.get(), entity);
+        } else {
+            return List.of(
+              "Unable to locate target table for persistent entity '%s'. Expected table name is '%s', but no such table in keyspace '%s'".formatted(
+                entity.getName(),
+                entity.getTableName(),
+                keyspaceMetadata.getName()
+              )
+            );
+        }
+    }
+
+    private List<String> validateProperties(TableMetadata tableMetadata, BasicCassandraPersistentEntity<?> entity) {
+
+        List<String> validationErrors = new LinkedList<>();
+
+        entity.doWithProperties((PropertyHandler<CassandraPersistentProperty>) persistentProperty -> {
+            CqlIdentifier expectedColumnName = persistentProperty.getColumnName();
+
+            Assert.notNull(expectedColumnName, "Column cannot not be null at this point");
+
+            Optional<ColumnMetadata> column = tableMetadata.getColumn(expectedColumnName);
+
+            if (column.isPresent()) {
+                ColumnMetadata columnMetadata = column.get();
+                DataType dataTypeExpected = CassandraSimpleTypeHolder.getDataTypeFor(persistentProperty.getRawType());
+
+                if (dataTypeExpected == null) {
+                    validationErrors.add(
+                      "Unable to deduce cassandra data type for property '%s' inside the persistent entity '%s'".formatted(
+                        persistentProperty.getName(),
+                        entity.getName()
+                      )
+                    );
+                } else {
+                    if (!Objects.equals(dataTypeExpected.getProtocolCode(), columnMetadata.getType().getProtocolCode())) {
+                        validationErrors.add(
+                          "Expected '%s' data type for '%s' property in the '%s' persistent entity, but actual data type is '%s'".formatted(
+                            dataTypeExpected,
+                            persistentProperty.getName(),
+                            entity.getName(),
+                            columnMetadata.getType()
+                          )
+                        );
+                    }
+                }
+            } else {
+                validationErrors.add(
+                  "Unable to locate target column for persistent property '%s' in persistent entity '%s'. Expected to see column with name '%s', but there is no such column in table '%s'".formatted(
+                    persistentProperty.getName(),
+                    entity.getName(),
+                    expectedColumnName,
+                    entity.getTableName()
+                  )
+                );
+            }
+        });
+
+        return validationErrors;
+    }
+
+    public boolean isStrictValidation() {
+        return strictValidation;
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CassandraAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CassandraAccessor.java
@@ -45,6 +45,7 @@ import com.datastax.oss.driver.api.core.retry.RetryPolicy;
  * @author Mark Paluch
  * @author John Blum
  * @author Tomasz Lelek
+ * @author Mikhail Polivakha
  * @see org.springframework.beans.factory.InitializingBean
  * @see com.datastax.oss.driver.api.core.CqlSession
  */

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CassandraAccessor.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CassandraAccessor.java
@@ -85,7 +85,7 @@ public class CassandraAccessor implements InitializingBean {
 	 */
 	private @Nullable ConsistencyLevel serialConsistencyLevel;
 
-	private @Nullable SessionFactory sessionFactory;
+	private SessionFactory sessionFactory;
 
 	/**
 	 * Ensures the Cassandra {@link CqlSession} and exception translator has been propertly set.
@@ -314,7 +314,6 @@ public class CassandraAccessor implements InitializingBean {
 	 * @since 2.0
 	 * @see SessionFactory
 	 */
-	@Nullable
 	public SessionFactory getSessionFactory() {
 		return this.sessionFactory;
 	}
@@ -361,11 +360,10 @@ public class CassandraAccessor implements InitializingBean {
 		}
 
 		if (keyspace != null) {
-			if (statementToUse instanceof BatchStatement) {
-				statementToUse = ((BatchStatement) statementToUse).setKeyspace(keyspace);
-			}
-			if (statementToUse instanceof SimpleStatement) {
-				statementToUse = ((SimpleStatement) statementToUse).setKeyspace(keyspace);
+			if (statementToUse instanceof BatchStatement bs) {
+				statementToUse = bs.setKeyspace(keyspace);
+			} else if (statementToUse instanceof SimpleStatement ss) {
+				statementToUse = ss.setKeyspace(keyspace);
 			}
 		}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/CqlTemplate.java
@@ -620,7 +620,7 @@ public class CqlTemplate extends CassandraAccessor implements CqlOperations {
 
 		SessionFactory sessionFactory = getSessionFactory();
 
-		Assert.state(sessionFactory != null, "SessionFactory is null");
+		Assert.notNull(sessionFactory, "SessionFactory is null");
 
 		return sessionFactory.getSession();
 	}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/util/AbstractCollectionTerm.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/util/AbstractCollectionTerm.java
@@ -1,0 +1,62 @@
+package org.springframework.data.cassandra.core.cql.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.lang.NonNull;
+
+import com.datastax.oss.driver.api.querybuilder.term.Term;
+import com.datastax.oss.driver.internal.querybuilder.CqlHelper;
+
+/**
+ * Represents an abstract collection like {@link Term} such as Set, List, Tuple in CQL
+ *
+ * @author Mikhail Polivakha
+ */
+public abstract class AbstractCollectionTerm implements Term {
+
+    @NonNull
+    private final Collection<? extends Term> components;
+
+    /**
+     * @return EnclosingLiterals that are used to render the collection of terms
+     */
+    public abstract EnclosingLiterals enclosingLiterals();
+
+    public AbstractCollectionTerm(Collection<? extends Term> components) {
+        this.components = Optional.ofNullable(components).orElse(Collections.emptySet());
+    }
+
+    @Override
+    public boolean isIdempotent() {
+        return components.stream().allMatch(Term::isIdempotent);
+    }
+
+    @Override
+    public void appendTo(@NotNull StringBuilder builder) {
+        EnclosingLiterals literals = this.enclosingLiterals();
+
+        if (components.isEmpty()) {
+            builder.append(literals.prefix).append(literals.postfix);
+        } else {
+            CqlHelper.append(components, builder, literals.prefix, ",", literals.postfix);
+        }
+    }
+
+    protected static class EnclosingLiterals {
+
+        private final String prefix;
+        private final String postfix;
+
+        protected EnclosingLiterals(String prefix, String postfix) {
+            this.prefix = prefix;
+            this.postfix = postfix;
+        }
+
+        protected static EnclosingLiterals of(String prefix, String postfix) {
+            return new EnclosingLiterals(prefix, postfix);
+        }
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/util/ListTerm.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/util/ListTerm.java
@@ -1,0 +1,17 @@
+package org.springframework.data.cassandra.core.cql.util;
+
+import java.util.Collection;
+
+import com.datastax.oss.driver.api.querybuilder.term.Term;
+
+public class ListTerm extends AbstractCollectionTerm {
+
+    public ListTerm(Collection<? extends Term> components) {
+        super(components);
+    }
+
+    @Override
+    public EnclosingLiterals enclosingLiterals() {
+        return EnclosingLiterals.of("[", "]");
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/util/SetTerm.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/util/SetTerm.java
@@ -1,0 +1,17 @@
+package org.springframework.data.cassandra.core.cql.util;
+
+import java.util.Collection;
+
+import com.datastax.oss.driver.api.querybuilder.term.Term;
+
+public class SetTerm extends AbstractCollectionTerm {
+
+    public SetTerm(Collection<? extends Term> components) {
+        super(components);
+    }
+
+    @Override
+    public EnclosingLiterals enclosingLiterals() {
+        return EnclosingLiterals.of("{", "}");
+    }
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/util/StatementBuilder.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/util/StatementBuilder.java
@@ -25,7 +25,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
@@ -38,7 +37,6 @@ import com.datastax.oss.driver.api.querybuilder.BindMarker;
 import com.datastax.oss.driver.api.querybuilder.BuildableQuery;
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
 import com.datastax.oss.driver.api.querybuilder.term.Term;
-import com.datastax.oss.driver.internal.querybuilder.CqlHelper;
 
 /**
  * Functional builder for Cassandra {@link BuildableQuery statements}. Statements are built by applying
@@ -67,6 +65,7 @@ import com.datastax.oss.driver.internal.querybuilder.CqlHelper;
  * All methods returning {@link StatementBuilder} point to the same instance. This class is intended for internal use.
  *
  * @author Mark Paluch
+ * @author Mikhail Polivakha
  * @param <S> Statement type
  * @since 3.0
  */

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/util/TermFactory.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/util/TermFactory.java
@@ -20,11 +20,12 @@ import java.util.function.Supplier;
 
 import org.springframework.lang.Nullable;
 
+import com.datastax.oss.driver.api.querybuilder.BindMarker;
 import com.datastax.oss.driver.api.querybuilder.term.Term;
 
 /**
  * Factory for {@link Term} objects encapsulating a binding {@code value}. Classes implementing this factory interface
- * may return inline terms to render values as part of the query string, or bind markers to supply parameters on
+ * may return inline {@link Term terms} to render values as part of the query string, or {@link BindMarker bind markers} to supply parameters on
  * statement creation/parameter binding.
  * <p>
  * A {@link TermFactory} is typically used with {@link StatementBuilder}.

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/PrimaryKeyClassEntityMetadataVerifier.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/PrimaryKeyClassEntityMetadataVerifier.java
@@ -45,8 +45,6 @@ public class PrimaryKeyClassEntityMetadataVerifier implements CassandraPersisten
 		List<CassandraPersistentProperty> partitionKeyColumns = new ArrayList<>();
 		List<CassandraPersistentProperty> primaryKeyColumns = new ArrayList<>();
 
-		Class<?> entityType = entity.getType();
-
 		// @Indexed not allowed on type level
 		if (entity.isAnnotationPresent(Indexed.class)) {
 			exceptions.add(new MappingException("@Indexed cannot be used on primary key classes"));

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSchemaValidationProfileTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSchemaValidationProfileTest.java
@@ -1,0 +1,30 @@
+package org.springframework.data.cassandra.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Mikhail Polivakha
+ */
+class CassandraSchemaValidationProfileUnitTest {
+
+    @Test
+    void testRenderingValidationErrorMessageOnSuccessfulValidation() {
+        CassandraSchemaValidationProfile empty = CassandraSchemaValidationProfile.empty();
+
+        assertThatThrownBy(empty::renderExceptionMessage).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testRenderingValidationErrorMessageOnFailedValidation() {
+        CassandraSchemaValidationProfile empty = CassandraSchemaValidationProfile.empty();
+
+        empty.addValidationErrors(List.of("Something went wrong"));
+
+        assertThat(empty.renderExceptionMessage()).contains("- Something went wrong");
+    }
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSchemaValidatorTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSchemaValidatorTest.java
@@ -1,0 +1,151 @@
+package org.springframework.data.cassandra.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.cassandra.CassandraSchemaValidationException;
+import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
+import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.Table;
+import org.springframework.data.cassandra.repository.support.IntegrationTestConfig;
+import org.springframework.data.cassandra.support.CqlDataSet;
+import org.springframework.data.cassandra.test.util.CassandraExtension;
+
+/**
+ * @author Mikhail Polivakha
+ */
+class CassandraSchemaValidatorTest {
+
+    @RegisterExtension
+    static CassandraExtension cassandraExtension = new CassandraExtension(
+      CqlDataSet.fromClassPath("org/springframework/data/cassandra/core/cql/session/init/schema-validation.cql")
+    );
+
+    @Configuration
+    static class Config extends IntegrationTestConfig {
+
+        @Bean("cassandraSchemaValidator")
+        CassandraSchemaValidator cassandraSchemaValidator(
+          CqlSessionFactoryBean cqlSessionFactoryBean,
+          CassandraMappingContext cassandraMappingContext,
+          @Value("${validation.mode.strict:true}") Boolean validationModeStrict
+        ) {
+            return new CassandraSchemaValidator(
+              cqlSessionFactoryBean,
+              cassandraMappingContext,
+              validationModeStrict
+            );
+        }
+
+        @Override
+        public SchemaAction getSchemaAction() {
+            return SchemaAction.NONE;
+        }
+
+        @Override
+        protected String getKeyspaceName() {
+            return "validation_keyspace";
+        }
+
+        @Bean
+        CassandraMappingContext cassandraMappingContext() {
+            return new CassandraMappingContext();
+        }
+    }
+
+    @Configuration
+    static class WithAutoCreationConfig extends Config {
+
+        @Override
+        public SchemaAction getSchemaAction() {
+            return SchemaAction.CREATE;
+        }
+    }
+
+    @Table(value = "should_pass")
+    static class ShouldPass {
+
+        @Id
+        private UUID id;
+
+        @Column(value = "name")
+        private String name;
+
+        @Column(value = "some_type")
+        private String type;
+
+        private Integer status;
+
+        private Integer precision;
+    }
+
+    @Table(value = "should_fail")
+    static class ShouldFail {
+
+        @Id
+        private UUID id;
+
+        @Column(value = "name")
+        private String name;
+
+        @Column(value = "some_type")
+        private String type;
+
+        private Integer status;
+
+        private Integer precision;
+
+        private Integer noSuchColumn;
+    }
+
+    @Table(value = "no_such_table")
+    static class NoSuchTable {
+
+        @Id
+        private UUID id;
+    }
+
+    @Test
+    void testValidationFailedWithNoSchemaAction() {
+        try {
+            new AnnotationConfigApplicationContext(Config.class);
+            Assertions.fail(); // Context should not boot
+        } catch (CassandraSchemaValidationException exception) {
+            String message = exception.getMessage();
+            assertThat(message).contains("Expected table name is 'no_such_table', but no such table in keyspace");
+            assertThat(message).contains("Expected 'TEXT' data type for 'name' property");
+            assertThat(message).contains("Unable to locate target column for persistent property 'noSuchColumn'");
+        }
+    }
+
+    @Test
+    void testValidationPassedWithSchemaAutoCreation() {
+        try {
+            System.setProperty("validation.mode.strict", "false");
+            new AnnotationConfigApplicationContext(Config.class);
+            System.clearProperty("validation.mode.strict");
+        } catch (CassandraSchemaValidationException exception) {
+            Assertions.fail(); // Context should load successfully, no exception should be thrown
+        }
+    }
+
+    @Test
+    void testWhenSchemaIsAutoCreatedThenValidationShouldPass() {
+        try {
+            var applicationContext = new AnnotationConfigApplicationContext(WithAutoCreationConfig.class);
+            CassandraSchemaValidator cassandraSchemaValidator = applicationContext.getBean("cassandraSchemaValidator", CassandraSchemaValidator.class);
+            Assertions.assertTrue(cassandraSchemaValidator.isStrictValidation());
+        } catch (CassandraSchemaValidationException exception) {
+            Assertions.fail(); // Context should load successfully, no exception should be thrown
+        }
+    }
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSchemaValidatorTest.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/config/CassandraSchemaValidatorTest.java
@@ -13,6 +13,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.cassandra.CassandraSchemaValidationException;
+import org.springframework.data.cassandra.core.convert.CassandraConverter;
+import org.springframework.data.cassandra.core.convert.CassandraSchemaValidator;
 import org.springframework.data.cassandra.core.mapping.CassandraMappingContext;
 import org.springframework.data.cassandra.core.mapping.Column;
 import org.springframework.data.cassandra.core.mapping.Table;
@@ -36,12 +38,12 @@ class CassandraSchemaValidatorTest {
         @Bean("cassandraSchemaValidator")
         CassandraSchemaValidator cassandraSchemaValidator(
           CqlSessionFactoryBean cqlSessionFactoryBean,
-          CassandraMappingContext cassandraMappingContext,
+          CassandraConverter cassandraConverter,
           @Value("${validation.mode.strict:true}") Boolean validationModeStrict
         ) {
             return new CassandraSchemaValidator(
-              cqlSessionFactoryBean,
-              cassandraMappingContext,
+              cqlSessionFactoryBean.getSession(),
+              cassandraConverter,
               validationModeStrict
             );
         }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/IntegrationTestConfig.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/repository/support/IntegrationTestConfig.java
@@ -37,6 +37,7 @@ import org.springframework.data.cassandra.support.RandomKeyspaceName;
  * @author David Webb
  * @author Matthew T. Adams
  * @author Mark Paluch
+ * @author Mikhail Polivakha
  */
 @Configuration
 public class IntegrationTestConfig extends AbstractReactiveCassandraConfiguration {
@@ -88,7 +89,7 @@ public class IntegrationTestConfig extends AbstractReactiveCassandraConfiguratio
 
 	@Override
 	protected List<CreateKeyspaceSpecification> getKeyspaceCreations() {
-		return Collections.singletonList(createKeyspace(getKeyspaceName()).withSimpleReplication());
+		return Collections.singletonList(createKeyspace(getKeyspaceName()).ifNotExists().withSimpleReplication());
 	}
 
 	@Override

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/support/CqlDataSet.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/support/CqlDataSet.java
@@ -29,6 +29,7 @@ import com.datastax.oss.driver.shaded.guava.common.io.Resources;
  * particular keyspace.
  *
  * @author Mark Paluch
+ * @author Mikhail Polivakha
  */
 public class CqlDataSet {
 
@@ -91,5 +92,14 @@ public class CqlDataSet {
 
 		URL url = Resources.getResource(resource);
 		return new CqlDataSet(url, null);
+	}
+
+	/**
+	 * Create a {@link CqlDataSet} from a class-path resource.
+	 */
+	public static CqlDataSet fromClassPath(String resource, String keyspaceName) {
+
+		URL url = Resources.getResource(resource);
+		return new CqlDataSet(url, keyspaceName);
 	}
 }

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/util/CassandraDelegate.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/util/CassandraDelegate.java
@@ -49,6 +49,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
  * @author Mark Paluch
  * @author John Blum
  * @author Tomasz Lelek
+ * @author Mikhail Polivakha
  * @see org.springframework.data.cassandra.support.CassandraConnectionProperties
  * @see com.datastax.oss.driver.api.core.CqlSessionBuilder
  * @see com.datastax.oss.driver.api.core.CqlSession
@@ -155,7 +156,7 @@ class CassandraDelegate {
 	 * @param cqlDataSet must not be {@literal null}
 	 * @return the rule
 	 */
-	private CassandraDelegate before(InvocationMode invocationMode, CqlDataSet cqlDataSet) {
+	public CassandraDelegate before(InvocationMode invocationMode, CqlDataSet cqlDataSet) {
 
 		Assert.notNull(cqlDataSet, "CqlDataSet must not be null");
 
@@ -346,7 +347,7 @@ class CassandraDelegate {
 	private String resolveHost() {
 
 		if (isTestcontainers()) {
-			return container.getContainerIpAddress();
+			return container.getHost();
 		}
 
 		return isEmbedded() ? EmbeddedCassandraServerHelper.getHost() : this.properties.getCassandraHost();
@@ -425,7 +426,7 @@ class CassandraDelegate {
 
 	private void load(CqlSession session, CqlDataSet cqlDataSet) {
 
-		Optional.of(cqlDataSet.getKeyspaceName()).filter(StringUtils::hasText)
+		Optional.ofNullable(cqlDataSet.getKeyspaceName()).filter(StringUtils::hasText)
 				.filter(
 						keyspaceName -> !keyspaceName.equals(session.getKeyspace().map(CqlIdentifier::toString).orElse("system")))
 				.ifPresent(keyspaceName -> session.execute(String.format(TestKeyspaceDelegate.USE_KEYSPACE_CQL, keyspaceName)));

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/util/CassandraExtension.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/test/util/CassandraExtension.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.commons.util.StringUtils;
+import org.springframework.data.cassandra.support.CqlDataSet;
 import org.springframework.data.cassandra.support.RandomKeyspaceName;
 import org.springframework.util.Assert;
 
@@ -52,6 +53,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
  * </pre>
  *
  * @author Mark Paluch
+ * @author Mikhail Polivakha
  */
 public class CassandraExtension implements BeforeAllCallback, AfterAllCallback, TestInstancePostProcessor {
 
@@ -60,6 +62,13 @@ public class CassandraExtension implements BeforeAllCallback, AfterAllCallback, 
 	private static final ThreadLocal<Resources> TEST_RESOURCES = new ThreadLocal<>();
 
 	private final CassandraDelegate delegate = new CassandraDelegate("embedded-cassandra.yaml");
+
+	public CassandraExtension() {
+	}
+
+	public CassandraExtension(CqlDataSet cqlDataSet) {
+		this.delegate.before(CassandraDelegate.InvocationMode.ONCE, cqlDataSet);
+	}
 
 	/**
 	 * Retrieve the keyspace {@link CqlSession} that is associated with the current {@link Thread}.

--- a/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/core/cql/session/init/schema-validation.cql
+++ b/spring-data-cassandra/src/test/resources/org/springframework/data/cassandra/core/cql/session/init/schema-validation.cql
@@ -1,0 +1,4 @@
+CREATE KEYSPACE IF NOT EXISTS validation_keyspace WITH durable_writes = false AND replication = {'class': 'SimpleStrategy', 'replication_factor' : 1};
+USE validation_keyspace;
+CREATE TABLE should_pass(id UUID PRIMARY KEY, name TEXT, some_type TEXT, status INT, precision INT);
+CREATE TABLE should_fail(id UUID PRIMARY KEY, name INT, type TEXT, status TEXT, precision INT);


### PR DESCRIPTION
This is the PR to solve #764 issue.
The key takeaways in the PR: there is a new class, called `CassandraSchemaValidator`, that is validating Cassandra schema against existing entities in the `MappingContext`. The keyspace where we expect the entities to show up is one that is configured to be used by `CqlSession` (for now that is correct because we do not have a keyspace segregation for entities yet, see this ticket).

The validation checks that:
- All Tables exists
- All **non-transient** properties are expected to be mapped to a single column (I do not know if this is correct or not, appreciate any help on this)
- We expect that the type of the persistent property matches the one we expect in Cassandra  

P.S: I think it would be nice to add this as a bean to Cassandra auto-configuration to spring boot with some properties conditional annotations