### PR TITLE
Support multiple `Update` operations for the same column name

### DIFF
--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/Update.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/Update.java
@@ -17,10 +17,11 @@ package org.springframework.data.cassandra.core.query;
 
 import static org.springframework.data.cassandra.core.query.SerializationUtils.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -40,13 +41,14 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
  *
  * @author Mark Paluch
  * @author Chema Vinacua
+ * @author Jeongjun Min
  * @since 2.0
  */
 public class Update {
 
-	private static final Update EMPTY = new Update(Collections.emptyMap());
+	private static final Update EMPTY = new Update(Collections.emptyList());
 
-	private final Map<ColumnName, AssignmentOp> updateOperations;
+	private final List<AssignmentOp> updateOperations;
 
 	/**
 	 * Create an empty {@link Update} object.
@@ -66,11 +68,9 @@ public class Update {
 
 		Assert.notNull(assignmentOps, "Update operations must not be null");
 
-		Map<ColumnName, AssignmentOp> updateOperations = assignmentOps instanceof Collection
-				? new LinkedHashMap<>(((Collection<?>) assignmentOps).size())
-				: new LinkedHashMap<>();
+		List<AssignmentOp> updateOperations = new ArrayList<>();
 
-		assignmentOps.forEach(assignmentOp -> updateOperations.put(assignmentOp.getColumnName(), assignmentOp));
+		assignmentOps.forEach(updateOperations::add);
 
 		return new Update(updateOperations);
 	}
@@ -84,7 +84,7 @@ public class Update {
 		return empty().set(columnName, value);
 	}
 
-	private Update(Map<ColumnName, AssignmentOp> updateOperations) {
+	private Update(List<AssignmentOp> updateOperations) {
 		this.updateOperations = updateOperations;
 	}
 
@@ -215,23 +215,55 @@ public class Update {
 	 * @return {@link Collection} of update operations.
 	 */
 	public Collection<AssignmentOp> getUpdateOperations() {
-		return Collections.unmodifiableCollection(updateOperations.values());
+		return Collections.unmodifiableCollection(updateOperations);
 	}
 
 	private Update add(AssignmentOp assignmentOp) {
 
-		Map<ColumnName, AssignmentOp> map = new LinkedHashMap<>(this.updateOperations.size() + 1);
+        List<AssignmentOp> list = new ArrayList<>(this.updateOperations.size() + 1);
 
-		map.putAll(this.updateOperations);
-		map.put(assignmentOp.getColumnName(), assignmentOp);
+        for (AssignmentOp existing : this.updateOperations) {
+            if (!conflicts(existing, assignmentOp)) {
+                list.add(existing);
+            }
+        }
 
-		return new Update(map);
+        list.add(assignmentOp);
+
+        return new Update(list);
+    }
+
+    /**
+     * Determine whether two assignment operations conflict and should not co-exist in a single {@link Update}.
+     * Conflicts are defined as whole-column operations on the same column or element-level operations targeting
+     * the same element (same map key or same list index) on the same column. In case of conflict, last-wins semantics
+     * apply and the incoming operation replaces the existing one.
+     */
+	private static boolean conflicts(AssignmentOp existing, AssignmentOp incoming) {
+
+		if (!existing.getColumnName().equals(incoming.getColumnName())) {
+			return false;
+		}
+
+		if (existing instanceof SetAtKeyOp e && incoming instanceof SetAtKeyOp i) {
+			return equalsNullSafe(e.getKey(), i.getKey());
+		}
+
+		if (existing instanceof SetAtIndexOp e && incoming instanceof SetAtIndexOp i) {
+			return e.getIndex() == i.getIndex();
+		}
+
+		return true;
+	}
+
+	private static boolean equalsNullSafe(@Nullable Object a, @Nullable Object b) {
+		return a == b || (a != null && a.equals(b));
 	}
 
 	@Override
-	public String toString() {
-		return StringUtils.collectionToDelimitedString(updateOperations.values(), ", ");
-	}
+    public String toString() {
+        return StringUtils.collectionToDelimitedString(updateOperations, ", ");
+    }
 
 	/**
 	 * Builder to add a single element/multiple elements to a collection associated with a {@link ColumnName}.

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/StatementFactoryUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/StatementFactoryUnitTests.java
@@ -67,6 +67,7 @@ import com.datastax.oss.driver.internal.core.type.codec.registry.DefaultCodecReg
  *
  * @author Mark Paluch
  * @author Sam Lightfoot
+ * @author Jeongjun Min
  */
 class StatementFactoryUnitTests {
 
@@ -960,6 +961,19 @@ class StatementFactoryUnitTests {
 		assertThat(statement.getQuery()).isEqualTo(
 				"SELECT comment,similarity_cosine(vector,[0.2, 0.15, 0.3, 0.2, 0.05]) AS vector FROM withvector ORDER BY vector ANN OF [1.2, 1.3]");
 		assertThat(statement.getNamedValues()).isEmpty();
+	}
+
+	@Test // GH-1525
+	void shouldCreateUpdateWithMultipleOperationsOnSameColumnDifferentKeys() {
+
+		Update update = Update.empty().set("map").atKey("key1").to("value1").set("map").atKey("key2").to("value2");
+
+		StatementBuilder<com.datastax.oss.driver.api.querybuilder.update.Update> updateStatementBuilder = statementFactory
+			.update(Query.empty(), update, personEntity);
+
+		String cql = updateStatementBuilder.build(ParameterHandling.INLINE).getQuery();
+
+		assertThat(cql).isEqualTo("UPDATE person SET map['key1']='value1', map['key2']='value2'");
 	}
 
 	@SuppressWarnings("unused")


### PR DESCRIPTION
Fixes #1525

This PR enhances the `Update` class to support multiple operations on the same column, resolving the limitation of the previous `Map`-based implementation.


* Changed the internal data structure of `Update` from `Map<ColumnName, AssignmentOp>` to `List<AssignmentOp>`. This allows multiple non-conflicting operations (e.g., setting different keys in a map) to coexist.

* Introduced a conflict resolution mechanism to handle duplicate or conflicting operations. The new implementation follows a "last-wins" policy, as suggested in the issue discussion. For example, a `set("name", "B")` operation will replace a previous `set("name", "A")`.

* Added a comprehensive suite of unit tests to `UpdateUnitTests` to verify both the coexistence of non-conflicting operations and the "last-wins" replacement policy for various edge cases.

---

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
