### PR TITLE
Fix flaky test in BasicCassandraPersistentTupleEntityUnitTests

### DIFF
--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentTupleEntityUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentTupleEntityUnitTests.java
@@ -99,7 +99,7 @@ class BasicCassandraPersistentTupleEntityUnitTests {
 		assertThatThrownBy(() -> this.mappingContext.getRequiredPersistentEntity(MissingAnnotation.class))
 				.isInstanceOf(MappingException.class)
 				.cause()
-				.hasMessageContaining("Missing @Element annotation in mapped tuple type for property [street]");
+				.hasMessageMatching(".*Missing @Element annotation in mapped tuple type for property \\[(street|city)\\].*");
 	}
 
 	@Tuple


### PR DESCRIPTION
### Summary
Fixes nondeterministic failure caused by reflection order of Class.getDeclaredFields(). The failure was found with [NonDex](https://github.com/TestingResearchIllinois/NonDex), which explores non-determinism in tests.

### Root Cause
ReflectionUtils.doWithFields() iterates declared fields in an undefined order.
As a result, the exception message may reference the field [street] or [city] first, leading to intermittent assertion mismatches in the test.

### Fix
Relaxed the assertion to accept either field name using hasMessageMatching(".*(street|city).*"), since modifying the code under test is neither practical nor necessary in this case:
```
.hasMessageMatching(".*Missing @Element annotation in mapped tuple type for property \\[(street|city)\\].*");
```

### Notes
Test-only change, no impact on production code.


### Reproduction of Failure

- JVM version
> openjdk version "17.0.16" 2025-07-15
> OpenJDK Runtime Environment (build 17.0.16+8-Ubuntu-0ubuntu124.04.1)
> OpenJDK 64-Bit Server VM (build 17.0.16+8-Ubuntu-0ubuntu124.04.1, mixed mode, sharing

- Maven
> Apache Maven 3.9.11

- Original commit: 3239d1b70c7db2ef7acb07d7e1f0d81600c8b757

- Add one line to pom.xml to skip verification when run with NonDex
```
<plugin>
	<groupId>org.apache.maven.plugins</groupId>
	<artifactId>maven-surefire-plugin</artifactId>
	<configuration>
+	         <argLine>-Xverify:none</argLine>
```

- Commands to reproduce

```
mvn -pl spring-data-cassandra edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=org.springframework.data.cassandra.core.mapping.BasicCassandraPersistentTupleEntityUnitTests#shouldReportMissingAnnotations \
    -Djacoco.skip -Drat.skip -Dpmd.skip -Denforcer.skip 
```
