### PR TITLE
Fix ClassCastException for CassandraObservationContext

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/observability/ObservationRequestTracker.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/observability/ObservationRequestTracker.java
@@ -16,6 +16,7 @@
 package org.springframework.data.cassandra.observability;
 
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.Observation.Context;
 import io.micrometer.observation.Observation.Event;
 
 import org.apache.commons.logging.Log;
@@ -85,15 +86,19 @@ public enum ObservationRequestTracker implements RequestTracker {
 		if (request instanceof CassandraObservationSupplier) {
 
 			Observation observation = ((CassandraObservationSupplier) request).getObservation();
+			Context context = observation.getContext();
 
-			((CassandraObservationContext) observation.getContext()).setNode(node);
+			if (context instanceof CassandraObservationContext) {
 
-			observation.highCardinalityKeyValue(
-					String.format(HighCardinalityKeyNames.NODE_ERROR_TAG.asString(), node.getEndPoint()), error.toString());
-			observation.event(Event.of(Events.NODE_ERROR.getValue()));
+				((CassandraObservationContext) context).setNode(node);
 
-			if (log.isDebugEnabled()) {
-				log.debug("Marking node error for [" + observation + "]");
+				observation.highCardinalityKeyValue(
+						String.format(HighCardinalityKeyNames.NODE_ERROR_TAG.asString(), node.getEndPoint()), error.toString());
+				observation.event(Event.of(Events.NODE_ERROR.getValue()));
+
+				if (log.isDebugEnabled()) {
+					log.debug("Marking node error for [" + observation + "]");
+				}
 			}
 		}
 	}
@@ -105,13 +110,17 @@ public enum ObservationRequestTracker implements RequestTracker {
 		if (request instanceof CassandraObservationSupplier) {
 
 			Observation observation = ((CassandraObservationSupplier) request).getObservation();
+			Context context = observation.getContext();
 
-			((CassandraObservationContext) observation.getContext()).setNode(node);
+			if (context instanceof CassandraObservationContext) {
 
-			observation.event(Event.of(Events.NODE_SUCCESS.getValue()));
+				((CassandraObservationContext) context).setNode(node);
 
-			if (log.isDebugEnabled()) {
-				log.debug("Marking node success for [" + observation + "]");
+				observation.event(Event.of(Events.NODE_SUCCESS.getValue()));
+
+				if (log.isDebugEnabled()) {
+					log.debug("Marking node success for [" + observation + "]");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This fixes a ClassCastException for CassandraObservationContext when a NoopObservation is returned by the observation registry.




```
2024-11-28 10:46:44.837+0100 [s1-admin-0] WARN  c.d.o.d.i.core.tracker.MultiplexingRequestTracker - [warnWithException] [s1|2034963355] Unexpected error while notifying request tracker INSTANCE of an onNodeSuccess event.
java.lang.ClassCastException: class io.micrometer.observation.Observation$Context cannot be cast to class org.springframework.data.cassandra.observability.CassandraObservationContext (io.micrometer.observation.Observation$Context and org.springframework.data.cassandra.observability.CassandraObservationContext are in unnamed module of loader 'app')
	at org.springframework.data.cassandra.observability.ObservationRequestTracker.onNodeSuccess(ObservationRequestTracker.java:109)
	at com.datastax.oss.driver.internal.core.tracker.MultiplexingRequestTracker.lambda$onNodeSuccess$2(MultiplexingRequestTracker.java:114)
	at com.datastax.oss.driver.internal.core.tracker.MultiplexingRequestTracker.invokeTrackers(MultiplexingRequestTracker.java:155)
	at com.datastax.oss.driver.internal.core.tracker.MultiplexingRequestTracker.onNodeSuccess(MultiplexingRequestTracker.java:113)
	at com.datastax.oss.driver.internal.core.cql.CqlRequestHandler.setFinalResult(CqlRequestHandler.java:338)
	at com.datastax.oss.driver.internal.core.cql.CqlRequestHandler.access$1500(CqlRequestHandler.java:97)
	at com.datastax.oss.driver.internal.core.cql.CqlRequestHandler$NodeResponseCallback.lambda$onResponse$1(CqlRequestHandler.java:648)
...
2024-11-28 10:46:44.840+0100 [s1-admin-0] DEBUG o.s.d.c.observability.ObservationRequestTracker - [onSuccess] Closing observation [io.micrometer.observation.NoopObservation@56c0e4a0]
```
```
2024-11-28 10:46:44.893+0100 [s1-io-3] WARN  c.d.o.d.i.core.tracker.MultiplexingRequestTracker - [warnWithException] [s1|1865288005] Unexpected error while notifying request tracker INSTANCE of an onNodeSuccess event.
java.lang.ClassCastException: class io.micrometer.observation.Observation$Context cannot be cast to class org.springframework.data.cassandra.observability.CassandraObservationContext (io.micrometer.observation.Observation$Context and org.springframework.data.cassandra.observability.CassandraObservationContext are in unnamed module of loader 'app')
	at org.springframework.data.cassandra.observability.ObservationRequestTracker.onNodeSuccess(ObservationRequestTracker.java:109)
	at com.datastax.oss.driver.internal.core.tracker.MultiplexingRequestTracker.lambda$onNodeSuccess$2(MultiplexingRequestTracker.java:114)
	at com.datastax.oss.driver.internal.core.tracker.MultiplexingRequestTracker.invokeTrackers(MultiplexingRequestTracker.java:155)
	at com.datastax.oss.driver.internal.core.tracker.MultiplexingRequestTracker.onNodeSuccess(MultiplexingRequestTracker.java:113)
	at com.datastax.oss.driver.internal.core.cql.CqlRequestHandler.setFinalResult(CqlRequestHandler.java:338)
	at com.datastax.oss.driver.internal.core.cql.CqlRequestHandler.access$1500(CqlRequestHandler.java:97)
	at com.datastax.oss.driver.internal.core.cql.CqlRequestHandler$NodeResponseCallback.onResponse(CqlRequestHandler.java:657)
...
2024-11-28 10:46:44.905+0100 [s1-io-3] DEBUG o.s.d.c.observability.ObservationRequestTracker - [onSuccess] Closing observation [io.micrometer.observation.NoopObservation@56c0e4a0]
```