### PR TITLE
Retrofit `Query` and `Update` API accepting `TypedPropertyPath`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 		<cassandra-driver.version>4.19.2</cassandra-driver.version>
 		<dist.id>spring-data-cassandra</dist.id>
 		<multithreadedtc.version>1.01</multithreadedtc.version>
-		<springdata.commons>4.1.0-SNAPSHOT</springdata.commons>
+		<springdata.commons>4.1.0-GH-3400-SNAPSHOT</springdata.commons>
 	</properties>
 
 	<dependencyManagement>

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentProperty.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/mapping/BasicCassandraPersistentProperty.java
@@ -154,7 +154,6 @@ public class BasicCassandraPersistentProperty extends AnnotationBasedPersistentP
 		}
 
 		String overriddenName = null;
-		boolean forceQuote = false;
 
 		Column column = findAnnotation(Column.class);
 
@@ -209,6 +208,7 @@ public class BasicCassandraPersistentProperty extends AnnotationBasedPersistentP
 
 	@Override
 	public boolean isMapLike() {
+		// TODO: Super isMap?
 		return ClassUtils.isAssignable(Map.class, getType());
 	}
 

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/ColumnName.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/ColumnName.java
@@ -47,7 +47,9 @@ public abstract class ColumnName {
 	 * @since 5.1
 	 */
 	public static <T, P> ColumnName from(TypedPropertyPath<T, P> property) {
-		return from((PropertyPath) TypedPropertyPath.of(property));
+		// lambdas/method references do not provide equality semantics, so we need to obtain the resolved PropertyPath
+		// variant
+		return from((PropertyPath) (TypedPropertyPath.of(property)));
 	}
 
 	/**
@@ -213,8 +215,14 @@ public abstract class ColumnName {
 
 		@Override
 		public boolean equals(@Nullable Object obj) {
-			return super.equals(obj)
-					&& (obj instanceof PropertyPathColumnName that && this.propertyPath.equals(that.propertyPath));
+
+			if (obj instanceof PropertyPathColumnName that) {
+				if (!this.propertyPath.equals(that.propertyPath)) {
+					return false;
+				}
+			}
+
+			return super.equals(obj);
 		}
 
 		@Override

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/Columns.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/Columns.java
@@ -85,8 +85,7 @@ public class Columns implements Iterable<ColumnName> {
 		Map<ColumnName, List<Selector>> columns = new LinkedHashMap<>(properties.length, 1);
 
 		for (TypedPropertyPath<T, ?> columnName : properties) {
-			TypedPropertyPath<T, ?> path = TypedPropertyPath.of(columnName);
-			add(columns, ColumnName.from(path));
+			add(columns, ColumnName.from(columnName));
 		}
 
 		return new Columns(columns);

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/Criteria.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/Criteria.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.core.TypedPropertyPath;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
@@ -53,6 +54,17 @@ public class Criteria implements CriteriaDefinition {
 		Assert.notNull(columnName, "ColumnName must not be null");
 
 		this.columnName = columnName;
+	}
+
+	/**
+	 * Static factory method to create a {@link Criteria} using the provided {@code property}.
+	 *
+	 * @param property must not be {@literal null}.
+	 * @return a new {@link Criteria} for {@code property}.
+	 * @since 5.1
+	 */
+	public static <T, P> Criteria where(TypedPropertyPath<T, P> property) {
+		return where(ColumnName.from(property));
 	}
 
 	/**

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/Query.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/core/query/Query.java
@@ -30,6 +30,7 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.cassandra.core.cql.QueryOptions;
+import org.springframework.data.core.TypedPropertyPath;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -89,6 +90,26 @@ public class Query implements Filter {
 	 */
 	public static Query empty() {
 		return EMPTY;
+	}
+
+	/**
+	 * Static factory method to create a {@link Query} for the given column selection.
+	 *
+	 * @return a new {@link Query} selecting {@link Columns}.
+	 * @since 5.1
+	 */
+	public static <T> Query select(TypedPropertyPath<T, ?>... properties) {
+		return select(Columns.from(properties));
+	}
+
+	/**
+	 * Static factory method to create a {@link Query} for the given column selection.
+	 *
+	 * @return a new {@link Query} selecting {@link Columns}.
+	 * @since 5.1
+	 */
+	public static <T> Query select(String... columnNames) {
+		return select(Columns.from(columnNames));
 	}
 
 	/**

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/core/convert/QueryMapperUnitTests.java
@@ -140,7 +140,7 @@ public class QueryMapperUnitTests {
 		assertThat(mappedCriteriaDefinition.getPredicate().getValue()).isInstanceOf(String.class).isEqualTo("Active");
 	}
 
-	@Test // DATACASS-343
+	@Test // DATACASS-343, GH-1625
 	void shouldMapEnumToNumber() {
 
 		Query query = Query.query(Criteria.where("number").is(State.Inactive));
@@ -152,7 +152,7 @@ public class QueryMapperUnitTests {
 		assertThat(mappedCriteriaDefinition.getPredicate().getValue()).isInstanceOf(Integer.class).isEqualTo(1);
 	}
 
-	@Test // DATACASS-343
+	@Test // DATACASS-343, GH-1625
 	void shouldMapEnumToNumberIn() {
 
 		Query query = Query.query(Criteria.where("number").in(State.Inactive));
@@ -191,7 +191,7 @@ public class QueryMapperUnitTests {
 		assertThat(mappedCriteriaDefinition.getPredicate().getValue()).isEqualTo(Collections.singletonList("Euro"));
 	}
 
-	@Test // DATACASS-343
+	@Test // DATACASS-343, GH-1625
 	void shouldMapApplyingUdtValueConversion() {
 
 		Query query = Query.query(Criteria.where("address").is(new Address("21 Jump-Street")));
@@ -206,7 +206,7 @@ public class QueryMapperUnitTests {
 		assertThat(predicate.as(UdtValue.class::cast).getFormattedContents()).isEqualTo("{street:'21 Jump-Street'}");
 	}
 
-	@Test // DATACASS-343
+	@Test // DATACASS-343, GH-1625
 	@SuppressWarnings("unchecked")
 	void shouldMapApplyingUdtValueCollectionConversion() {
 
@@ -224,7 +224,7 @@ public class QueryMapperUnitTests {
 				.contains("{street:'21 Jump-Street'}");
 	}
 
-	@Test // DATACASS-343
+	@Test // DATACASS-343, GH-1625
 	@SuppressWarnings("unchecked")
 	void shouldMapCollectionApplyingUdtValueCollectionConversion() {
 
@@ -241,7 +241,7 @@ public class QueryMapperUnitTests {
 				.contains("{street:'21 Jump-Street'}");
 	}
 
-	@Test // DATACASS-487
+	@Test // DATACASS-487, GH-1625
 	void shouldMapUdtMapContainsKey() {
 
 		Query query = Query.query(Criteria.where("relocations").containsKey(new Address("21 Jump-Street")));
@@ -256,7 +256,7 @@ public class QueryMapperUnitTests {
 				.isEqualTo("{street:'21 Jump-Street'}");
 	}
 
-	@Test // DATACASS-487
+	@Test // DATACASS-487, GH-1625
 	void shouldMapUdtMapContains() {
 
 		Query query = Query.query(Criteria.where("relocations").contains(new Address("21 Jump-Street")));
@@ -345,7 +345,7 @@ public class QueryMapperUnitTests {
 		assertThat(mappedObject).contains(new Order(Direction.ASC, "first_name"));
 	}
 
-	@Test // DATACASS-828
+	@Test // DATACASS-828, GH-1625
 	void allowSortByCompositeKey() {
 
 		Sort sort = Sort.by("key");
@@ -356,7 +356,7 @@ public class QueryMapperUnitTests {
 		assertThat(mappedSort).isEqualTo(Sort.by(asc("first_name"), asc("lastname")));
 	}
 
-	@Test // DATACASS-343
+	@Test // DATACASS-343, GH-1625
 	void shouldMapColumnWithCompositePrimaryKeyClass() {
 
 		Columns columnNames = Columns.from("key.firstname");
@@ -379,7 +379,7 @@ public class QueryMapperUnitTests {
 		assertThat(mappedObject).contains(CqlIdentifier.fromCql("array"));
 	}
 
-	@Test //
+	@Test
 	void shouldMapMultipleSelectorsNames() {
 
 		Columns columnNames = Columns.from("array").select("array",
@@ -476,7 +476,6 @@ public class QueryMapperUnitTests {
 		assertThat(mappedObject.iterator().next().getPredicate().getValue()).isEqualTo(new float[] { 1.1f, 2.2f });
 	}
 
-
 	@Test // GH-1504
 	void shouldConvertVectorSelectorFunction() {
 
@@ -506,7 +505,7 @@ public class QueryMapperUnitTests {
 		Currency currency;
 		State state;
 
-		Integer number;
+	Integer number;
 
 		LocalDate localDate;
 		LocalTime localTime;

--- a/src/main/antora/modules/ROOT/nav.adoc
+++ b/src/main/antora/modules/ROOT/nav.adoc
@@ -15,6 +15,7 @@
 ** xref:cassandra/template.adoc[]
 ** xref:cassandra/prepared-statements.adoc[]
 ** xref:object-mapping.adoc[]
+** xref:property-paths.adoc[]
 ** xref:cassandra/converters.adoc[Type-based Converter]
 ** xref:cassandra/property-converters.adoc[]
 ** xref:cassandra/events.adoc[]

--- a/src/main/antora/modules/ROOT/pages/property-paths.adoc
+++ b/src/main/antora/modules/ROOT/pages/property-paths.adoc
@@ -1,0 +1,1 @@
+include::{commons}@data-commons::page$property-paths.adoc[]


### PR DESCRIPTION
`Query`, `Update`, `Columns` and `ColumnName` now accept `TypedPropertyPath`

Closes #1625