### PR TITLE
Allow `QueryOptions` to disable timeout

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/QueryOptions.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/cql/QueryOptions.java
@@ -284,6 +284,7 @@ public class QueryOptions {
 	 * Builder for {@link QueryOptions}.
 	 *
 	 * @author Mark Paluch
+	 * @author Seungho Kang
 	 * @since 1.5
 	 */
 	public static class QueryOptionsBuilder {
@@ -482,8 +483,7 @@ public class QueryOptions {
 		@Deprecated
 		public QueryOptionsBuilder readTimeout(Duration readTimeout) {
 
-			Assert.isTrue(!readTimeout.isZero() && !readTimeout.isNegative(),
-					"ReadTimeout must be greater than equal to zero");
+			Assert.isTrue(!readTimeout.isNegative(), "ReadTimeout must be greater than equal to zero");
 
 			this.timeout = readTimeout;
 
@@ -548,7 +548,7 @@ public class QueryOptions {
 		 */
 		public QueryOptionsBuilder timeout(Duration timeout) {
 
-			Assert.isTrue(!timeout.isZero() && !timeout.isNegative(), "ReadTimeout must be greater than equal to zero");
+			Assert.isTrue(!timeout.isNegative(), "ReadTimeout must be greater than equal to zero");
 
 			this.timeout = timeout;
 

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/QueryOptionsUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/cql/QueryOptionsUnitTests.java
@@ -31,6 +31,7 @@ import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
  * @author Mark Paluch
  * @author Tomasz Lelek
  * @author Sam Lightfoot
+ * @author Seungho Kang
  */
 class QueryOptionsUnitTests {
 
@@ -85,5 +86,35 @@ class QueryOptionsUnitTests {
 		assertThat(mutated.isIdempotent()).isEqualTo(true);
 		assertThat(mutated.getRoutingKeyspace()).isEqualTo(CqlIdentifier.fromCql("rksl"));
 		assertThat(mutated.getRoutingKey()).isEqualTo(ByteBuffer.allocate(1));
+	}
+
+	@Test // GH-1494
+	void buildZeroDurationTimeoutQueryOptions() {
+
+		QueryOptions queryOptions = QueryOptions.builder().timeout(Duration.ofSeconds(0)).build();
+
+		assertThat(queryOptions.getTimeout()).isEqualTo(Duration.ZERO);
+	}
+
+	@Test // GH-1494
+	void shouldRejectNegativeDurationTimeoutQueryOptions() {
+
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> QueryOptions.builder().timeout(Duration.ofSeconds(-1)).build());
+	}
+
+	@Test // GH-1494
+	void buildZeroDurationReadTimeoutQueryOptions() {
+
+		QueryOptions queryOptions = QueryOptions.builder().readTimeout(Duration.ofSeconds(0)).build();
+
+		assertThat(queryOptions.getReadTimeout()).isEqualTo(Duration.ZERO);
+	}
+
+	@Test // GH-1494
+	void shouldRejectNegativeDurationReadTimeoutQueryOptions() {
+
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> QueryOptions.builder().readTimeout(Duration.ofSeconds(-1)).build());
 	}
 }


### PR DESCRIPTION
Allow QueryOptions to set timeout to 0.

If it is zero, the read timeout will be disabled for this statement

Closes https://github.com/spring-projects/spring-data-cassandra/issues/1494
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
