### PR TITLE
Spring Cache using Cassandra

### DIFF
--- a/spring-data-cassandra/pom.xml
+++ b/spring-data-cassandra/pom.xml
@@ -86,6 +86,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-test</artifactId>
 			<scope>test</scope>

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CacheDocument.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CacheDocument.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A single persisted cache entry stored as one Cassandra row.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ * @param cacheName the logical cache name (partition key).
+ * @param cacheKey the serialized lookup key (clustering key).
+ * @param keyJson the JSON representation of the original key.
+ * @param valueJson the JSON representation of the cached value.
+ * @param expiresAt the epoch millis at which the entry expires, or {@literal null} if it never expires.
+ */
+public record CacheDocument(String cacheName, String cacheKey, String keyJson, String valueJson, @Nullable Long expiresAt) {
+	public CacheDocument {
+		Objects.requireNonNull(cacheName, "CacheName must not be null");
+		Objects.requireNonNull(cacheKey, "CacheKey must not be null");
+		Objects.requireNonNull(keyJson, "KeyJson must not be null");
+		Objects.requireNonNull(valueJson, "ValueJson must not be null");
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CacheDocumentStore.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CacheDocumentStore.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Contract for persisting and loading {@link CacheDocument cache documents} from a backing store.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ */
+public interface CacheDocumentStore {
+
+	/**
+	 * Load a single {@link CacheDocument} for the given {@code cacheName} and {@code cacheKey}.
+	 *
+	 * @param cacheName the logical cache name, must not be {@literal null}.
+	 * @param cacheKey the serialized cache key, must not be {@literal null}.
+	 * @return the matching {@link CacheDocument}, or {@literal null} if no entry exists.
+	 */
+	@Nullable
+	CacheDocument get(final String cacheName, final String cacheKey);
+
+	/**
+	 * Persist the given {@link CacheDocument}, overwriting any existing entry with the same key.
+	 *
+	 * @param document the document to persist, must not be {@literal null}.
+	 */
+	void put(final CacheDocument document);
+
+	/**
+	 * Delete the entry identified by the given {@code cacheName} and {@code cacheKey}.
+	 *
+	 * @param cacheName the logical cache name, must not be {@literal null}.
+	 * @param cacheKey the serialized cache key, must not be {@literal null}.
+	 * @return the removed {@link CacheDocument}, or {@literal null} if no entry existed.
+	 */
+	@Nullable
+	CacheDocument delete(final String cacheName, final String cacheKey);
+
+	/**
+	 * Load all {@link CacheDocument documents} for the given {@code cacheName}.
+	 *
+	 * @param cacheName the logical cache name, must not be {@literal null}.
+	 * @return a {@link List} of all matching documents, never {@literal null}.
+	 */
+	List<CacheDocument> findAll(final String cacheName);
+
+	/**
+	 * Delete all entries for the given {@code cacheName} that expired before {@code nowMillis}.
+	 *
+	 * @param cacheName the logical cache name, must not be {@literal null}.
+	 * @param nowMillis the reference time used to determine expiration, must not be {@literal null}.
+	 * @return the number of purged entries.
+	 */
+	default int purgeExpired(final String cacheName, final long nowMillis) {
+		return 0;
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CassandraBackedSpringCache.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CassandraBackedSpringCache.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.support.SimpleValueWrapper;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.cassandra.cache.event.CacheEvictedEvent;
+import org.springframework.data.cassandra.cache.event.CacheInsertedEvent;
+
+/**
+ * {@link Cache} adapter backed by a {@link CassandraCache}. Arbitrary values are wrapped in a {@link SpringCacheEntry}
+ * envelope together with their type so they can be restored after a reload from Cassandra.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ */
+public final class CassandraBackedSpringCache implements Cache {
+	private static final Logger log = LoggerFactory.getLogger(CassandraBackedSpringCache.class);
+
+	private final String name;
+	private final CassandraCache<String, SpringCacheEntry> cache;
+	private final ObjectMapper objectMapper;
+	private final Function<Object, String> keySerializer;
+	private final @Nullable ApplicationEventPublisher applicationEventPublisher;
+
+	public CassandraBackedSpringCache(final String name, final CassandraCache<String, SpringCacheEntry> cache,
+									  final ObjectMapper objectMapper) {
+		this(name, cache, objectMapper, Object::toString, null);
+	}
+
+	public CassandraBackedSpringCache(final String name, final CassandraCache<String, SpringCacheEntry> cache,
+									  final ObjectMapper objectMapper, final Function<Object, String> keySerializer,
+									  final @Nullable ApplicationEventPublisher applicationEventPublisher) {
+		this.name = Objects.requireNonNull(name, "Name must not be null");
+		this.cache = Objects.requireNonNull(cache, "Cache must not be null");
+		this.objectMapper = Objects.requireNonNull(objectMapper, "ObjectMapper must not be null");
+		this.keySerializer = Objects.requireNonNull(keySerializer, "KeySerializer must not be null");
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public Object getNativeCache() {
+		return cache;
+	}
+
+	@Override
+	public @Nullable ValueWrapper get(final Object key) {
+		final SpringCacheEntry entry = cache.get(toCacheKey(key));
+		return entry == null ? null : new SimpleValueWrapper(toValue(entry));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> @Nullable T get(Object key, @Nullable Class<T> type) {
+		final SpringCacheEntry entry = cache.get(toCacheKey(key));
+		if (entry == null) {
+			return null;
+		}
+		final Object value = toValue(entry);
+		if (type == null) {
+			return (T) value;
+		}
+		return type.isInstance(value) ? type.cast(value) : null;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T get(final Object key, final Callable<T> valueLoader) {
+		final String cacheKey = toCacheKey(key);
+		final SpringCacheEntry entry = cache.get(cacheKey);
+		if (entry != null) {
+			return (T) toValue(entry);
+		}
+		try {
+			final T loadedValue = valueLoader.call();
+			put(key, loadedValue);
+			return loadedValue;
+		} catch (Exception exception) {
+			throw new ValueRetrievalException(key, valueLoader, exception);
+		}
+	}
+
+	@Override
+	public void put(final Object key, final @Nullable Object value) {
+		if (value == null) {
+			return;
+		}
+		final String cacheKey = toCacheKey(key);
+		final SpringCacheEntry previousEntry = cache.get(cacheKey);
+		final Object previousValue = previousEntry == null ? null : toValue(previousEntry);
+		cache.put(cacheKey, new SpringCacheEntry(value.getClass().getName(), objectMapper.valueToTree(value)));
+		publishEvent(new CacheInsertedEvent<>(name, cacheKey, value, previousValue));
+	}
+
+	@Override
+	public void evict(final Object key) {
+		final String cacheKey = toCacheKey(key);
+		final SpringCacheEntry removed = cache.evict(cacheKey);
+		if (removed != null) {
+			publishEvent(new CacheEvictedEvent<>(name, cacheKey, toValue(removed)));
+		}
+	}
+
+	@Override
+	public void clear() {
+		final List<CacheEvictedEvent<String, Object>> events = new ArrayList<>();
+		for (String cacheKey : cache.keys()) {
+			final SpringCacheEntry entry = cache.get(cacheKey);
+			if (entry != null) {
+				events.add(new CacheEvictedEvent<>(name, cacheKey, toValue(entry)));
+			}
+		}
+		cache.clear();
+		events.forEach(this::publishEvent);
+	}
+
+	@Override
+	public boolean invalidate() {
+		clear();
+		return true;
+	}
+
+	/**
+	 * Remove all expired entries from this cache.
+	 *
+	 * @return the number of removed entries.
+	 */
+	public int evictExpired() {
+		final List<CacheEvictedEvent<String, Object>> events = cache.evictExpired().stream()
+				.map(entry -> new CacheEvictedEvent<>(name, entry.getKey(), toValue(entry.getValue())))
+				.toList();
+		if (!events.isEmpty()) {
+			log.info("Evicting {} expired entries from cache [{}]", events.size(), name);
+		}
+		events.forEach(this::publishEvent);
+		return events.size();
+	}
+
+	private String toCacheKey(final Object key) {
+		return keySerializer.apply(key);
+	}
+
+	private Object toValue(final SpringCacheEntry entry) {
+		try {
+			final Class<?> valueClass = Class.forName(entry.getType());
+			return objectMapper.treeToValue(entry.getValue(), valueClass);
+		} catch (ClassNotFoundException | JsonProcessingException exception) {
+			throw new IllegalStateException("Failed to deserialize cache entry for cache [%s]".formatted(name), exception);
+		}
+	}
+
+	private void publishEvent(final Object event) {
+		if (applicationEventPublisher != null) {
+			applicationEventPublisher.publishEvent(event);
+		}
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CassandraCache.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CassandraCache.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Typed cache contract whose state is persisted by a {@link CacheDocumentStore}.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ * @param <K> the cache key type.
+ * @param <V> the cache value type.
+ */
+public interface CassandraCache<K, V> {
+
+	/**
+	 * Read the value for the given {@code key}.
+	 *
+	 * @param key the cache key, must not be {@literal null}.
+	 * @return the cached value, or {@literal null} if absent or expired.
+	 */
+	@Nullable
+	V get(final K key);
+
+	/**
+	 * Write the given {@code value} for the {@code key}.
+	 *
+	 * @param key the cache key, must not be {@literal null}.
+	 * @param value the value to cache, must not be {@literal null}.
+	 */
+	void put(final K key, final V value);
+
+	/**
+	 * Remove the entry for the given {@code key}.
+	 *
+	 * @param key the cache key, must not be {@literal null}.
+	 * @return the removed value, or {@literal null} if no entry existed.
+	 */
+	@Nullable
+	V evict(final K key);
+
+	/**
+	 * Remove all entries that have expired. Returns the entries that were removed.
+	 *
+	 * @return a {@link List} of removed entries, never {@literal null}.
+	 */
+	default List<Map.Entry<K, V>> evictExpired() {
+		return List.of();
+	}
+
+	/**
+	 * Remove all entries.
+	 */
+	void clear();
+
+	/**
+	 * @param key the cache key, must not be {@literal null}.
+	 * @return whether an unexpired entry exists for the given {@code key}.
+	 */
+	boolean containsKey(final K key);
+
+	/**
+	 * @return the number of unexpired entries.
+	 */
+	int size();
+
+	/**
+	 * @return a {@link Set} of all unexpired keys.
+	 */
+	Set<K> keys();
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CassandraCacheDocumentStore.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CassandraCacheDocumentStore.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.core.cql.CqlOperations;
+import org.springframework.data.cassandra.core.cql.RowMapper;
+
+import com.datastax.oss.driver.api.core.cql.Row;
+
+/**
+ * {@link CacheDocumentStore} implementation backed by Cassandra. Documents are stored in a single table whose
+ * primary key is {@code (cache_name, cache_key)} so that repeated writes for the same key are naturally idempotent.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ */
+public final class CassandraCacheDocumentStore implements CacheDocumentStore {
+	private final CqlOperations cqlOperations;
+	private final String tableName;
+
+	public CassandraCacheDocumentStore(final CassandraOperations operations) {
+		this(operations, CassandraCacheImpl.DEFAULT_TABLE_NAME);
+	}
+
+	public CassandraCacheDocumentStore(final CassandraOperations operations, final String tableName) {
+		Objects.requireNonNull(operations, "Operations must not be null");
+		this.cqlOperations = operations.getCqlOperations();
+		this.tableName = validateTableName(tableName);
+		ensureTableExists();
+	}
+
+	@Override
+	public @Nullable CacheDocument get(final String cacheName, final String cacheKey) {
+		Objects.requireNonNull(cacheName, "CacheName must not be null");
+		Objects.requireNonNull(cacheKey, "CacheKey must not be null");
+		final List<CacheDocument> documents = cqlOperations.query(selectCql(), ROW_MAPPER, cacheName, cacheKey);
+		return documents.isEmpty() ? null : documents.get(0);
+	}
+
+	@Override
+	public void put(final CacheDocument document) {
+		Objects.requireNonNull(document, "Document must not be null");
+		cqlOperations.execute(insertCql(), document.cacheName(), document.cacheKey(), document.keyJson(),
+				document.valueJson(), document.expiresAt());
+	}
+
+	@Override
+	public @Nullable CacheDocument delete(final String cacheName, final String cacheKey) {
+		Objects.requireNonNull(cacheName, "CacheName must not be null");
+		Objects.requireNonNull(cacheKey, "CacheKey must not be null");
+		final CacheDocument document = get(cacheName, cacheKey);
+		if (document != null) {
+			cqlOperations.execute(deleteCql(), cacheName, cacheKey);
+		}
+		return document;
+	}
+
+	@Override
+	public List<CacheDocument> findAll(final String cacheName) {
+		Objects.requireNonNull(cacheName, "CacheName must not be null");
+		return cqlOperations.query(findAllCql(), ROW_MAPPER, cacheName);
+	}
+
+	@Override
+	public int purgeExpired(final String cacheName, final long nowMillis) {
+		int purged = 0;
+		for (CacheDocument document : findAll(cacheName)) {
+			if (document.expiresAt() != null && document.expiresAt() <= nowMillis) {
+				delete(cacheName, document.cacheKey());
+				purged++;
+			}
+		}
+		return purged;
+	}
+
+	private String selectCql() {
+		return """
+				SELECT cache_name, cache_key, key_json, value_json, expires_at
+				FROM "%s" WHERE cache_name = ? AND cache_key = ?
+				""".formatted(tableName);
+	}
+
+	private String insertCql() {
+		return """
+				INSERT INTO "%s" (cache_name, cache_key, key_json, value_json, expires_at)
+				VALUES (?, ?, ?, ?, ?)
+				""".formatted(tableName);
+	}
+
+	private String deleteCql() {
+		return """
+				DELETE FROM "%s" WHERE cache_name = ? AND cache_key = ?
+				""".formatted(tableName);
+	}
+
+	private String findAllCql() {
+		return """
+				SELECT cache_name, cache_key, key_json, value_json, expires_at
+				FROM "%s" WHERE cache_name = ?
+				""".formatted(tableName);
+	}
+
+	private void ensureTableExists() {
+		final String cql = """
+				CREATE TABLE IF NOT EXISTS "%s" (
+					cache_name text,
+					cache_key text,
+					key_json text,
+					value_json text,
+					expires_at bigint,
+					PRIMARY KEY (cache_name, cache_key)
+				)
+				""".formatted(tableName);
+		try {
+			cqlOperations.execute(cql);
+		} catch (RuntimeException exception) {
+			// Ignore; the schema may already be managed by the application or a schema-action setting.
+		}
+	}
+
+	private static String validateTableName(final String tableName) {
+		Objects.requireNonNull(tableName, "TableName must not be null");
+		if (!tableName.matches("[A-Za-z0-9_]+")) {
+			throw new IllegalArgumentException(
+					"Table name '%s' is not a valid Cassandra table identifier; use only alphanumeric and underscore characters"
+							.formatted(tableName));
+		}
+		return tableName;
+	}
+
+	private static final RowMapper<CacheDocument> ROW_MAPPER = (row, rowNum) -> toDocument(row);
+
+	private static CacheDocument toDocument(final Row row) {
+		return new CacheDocument(row.getString("cache_name"), row.getString("cache_key"), row.getString("key_json"),
+				row.getString("value_json"), row.isNull("expires_at") ? null : row.getLong("expires_at"));
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CassandraCacheImpl.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CassandraCacheImpl.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.jspecify.annotations.Nullable;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.cassandra.cache.event.CacheEvictedEvent;
+import org.springframework.data.cassandra.cache.event.CacheInsertedEvent;
+import org.springframework.data.cassandra.core.CassandraOperations;
+
+/**
+ * {@link CassandraCache} implementation that persists every entry in Cassandra. Each cache instance is confined to a
+ * single logical cache name identified by the {@code cacheName} partition key.
+ * <p>
+ * Entries expire according to the configured {@code entryTtl}. The read path treats any entry whose {@code expires_at}
+ * is in the past as absent without deleting it immediately; expired rows are removed by {@link #evictExpired()}.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ * @param <K> the cache key type.
+ * @param <V> the cache value type.
+ */
+public final class CassandraCacheImpl<K, V> implements CassandraCache<K, V> {
+	public static final String DEFAULT_TABLE_NAME = "spring_cache_entries";
+
+	private final String cacheName;
+	private final Class<K> keyType;
+	private final Class<V> valueType;
+	private final CacheDocumentStore cacheStore;
+	private final ObjectMapper objectMapper;
+	private final @Nullable ApplicationEventPublisher applicationEventPublisher;
+	private final @Nullable Duration entryTtl;
+	private final ReentrantLock ioLock = new ReentrantLock();
+
+	public CassandraCacheImpl(final String cacheName, final Class<K> keyType, final Class<V> valueType,
+							 final CassandraOperations cassandraOperations) {
+		this(cacheName, keyType, valueType, new CassandraCacheDocumentStore(cassandraOperations), defaultObjectMapper(),
+				null, null);
+	}
+
+	public CassandraCacheImpl(final String cacheName, final Class<K> keyType, final Class<V> valueType,
+							  final CassandraOperations cassandraOperations, final String tableName) {
+		this(cacheName, keyType, valueType, new CassandraCacheDocumentStore(cassandraOperations, tableName),
+				defaultObjectMapper(), null, null);
+	}
+
+	public CassandraCacheImpl(final String cacheName, final Class<K> keyType, final Class<V> valueType,
+							  final CassandraOperations cassandraOperations, final String tableName, final ObjectMapper objectMapper,
+							  final @Nullable ApplicationEventPublisher applicationEventPublisher, final @Nullable Duration entryTtl) {
+		this(cacheName, keyType, valueType, new CassandraCacheDocumentStore(cassandraOperations, tableName), objectMapper,
+				applicationEventPublisher, entryTtl);
+	}
+
+	public CassandraCacheImpl(final String cacheName, final Class<K> keyType, final Class<V> valueType,
+							  final CacheDocumentStore cacheStore) {
+		this(cacheName, keyType, valueType, cacheStore, defaultObjectMapper(), null, null);
+	}
+
+	public CassandraCacheImpl(final String cacheName, final Class<K> keyType, final Class<V> valueType,
+							  final CacheDocumentStore cacheStore, final ObjectMapper objectMapper) {
+		this(cacheName, keyType, valueType, cacheStore, objectMapper, null, null);
+	}
+
+	public CassandraCacheImpl(final String cacheName, final Class<K> keyType, final Class<V> valueType,
+	                          final CacheDocumentStore cacheStore, final ObjectMapper objectMapper,
+	                          final @Nullable ApplicationEventPublisher applicationEventPublisher, final @Nullable Duration entryTtl) {
+		Objects.requireNonNull(keyType, "KeyType must not be null");
+		Objects.requireNonNull(valueType, "ValueType must not be null");
+		Objects.requireNonNull(cacheStore, "CacheStore must not be null");
+		Objects.requireNonNull(objectMapper, "ObjectMapper must not be null");
+		if (entryTtl != null && entryTtl.isNegative()) {
+			throw new IllegalArgumentException("Entry TTL must not be negative");
+		}
+		this.cacheName = validateCacheName(cacheName);
+		this.keyType = keyType;
+		this.valueType = valueType;
+		this.cacheStore = cacheStore;
+		this.objectMapper = objectMapper;
+		this.applicationEventPublisher = applicationEventPublisher;
+		this.entryTtl = entryTtl;
+	}
+
+	@Override
+	public @Nullable V get(final K key) {
+		ioLock.lock();
+		try {
+			final CacheDocument document = cacheStore.get(cacheName, toStoredKey(key));
+			if (document == null || isExpired(document, nowMillis())) {
+				return null;
+			}
+			return fromStoredValue(document.valueJson());
+		} finally {
+			ioLock.unlock();
+		}
+	}
+
+	@Override
+	public void put(K key, V value) {
+		CacheInsertedEvent<K, V> event;
+		ioLock.lock();
+		try {
+			final long nowMillis = nowMillis();
+			final String storedKey = toStoredKey(key);
+			final CacheDocument previousDocument = cacheStore.get(cacheName, storedKey);
+			final V previousValue = previousDocument == null || isExpired(previousDocument, nowMillis)
+					? null
+					: fromStoredValue(previousDocument.valueJson());
+			cacheStore.put(new CacheDocument(cacheName, storedKey, storedKey, toStoredValue(value),
+					resolveExpiresAt(nowMillis)));
+			event = new CacheInsertedEvent<>(cacheName, key, value, previousValue);
+		} finally {
+			ioLock.unlock();
+		}
+		fireEvent(event);
+	}
+
+	@Override
+	public @Nullable V evict(final K key) {
+		CacheEvictedEvent<K, V> event;
+		ioLock.lock();
+		try {
+			final CacheDocument removedDocument = cacheStore.delete(cacheName, toStoredKey(key));
+			if (removedDocument == null) {
+				return null;
+			}
+			event = new CacheEvictedEvent<>(cacheName, key, fromStoredValue(removedDocument.valueJson()));
+		} finally {
+			ioLock.unlock();
+		}
+		fireEvent(event);
+		return event.getValue();
+	}
+
+	@Override
+	public List<Map.Entry<K, V>> evictExpired() {
+		final List<CacheEvictedEvent<K, V>> events = new ArrayList<>();
+		ioLock.lock();
+		try {
+			long nowMillis = nowMillis();
+			for (CacheDocument document : cacheStore.findAll(cacheName)) {
+				if (!isExpired(document, nowMillis)) {
+					continue;
+				}
+				final CacheDocument removedDocument = cacheStore.delete(cacheName, document.cacheKey());
+				if (removedDocument != null) {
+					events.add(new CacheEvictedEvent<>(cacheName, fromStoredKey(removedDocument.keyJson()),
+							fromStoredValue(removedDocument.valueJson())));
+				}
+			}
+		} finally {
+			ioLock.unlock();
+		}
+		events.forEach(this::fireEvent);
+		return events.stream().map(event -> Map.entry(event.getKey(), event.getValue())).toList();
+	}
+
+	@Override
+	public void clear() {
+		final List<CacheEvictedEvent<K, V>> events = new ArrayList<>();
+		ioLock.lock();
+		try {
+			for (CacheDocument document : cacheStore.findAll(cacheName)) {
+				final CacheDocument removedDocument = cacheStore.delete(cacheName, document.cacheKey());
+				if (removedDocument != null) {
+					events.add(new CacheEvictedEvent<>(cacheName, fromStoredKey(removedDocument.keyJson()),
+							fromStoredValue(removedDocument.valueJson())));
+				}
+			}
+		} finally {
+			ioLock.unlock();
+		}
+		events.forEach(this::fireEvent);
+	}
+
+	@Override
+	public boolean containsKey(K key) {
+		ioLock.lock();
+		try {
+			final CacheDocument document = cacheStore.get(cacheName, toStoredKey(key));
+			return document != null && !isExpired(document, nowMillis());
+		} finally {
+			ioLock.unlock();
+		}
+	}
+
+	@Override
+	public int size() {
+		ioLock.lock();
+		try {
+			final long nowMillis = nowMillis();
+			return (int) cacheStore.findAll(cacheName).stream()
+					.filter(document -> !isExpired(document, nowMillis))
+					.count();
+		} finally {
+			ioLock.unlock();
+		}
+	}
+
+	@Override
+	public Set<K> keys() {
+		ioLock.lock();
+		try {
+			final long nowMillis = nowMillis();
+			final LinkedHashSet<K> keys = new LinkedHashSet<>();
+			cacheStore.findAll(cacheName).stream()
+					.filter(document -> !isExpired(document, nowMillis))
+					.sorted(Comparator.comparing(CacheDocument::cacheKey))
+					.map(document -> fromStoredKey(document.keyJson()))
+					.forEach(keys::add);
+			return keys;
+		} finally {
+			ioLock.unlock();
+		}
+	}
+
+	/**
+	 * Create an {@link ObjectMapper} pre-configured for typical cache value serialization. All modules on the classpath
+	 * are registered (for example Java time support) and unknown properties are ignored on deserialization.
+	 *
+	 * @return a configured {@link ObjectMapper}, never {@literal null}.
+	 */
+	public static ObjectMapper defaultObjectMapper() {
+		return new ObjectMapper()
+				.findAndRegisterModules()
+				.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+				.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+	}
+
+	private @Nullable Long resolveExpiresAt(final long nowMillis) {
+		if (entryTtl == null || entryTtl.isZero()) {
+			return null;
+		}
+		return nowMillis + Math.max(entryTtl.toMillis(), 1L);
+	}
+
+	private boolean isExpired(final CacheDocument document, final long nowMillis) {
+		return document.expiresAt() != null && document.expiresAt() <= nowMillis;
+	}
+
+	private String toStoredKey(final K key) {
+		return writeValue(key);
+	}
+
+	private K fromStoredKey(final String keyJson) {
+		return readValue(keyJson, keyType);
+	}
+
+	private String toStoredValue(final V value) {
+		return writeValue(value);
+	}
+
+	private V fromStoredValue(final String valueJson) {
+		return readValue(valueJson, valueType);
+	}
+
+	private String writeValue(final Object value) {
+		try {
+			return objectMapper.writeValueAsString(value);
+		} catch (JsonProcessingException exception) {
+			throw new IllegalStateException("Failed to serialize cache value", exception);
+		}
+	}
+
+	private <T> T readValue(final String json, final Class<T> type) {
+		try {
+			return objectMapper.readValue(json, type);
+		} catch (JsonProcessingException exception) {
+			throw new IllegalStateException("Failed to deserialize cache value", exception);
+		}
+	}
+
+	private long nowMillis() {
+		return System.currentTimeMillis();
+	}
+
+	private void fireEvent(final Object event) {
+		if (applicationEventPublisher != null) {
+			applicationEventPublisher.publishEvent(event);
+		}
+	}
+
+	private static String validateCacheName(final String cacheName) {
+		Objects.requireNonNull(cacheName, "CacheName must not be null");
+		if (cacheName.isBlank() || !cacheName
+				.matches("[A-Za-z0-9_\\-.]+")) {
+			throw new IllegalArgumentException(
+					"Cache name '%s' may only contain letters, digits, dots, dashes, and underscores".formatted(cacheName));
+		}
+		return cacheName;
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CassandraCacheManager.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/CassandraCacheManager.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jspecify.annotations.Nullable;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.cassandra.core.CassandraOperations;
+
+/**
+ * {@link CacheManager} that stores all managed cache entries in Cassandra. Every named cache shares the same
+ * Cassandra table, using the cache name as the partition key, so that all application instances observe the same
+ * cache state.
+ * <p>
+ * Expired entries can be removed on a background thread by supplying a positive {@code clearInterval}. The returned
+ * manager must be {@link #close() closed} (for example as a {@code destroy-method}) to stop that thread.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ */
+public final class CassandraCacheManager implements CacheManager, AutoCloseable {
+	private final Function<String, CassandraCache<String, SpringCacheEntry>> cacheFactory;
+	private final ObjectMapper objectMapper;
+	private final Function<Object, String> keySerializer;
+	private final @Nullable ApplicationEventPublisher applicationEventPublisher;
+	private final @Nullable Duration entryTtl;
+	private final ConcurrentHashMap<String, Cache> caches = new ConcurrentHashMap<>();
+	private final @Nullable ScheduledExecutorService clearExecutor;
+
+	public CassandraCacheManager(final Function<String, CassandraCache<String, SpringCacheEntry>> cacheFactory,
+								 final ObjectMapper objectMapper) {
+		this(cacheFactory, objectMapper, Object::toString, null, null, null);
+	}
+
+	public CassandraCacheManager(final Function<String, CassandraCache<String, SpringCacheEntry>> cacheFactory,
+								 final ObjectMapper objectMapper, final Function<Object, String> keySerializer,
+								 final @Nullable Duration clearInterval, final @Nullable ApplicationEventPublisher applicationEventPublisher,
+								 final @Nullable Duration entryTtl) {
+		this.cacheFactory = Objects.requireNonNull(cacheFactory, "CacheFactory must not be null");
+		this.objectMapper = Objects.requireNonNull(objectMapper, "ObjectMapper must not be null");
+		this.keySerializer = Objects.requireNonNull(keySerializer, "KeySerializer must not be null");
+		this.applicationEventPublisher = applicationEventPublisher;
+		this.entryTtl = entryTtl;
+		this.clearExecutor = schedulePeriodicClear(clearInterval);
+	}
+
+	public CassandraCacheManager(final CassandraOperations cassandraOperations) {
+		this(cassandraOperations, CassandraCacheImpl.DEFAULT_TABLE_NAME);
+	}
+
+	public CassandraCacheManager(final CassandraOperations cassandraOperations, final String tableName) {
+		this(cassandraOperations, tableName, CassandraCacheImpl.defaultObjectMapper(), Object::toString, null, null, null);
+	}
+
+	public CassandraCacheManager(final CassandraOperations cassandraOperations, final String tableName, final ObjectMapper objectMapper,
+								 final Function<Object, String> keySerializer, final @Nullable Duration clearInterval,
+								 final @Nullable ApplicationEventPublisher applicationEventPublisher, final @Nullable Duration entryTtl) {
+		this(cacheName -> new CassandraCacheImpl<>(cacheName, String.class, SpringCacheEntry.class,
+				new CassandraCacheDocumentStore(cassandraOperations, tableName), objectMapper,
+				applicationEventPublisher, entryTtl),
+				objectMapper, keySerializer, clearInterval, applicationEventPublisher, entryTtl);
+	}
+
+	@Override
+	public Cache getCache(final String name) {
+		return caches.computeIfAbsent(name,
+				cacheName -> new CassandraBackedSpringCache(cacheName, cacheFactory.apply(cacheName), objectMapper,
+						keySerializer, applicationEventPublisher));
+	}
+
+	@Override
+	public Collection<String> getCacheNames() {
+		return List.copyOf(caches.keySet());
+	}
+
+	/**
+	 * Clear all managed caches.
+	 */
+	public void clearAll() {
+		caches.values().forEach(Cache::clear);
+	}
+
+	/**
+	 * Remove all expired entries from all managed caches.
+	 *
+	 * @return the number of removed entries.
+	 */
+	public int evictExpired() {
+		return caches.values().stream()
+				.mapToInt(cache -> cache instanceof CassandraBackedSpringCache cassandraCache
+						? cassandraCache.evictExpired()
+						: 0)
+				.sum();
+	}
+
+	/**
+	 * @return the number of currently managed caches.
+	 */
+	public int getCacheCount() {
+		return caches.size();
+	}
+
+	/**
+	 * @return whether a periodic cleanup task is scheduled.
+	 */
+	public boolean isPeriodicClearEnabled() {
+		return clearExecutor != null;
+	}
+
+	@Override
+	public void close() {
+		if (clearExecutor != null) {
+			clearExecutor.shutdownNow();
+		}
+	}
+
+	private @Nullable ScheduledExecutorService schedulePeriodicClear(final @Nullable Duration interval) {
+		if (interval == null || interval.isZero()) {
+			return null;
+		}
+		if (interval.isNegative()) {
+			throw new IllegalArgumentException("Clear interval must not be negative");
+		}
+		if (entryTtl != null && entryTtl.isNegative()) {
+			throw new IllegalArgumentException("Entry TTL must not be negative");
+		}
+		final long delayMillis = Math.max(interval.toMillis(), 1L);
+		final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+			final Thread thread = new Thread(runnable, "cassandra-cache-expirer");
+			thread.setDaemon(true);
+			return thread;
+		});
+		executor.scheduleWithFixedDelay(this::evictExpired, delayMillis, delayMillis, TimeUnit.MILLISECONDS);
+		return executor;
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/SpringCacheEntry.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/SpringCacheEntry.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Internal envelope that pairs the value type with its serialized {@link JsonNode} so that arbitrary Spring Cache
+ * values can be stored and restored through the shared Cassandra store.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ */
+public final class SpringCacheEntry {
+	private final String type;
+	private final JsonNode value;
+
+	@JsonCreator
+	public SpringCacheEntry(final @JsonProperty("type") String type, final @JsonProperty("value") JsonNode value) {
+		this.type = Objects.requireNonNull(type, "Type must not be null");
+		this.value = Objects.requireNonNull(value, "Value must not be null");
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public JsonNode getValue() {
+		return value;
+	}
+
+	@Override
+	public boolean equals(final Object other) {
+		if (this == other) {
+			return true;
+		}
+		if (!(other instanceof SpringCacheEntry that)) {
+			return false;
+		}
+		return this.type.equals(that.type) && this.value.equals(that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(type, value);
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/event/CacheEvent.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/event/CacheEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache.event;
+
+import java.time.Instant;
+
+/**
+ * Base contract for cache lifecycle events published by the Cassandra-backed cache support.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ * @param <K> the cache key type.
+ * @param <V> the cache value type.
+ */
+public sealed interface CacheEvent<K, V> permits CacheInsertedEvent, CacheEvictedEvent {
+
+	String getCacheName();
+
+	K getKey();
+
+	V getValue();
+
+	Instant getOccurredAt();
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/event/CacheEvictedEvent.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/event/CacheEvictedEvent.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache.event;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Published when a value is removed from the cache, either explicitly, through a {@code clear} or by expiry eviction.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ * @param <K> the cache key type.
+ * @param <V> the cache value type.
+ */
+public final class CacheEvictedEvent<K, V> implements CacheEvent<K, V> {
+	private final String cacheName;
+	private final K key;
+	private final V value;
+	private final Instant occurredAt;
+
+	public CacheEvictedEvent(final String cacheName, final K key, final V value) {
+		this(cacheName, key, value, Instant.now());
+	}
+
+	public CacheEvictedEvent(final String cacheName, final K key, final V value, final Instant occurredAt) {
+		this.cacheName = Objects.requireNonNull(cacheName, "CacheName must not be null");
+		this.key = Objects.requireNonNull(key, "Key must not be null");
+		this.value = Objects.requireNonNull(value, "Value must not be null");
+		this.occurredAt = Objects.requireNonNull(occurredAt, "OccurredAt must not be null");
+	}
+
+	@Override
+	public String getCacheName() {
+		return cacheName;
+	}
+
+	@Override
+	public K getKey() {
+		return key;
+	}
+
+	@Override
+	public V getValue() {
+		return value;
+	}
+
+	@Override
+	public Instant getOccurredAt() {
+		return occurredAt;
+	}
+
+	@Override
+	public boolean equals(final Object other) {
+		if (this == other) {
+			return true;
+		}
+		if (!(other instanceof CacheEvictedEvent<?, ?> that)) {
+			return false;
+		}
+		return this.cacheName.equals(that.cacheName) && this.key.equals(that.key) && this.value.equals(that.value)
+				&& this.occurredAt.equals(that.occurredAt);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(cacheName, key, value, occurredAt);
+	}
+
+	@Override
+	public String toString() {
+		return "CacheEvictedEvent[cacheName=%s, key=%s, value=%s, occurredAt=%s]".formatted(cacheName, key, value,
+				occurredAt);
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/event/CacheInsertedEvent.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/event/CacheInsertedEvent.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache.event;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Published when a value is written to the cache. Carries the previous value, if one existed.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ * @param <K> the cache key type.
+ * @param <V> the cache value type.
+ */
+public final class CacheInsertedEvent<K, V> implements CacheEvent<K, V> {
+	private final String cacheName;
+	private final K key;
+	private final V value;
+	private final @Nullable V previousValue;
+	private final Instant occurredAt;
+
+	public CacheInsertedEvent(final String cacheName, final K key, final V value) {
+		this(cacheName, key, value, null, Instant.now());
+	}
+
+	public CacheInsertedEvent(final String cacheName, final K key, final V value, final @Nullable V previousValue) {
+		this(cacheName, key, value, previousValue, Instant.now());
+	}
+
+	public CacheInsertedEvent(final String cacheName, final K key, final V value, final @Nullable V previousValue, final Instant occurredAt) {
+		this.cacheName = Objects.requireNonNull(cacheName, "CacheName must not be null");
+		this.key = Objects.requireNonNull(key, "Key must not be null");
+		this.value = Objects.requireNonNull(value, "Value must not be null");
+		this.previousValue = previousValue;
+		this.occurredAt = Objects.requireNonNull(occurredAt, "OccurredAt must not be null");
+	}
+
+	@Override
+	public String getCacheName() {
+		return cacheName;
+	}
+
+	@Override
+	public K getKey() {
+		return key;
+	}
+
+	@Override
+	public V getValue() {
+		return value;
+	}
+
+	public @Nullable V getPreviousValue() {
+		return previousValue;
+	}
+
+	@Override
+	public Instant getOccurredAt() {
+		return occurredAt;
+	}
+
+	@Override
+	public boolean equals(final Object other) {
+		if (this == other) {
+			return true;
+		}
+		if (!(other instanceof CacheInsertedEvent<?, ?> that)) {
+			return false;
+		}
+		return this.cacheName.equals(that.cacheName) && this.key.equals(that.key) && this.value.equals(that.value)
+				&& Objects.equals(this.previousValue, that.previousValue) && this.occurredAt.equals(that.occurredAt);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(cacheName, key, value, previousValue, occurredAt);
+	}
+
+	@Override
+	public String toString() {
+		return "CacheInsertedEvent[cacheName=%s, key=%s, value=%s, previousValue=%s, occurredAt=%s]".formatted(cacheName,
+				key, value, previousValue, occurredAt);
+	}
+}

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/event/package-info.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/event/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Application events published by the Cassandra-backed cache support.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ */
+@org.jspecify.annotations.NullMarked
+package org.springframework.data.cassandra.cache.event;

--- a/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/package-info.java
+++ b/spring-data-cassandra/src/main/java/org/springframework/data/cassandra/cache/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Cassandra-backed Spring Cache support. Provides a {@link org.springframework.cache.CacheManager} and
+ * {@link org.springframework.cache.Cache} that store entries in Cassandra for shared, persistent caching.
+ *
+ * @author Anıl Şenocak
+ * @since 5.2
+ */
+@org.jspecify.annotations.NullMarked
+package org.springframework.data.cassandra.cache;

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/cache/CassandraBackedSpringCacheUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/cache/CassandraBackedSpringCacheUnitTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cache.Cache;
+import org.springframework.data.cassandra.cache.event.CacheEvictedEvent;
+import org.springframework.data.cassandra.cache.event.CacheInsertedEvent;
+
+/**
+ * Unit tests for {@link CassandraBackedSpringCache}.
+ *
+ * @author Anıl Şenocak
+ */
+class CassandraBackedSpringCacheUnitTests {
+
+	@Test
+	void reloadsTypedValuesFromManagedCaches() {
+
+		Map<String, InMemoryCassandraCache> backingCaches = new LinkedHashMap<>();
+		Cache cache = managerUsing(backingCaches).getCache("users");
+
+		cache.put("42", new CachedUser("42", "ada"));
+
+		Object value = managerUsing(backingCaches).getCache("users").get("42").get();
+
+		assertThat(value).isInstanceOf(CachedUser.class).isEqualTo(new CachedUser("42", "ada"));
+	}
+
+	@Test
+	void usesLoaderOnlyWhenKeyIsMissing() {
+
+		Cache cache = managerUsing(new LinkedHashMap<>()).getCache("users");
+		CachedUser loaded = cache.get("42", () -> new CachedUser("42", "ada"));
+
+		assertThat(loaded).isEqualTo(new CachedUser("42", "ada"));
+		assertThat(cache.get("42", CachedUser.class)).isEqualTo(loaded);
+		CachedUser cached = cache.get("42", () -> {
+			throw new IllegalStateException("not called");
+		});
+		assertThat(cached).isEqualTo(loaded);
+	}
+
+	@Test
+	void returnsWrappedTypedAndUntypedValues() {
+
+		InMemoryCassandraCache backingCache = new InMemoryCassandraCache();
+		CassandraBackedSpringCache cache = new CassandraBackedSpringCache("users", backingCache,
+				CassandraCacheImpl.defaultObjectMapper());
+		CachedUser user = new CachedUser("42", "ada");
+
+		cache.put("42", user);
+
+		assertThat(cache.getName()).isEqualTo("users");
+		assertThat(cache.getNativeCache()).isSameAs(backingCache);
+		assertThat(cache.get("42").get()).isEqualTo(user);
+		assertThat(cache.get("42", CachedUser.class)).isEqualTo(user);
+		assertThat(cache.get("42", (Class<Object>) null)).isEqualTo(user);
+		assertThat(cache.get("42", String.class)).isNull();
+		assertThat(cache.get("missing")).isNull();
+	}
+
+	@Test
+	void doesNotCacheNullValues() {
+
+		InMemoryCassandraCache backingCache = new InMemoryCassandraCache();
+		CassandraBackedSpringCache cache = new CassandraBackedSpringCache("users", backingCache,
+				CassandraCacheImpl.defaultObjectMapper());
+
+		cache.put("42", null);
+
+		assertThat(backingCache.containsKey("42")).isFalse();
+		assertThat(cache.get("42")).isNull();
+	}
+
+	@Test
+	void wrapsLoaderExceptions() {
+
+		CassandraBackedSpringCache cache = new CassandraBackedSpringCache("users", new InMemoryCassandraCache(),
+				CassandraCacheImpl.defaultObjectMapper());
+		java.util.concurrent.		Callable<CachedUser> failingLoader = () -> {
+			throw new IllegalStateException("boom");
+		};
+
+		Cache.ValueRetrievalException exception = catchThrowableOfType(() -> cache.get("42", failingLoader),
+				Cache.ValueRetrievalException.class);
+
+		assertThat(exception.getCause()).isInstanceOf(IllegalStateException.class).hasMessage("boom");
+	}
+
+	@Test
+	void evictsClearsAndInvalidatesEntries() {
+
+		InMemoryCassandraCache backingCache = new InMemoryCassandraCache();
+		CassandraBackedSpringCache cache = new CassandraBackedSpringCache("users", backingCache,
+				CassandraCacheImpl.defaultObjectMapper());
+
+		cache.put("42", new CachedUser("42", "ada"));
+		cache.evict("42");
+
+		assertThat(cache.get("42")).isNull();
+
+		cache.put("43", new CachedUser("43", "grace"));
+		cache.clear();
+
+		assertThat(backingCache.size()).isZero();
+
+		cache.put("44", new CachedUser("44", "katherine"));
+
+		assertThat(cache.invalidate()).isTrue();
+		assertThat(backingCache.size()).isZero();
+	}
+
+	@Test
+	void publishesDecodedSpringCacheEvents() {
+
+		RecordingApplicationEventPublisher publisher = new RecordingApplicationEventPublisher();
+		CassandraBackedSpringCache cache = new CassandraBackedSpringCache("users", new InMemoryCassandraCache(),
+				CassandraCacheImpl.defaultObjectMapper(), Object::toString, publisher);
+
+		cache.put("42", new CachedUser("42", "ada"));
+		cache.put("42", new CachedUser("42", "grace"));
+		cache.evict("42");
+
+		assertThat(publisher.events.get(0)).isInstanceOf(CacheInsertedEvent.class);
+		CacheInsertedEvent<String, Object> inserted = (CacheInsertedEvent<String, Object>) publisher.events.get(0);
+		assertThat(inserted.getValue()).isEqualTo(new CachedUser("42", "ada"));
+		assertThat(inserted.getPreviousValue()).isNull();
+
+		assertThat(publisher.events.get(1)).isInstanceOf(CacheInsertedEvent.class);
+		CacheInsertedEvent<String, Object> updated = (CacheInsertedEvent<String, Object>) publisher.events.get(1);
+		assertThat(updated.getPreviousValue()).isEqualTo(new CachedUser("42", "ada"));
+
+		assertThat(publisher.events.get(2)).isInstanceOf(CacheEvictedEvent.class);
+		CacheEvictedEvent<String, Object> evicted = (CacheEvictedEvent<String, Object>) publisher.events.get(2);
+		assertThat(evicted.getValue()).isEqualTo(new CachedUser("42", "grace"));
+	}
+
+	private CassandraCacheManager managerUsing(Map<String, InMemoryCassandraCache> backingCaches) {
+
+		return new CassandraCacheManager(
+				cacheName -> backingCaches.computeIfAbsent(cacheName, ignored -> new InMemoryCassandraCache()),
+				CassandraCacheImpl.defaultObjectMapper());
+	}
+
+	record CachedUser(String id, String username) {
+	}
+
+	static final class InMemoryCassandraCache implements CassandraCache<String, SpringCacheEntry> {
+
+		private final Map<String, SpringCacheEntry> entries = new LinkedHashMap<>();
+
+		@Override
+		public SpringCacheEntry get(String key) {
+			return entries.get(key);
+		}
+
+		@Override
+		public void put(String key, SpringCacheEntry value) {
+			entries.put(key, value);
+		}
+
+		@Override
+		public SpringCacheEntry evict(String key) {
+			return entries.remove(key);
+		}
+
+		@Override
+		public void clear() {
+			entries.clear();
+		}
+
+		@Override
+		public boolean containsKey(String key) {
+			return entries.containsKey(key);
+		}
+
+		@Override
+		public int size() {
+			return entries.size();
+		}
+
+		@Override
+		public Set<String> keys() {
+			return entries.keySet();
+		}
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/cache/CassandraCacheDocumentStoreUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/cache/CassandraCacheDocumentStoreUnitTests.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.data.cassandra.core.cql.CqlOperations;
+import org.springframework.data.cassandra.core.cql.RowMapper;
+
+import com.datastax.oss.driver.api.core.cql.Row;
+
+/**
+ * Unit tests for {@link CassandraCacheDocumentStore}.
+ *
+ * @author Anıl Şenocak
+ */
+class CassandraCacheDocumentStoreUnitTests {
+
+	private static final String TABLE_NAME = "test_cache";
+
+	private CqlOperations cqlOperations;
+	private CassandraCacheDocumentStore store;
+
+	@BeforeEach
+	void setUp() {
+
+		CassandraOperations operations = mock(CassandraOperations.class);
+		this.cqlOperations = mock(CqlOperations.class);
+		when(operations.getCqlOperations()).thenReturn(this.cqlOperations);
+
+		this.store = new CassandraCacheDocumentStore(operations, TABLE_NAME);
+	}
+
+	@Test
+	void createsBackingTableOnConstruction() {
+
+		verify(cqlOperations).execute(contains("CREATE TABLE IF NOT EXISTS"));
+		verify(cqlOperations).execute(contains('"' + TABLE_NAME + '"'));
+	}
+
+	@Test
+	void rejectsInvalidTableNames() {
+
+		CassandraOperations operations = mock(CassandraOperations.class);
+		when(operations.getCqlOperations()).thenReturn(mock(CqlOperations.class));
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new CassandraCacheDocumentStore(operations, "user_cache-it"));
+		assertThatIllegalArgumentException().isThrownBy(() -> new CassandraCacheDocumentStore(operations, "user cache"));
+	}
+
+	@Test
+	void getReturnsNullForMissingKey() {
+
+		when(cqlOperations.query(anyString(), any(RowMapper.class), any(Object[].class))).thenReturn(List.of());
+
+		assertThat(store.get("users", "missing")).isNull();
+	}
+
+	@Test
+	void getMapsRowToDocument() {
+
+		CacheDocument document = new CacheDocument("users", "1", "{\"id\":\"1\"}", "{\"username\":\"ada\"}",
+				System.currentTimeMillis());
+
+		Row row = row(document);
+		stubRows(row);
+
+		CacheDocument result = store.get("users", "1");
+
+		assertThat(result).isEqualTo(document);
+	}
+
+	@Test
+	void getMapsNullExpirationToNull() {
+
+		CacheDocument document = new CacheDocument("users", "1", "{\"id\":\"1\"}", "{\"username\":\"ada\"}", null);
+
+		Row row = row(document);
+		stubRows(row);
+
+		assertThat(store.get("users", "1").expiresAt()).isNull();
+	}
+
+	@Test
+	void putExecutesInsertWithDocumentColumns() {
+
+		CacheDocument document = new CacheDocument("users", "1", "{\"id\":\"1\"}", "{\"username\":\"ada\"}", 42L);
+
+		store.put(document);
+
+		verify(cqlOperations).execute(contains("INSERT INTO"), eq("users"), eq("1"), eq("{\"id\":\"1\"}"),
+				eq("{\"username\":\"ada\"}"), eq(42L));
+	}
+
+	@Test
+	void deleteRemovesExistingDocumentAndReturnsIt() {
+
+		CacheDocument document = new CacheDocument("users", "1", "{\"id\":\"1\"}", "{\"username\":\"ada\"}", null);
+
+		Row row = row(document);
+		stubRows(row);
+
+		assertThat(store.delete("users", "1")).isEqualTo(document);
+		verify(cqlOperations).execute(contains("DELETE FROM"), eq("users"), eq("1"));
+	}
+
+	@Test
+	void deleteDoesNotTouchMissingKey() {
+
+		when(cqlOperations.query(anyString(), any(RowMapper.class), any(Object[].class))).thenReturn(List.of());
+
+		assertThat(store.delete("users", "missing")).isNull();
+		verify(cqlOperations, never()).execute(contains("DELETE FROM"), any(), any());
+	}
+
+	@Test
+	void findAllReturnsEveryDocumentForCacheName() {
+
+		CacheDocument first = new CacheDocument("users", "1", "{\"id\":\"1\"}", "{\"username\":\"ada\"}", null);
+		CacheDocument second = new CacheDocument("users", "2", "{\"id\":\"2\"}", "{\"username\":\"grace\"}", null);
+
+		Row firstRow = row(first);
+		Row secondRow = row(second);
+		stubRows(firstRow, secondRow);
+
+		assertThat(store.findAll("users")).containsExactly(first, second);
+	}
+
+	@Test
+	void purgeExpiredDeletesOnlyExpiredDocuments() {
+
+		CacheDocument expired = new CacheDocument("users", "1", "{\"id\":\"1\"}", "{\"username\":\"ada\"}", 50L);
+		CacheDocument fresh = new CacheDocument("users", "2", "{\"id\":\"2\"}", "{\"username\":\"grace\"}", 200L);
+
+		Row expiredRow = row(expired);
+		Row freshRow = row(fresh);
+		stubRows(expiredRow, freshRow);
+
+		assertThat(store.purgeExpired("users", 100L)).isEqualTo(1);
+		verify(cqlOperations).execute(contains("DELETE FROM"), eq("users"), eq("1"));
+		verify(cqlOperations, never()).execute(contains("DELETE FROM"), eq("users"), eq("2"));
+	}
+
+	private void stubRows(Row... rows) {
+
+		when(cqlOperations.query(anyString(), any(RowMapper.class), any(Object[].class))).thenAnswer(invocation -> {
+
+			RowMapper<CacheDocument> rowMapper = invocation.getArgument(1);
+
+			List<CacheDocument> result = new ArrayList<>();
+			for (int i = 0; i < rows.length; i++) {
+				result.add(rowMapper.mapRow(rows[i], i));
+			}
+			return result;
+		});
+	}
+
+	private Row row(CacheDocument document) {
+
+		Row row = mock(Row.class);
+		when(row.getString("cache_name")).thenReturn(document.cacheName());
+		when(row.getString("cache_key")).thenReturn(document.cacheKey());
+		when(row.getString("key_json")).thenReturn(document.keyJson());
+		when(row.getString("value_json")).thenReturn(document.valueJson());
+		when(row.isNull("expires_at")).thenReturn(document.expiresAt() == null);
+		if (document.expiresAt() != null) {
+			when(row.getLong("expires_at")).thenReturn(document.expiresAt());
+		}
+		return row;
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/cache/CassandraCacheImplUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/cache/CassandraCacheImplUnitTests.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.cassandra.cache.event.CacheEvictedEvent;
+import org.springframework.data.cassandra.cache.event.CacheInsertedEvent;
+
+/**
+ * Unit tests for {@link CassandraCacheImpl}.
+ *
+ * @author Anıl Şenocak
+ */
+class CassandraCacheImplUnitTests {
+
+	@Test
+	void persistsAndReloadsValues() {
+
+		InMemoryCacheDocumentStore store = new InMemoryCacheDocumentStore();
+		CassandraCacheImpl<String, CachedUser> cache = newUserCache(store, null, null);
+
+		cache.put("1", new CachedUser("1", "ada"));
+
+		CassandraCacheImpl<String, CachedUser> reloaded = newUserCache(store, null, null);
+
+		assertThat(reloaded.get("1")).isEqualTo(new CachedUser("1", "ada"));
+		assertThat(reloaded.containsKey("1")).isTrue();
+		assertThat(reloaded.keys()).containsExactly("1");
+	}
+
+	@Test
+	void firesInsertedAndEvictedEvents() {
+
+		RecordingApplicationEventPublisher publisher = new RecordingApplicationEventPublisher();
+		CassandraCacheImpl<String, CachedUser> cache = newUserCache(new InMemoryCacheDocumentStore(), publisher, null);
+
+		cache.put("1", new CachedUser("1", "ada"));
+		cache.put("1", new CachedUser("1", "grace"));
+		cache.evict("1");
+
+		assertThat(publisher.events.get(0)).isInstanceOf(CacheInsertedEvent.class);
+		CacheInsertedEvent<String, CachedUser> inserted = (CacheInsertedEvent<String, CachedUser>) publisher.events.get(0);
+		assertThat(inserted.getCacheName()).isEqualTo("users");
+		assertThat(inserted.getKey()).isEqualTo("1");
+		assertThat(inserted.getValue()).isEqualTo(new CachedUser("1", "ada"));
+		assertThat(inserted.getPreviousValue()).isNull();
+
+		assertThat(publisher.events.get(1)).isInstanceOf(CacheInsertedEvent.class);
+		CacheInsertedEvent<String, CachedUser> updated = (CacheInsertedEvent<String, CachedUser>) publisher.events.get(1);
+		assertThat(updated.getValue()).isEqualTo(new CachedUser("1", "grace"));
+		assertThat(updated.getPreviousValue()).isEqualTo(new CachedUser("1", "ada"));
+
+		assertThat(publisher.events.get(2)).isInstanceOf(CacheEvictedEvent.class);
+		CacheEvictedEvent<String, CachedUser> evicted = (CacheEvictedEvent<String, CachedUser>) publisher.events.get(2);
+		assertThat(evicted.getKey()).isEqualTo("1");
+		assertThat(evicted.getValue()).isEqualTo(new CachedUser("1", "grace"));
+	}
+
+	@Test
+	void clearsEveryPersistedEntryAndPublishesEvents() {
+
+		RecordingApplicationEventPublisher publisher = new RecordingApplicationEventPublisher();
+		InMemoryCacheDocumentStore store = new InMemoryCacheDocumentStore();
+		CassandraCacheImpl<String, CachedUser> cache = newUserCache(store, publisher, null);
+
+		cache.put("1", new CachedUser("1", "ada"));
+		cache.put("2", new CachedUser("2", "grace"));
+		publisher.events.clear();
+
+		cache.clear();
+
+		assertThat(publisher.events).hasSize(2).allMatch(CacheEvictedEvent.class::isInstance);
+		assertThat(newUserCache(store, null, null).size()).isZero();
+	}
+
+	@Test
+	void readsCurrentValuesFromStoreForEveryGet() {
+
+		InMemoryCacheDocumentStore store = new InMemoryCacheDocumentStore();
+		CassandraCacheImpl<String, CachedUser> first = newUserCache(store, null, null);
+		CassandraCacheImpl<String, CachedUser> second = newUserCache(store, null, null);
+
+		first.put("1", new CachedUser("1", "ada"));
+		second.put("1", new CachedUser("1", "grace"));
+
+		assertThat(first.get("1")).isEqualTo(new CachedUser("1", "grace"));
+	}
+
+	@Test
+	void validatesCacheNames() {
+
+		assertThatIllegalArgumentException().isThrownBy(() -> new CassandraCacheImpl<>(" ", String.class, CachedUser.class,
+				new InMemoryCacheDocumentStore()));
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> new CassandraCacheImpl<>("users/active", String.class, CachedUser.class,
+						new InMemoryCacheDocumentStore()));
+
+		CassandraCacheImpl<String, CachedUser> cache = new CassandraCacheImpl<>("users-v1.active_cache", String.class,
+				CachedUser.class, new InMemoryCacheDocumentStore());
+
+		cache.put("1", new CachedUser("1", "ada"));
+		assertThat(cache.get("1")).isEqualTo(new CachedUser("1", "ada"));
+	}
+
+	@Test
+	void handlesMissingKeysAndEmptyStores() {
+
+		CassandraCacheImpl<String, CachedUser> cache = newUserCache(new InMemoryCacheDocumentStore(), null, null);
+
+		assertThat(cache.size()).isZero();
+		assertThat(cache.keys()).isEmpty();
+
+		cache.put("1", new CachedUser("1", "ada"));
+
+		assertThat(cache.evict("missing")).isNull();
+		assertThat(cache.size()).isEqualTo(1);
+	}
+
+	@Test
+	void expiresValuesAfterEntryTtl() throws InterruptedException {
+
+		CassandraCacheImpl<String, CachedUser> cache = newUserCache(new InMemoryCacheDocumentStore(), null,
+				Duration.ofMillis(25));
+
+		cache.put("1", new CachedUser("1", "ada"));
+		Thread.sleep(50);
+
+		assertThat(cache.get("1")).isNull();
+		assertThat(cache.containsKey("1")).isFalse();
+		assertThat(cache.size()).isZero();
+		assertThat(cache.evictExpired()).containsExactly(Map.entry("1", new CachedUser("1", "ada")));
+		assertThat(cache.evictExpired()).isEmpty();
+	}
+
+	@Test
+	void zeroEntryTtlDoesNotExpireValues() throws InterruptedException {
+
+		CassandraCacheImpl<String, CachedUser> cache = newUserCache(new InMemoryCacheDocumentStore(), null,
+				Duration.ZERO);
+
+		cache.put("1", new CachedUser("1", "ada"));
+		Thread.sleep(25);
+
+		assertThat(cache.get("1")).isEqualTo(new CachedUser("1", "ada"));
+		assertThat(cache.evictExpired()).isEmpty();
+	}
+
+	@Test
+	void persistsJavaTimeValues() {
+
+		InMemoryCacheDocumentStore store = new InMemoryCacheDocumentStore();
+		CassandraCacheImpl<String, CachedEvent> cache = new CassandraCacheImpl<>("events", String.class, CachedEvent.class,
+				store);
+		CachedEvent event = new CachedEvent("1", LocalDate.of(2026, Month.JUNE, 10));
+
+		cache.put("1", event);
+
+		assertThat(new CassandraCacheImpl<>("events", String.class, CachedEvent.class, store).get("1")).isEqualTo(event);
+	}
+
+	private CassandraCacheImpl<String, CachedUser> newUserCache(CacheDocumentStore store,
+			RecordingApplicationEventPublisher publisher, Duration entryTtl) {
+
+		return new CassandraCacheImpl<>("users", String.class, CachedUser.class, store,
+				CassandraCacheImpl.defaultObjectMapper(), publisher, entryTtl);
+	}
+
+	record CachedUser(String id, String username) {
+	}
+
+	record CachedEvent(String id, LocalDate happenedOn) {
+	}
+
+	static final class InMemoryCacheDocumentStore implements CacheDocumentStore {
+
+		private final Map<String, CacheDocument> documents = new LinkedHashMap<>();
+
+		@Override
+		public CacheDocument get(String cacheName, String cacheKey) {
+			return documents.get(documentKey(cacheName, cacheKey));
+		}
+
+		@Override
+		public void put(CacheDocument document) {
+			documents.put(documentKey(document.cacheName(), document.cacheKey()), document);
+		}
+
+		@Override
+		public CacheDocument delete(String cacheName, String cacheKey) {
+			return documents.remove(documentKey(cacheName, cacheKey));
+		}
+
+		@Override
+		public List<CacheDocument> findAll(String cacheName) {
+
+			return documents.values().stream().filter(document -> document.cacheName().equals(cacheName)).toList();
+		}
+
+		private String documentKey(String cacheName, String cacheKey) {
+			return cacheName + "::" + cacheKey;
+		}
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/cache/CassandraCacheManagerUnitTests.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/cache/CassandraCacheManagerUnitTests.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cache.Cache;
+import org.springframework.data.cassandra.cache.event.CacheEvictedEvent;
+import org.springframework.data.cassandra.cache.event.CacheInsertedEvent;
+
+/**
+ * Unit tests for {@link CassandraCacheManager}.
+ *
+ * @author Anıl Şenocak
+ */
+class CassandraCacheManagerUnitTests {
+
+	@Test
+	void reusesCachesAndReportsCacheNames() {
+
+		CassandraCacheManager manager = managerFor(new InMemoryCacheDocumentStore(), Object::toString, null, null, null);
+
+		Cache users = manager.getCache("users");
+
+		assertThat(manager.getCache("users")).isSameAs(users);
+
+		manager.getCache("products");
+
+		assertThat(manager.getCacheCount()).isEqualTo(2);
+		assertThat(manager.getCacheNames()).containsExactlyInAnyOrderElementsOf(Set.of("users", "products"));
+	}
+
+	@Test
+	void clearsAllManagedCaches() {
+
+		CassandraCacheManager manager = managerFor(new InMemoryCacheDocumentStore(), Object::toString, null, null, null);
+		Cache users = manager.getCache("users");
+		Cache products = manager.getCache("products");
+
+		users.put("1", new CachedUser("1", "ada"));
+		products.put("2", new CachedUser("2", "grace"));
+
+		manager.clearAll();
+
+		assertThat(users.get("1")).isNull();
+		assertThat(products.get("2")).isNull();
+	}
+
+	@Test
+	void usesCustomKeySerializerAndPersistsValues() {
+
+		InMemoryCacheDocumentStore store = new InMemoryCacheDocumentStore();
+		Function<Object, String> serializer = key -> ((LookupKey) key).id();
+		CassandraCacheManager manager = managerFor(store, serializer, null, null, null);
+
+		manager.getCache("users").put(new LookupKey("42"), new CachedUser("42", "ada"));
+
+		CachedUser actual = managerFor(store, serializer, null, null, null).getCache("users")
+				.get(new LookupKey("42"), CachedUser.class);
+
+		assertThat(actual).isEqualTo(new CachedUser("42", "ada"));
+	}
+
+	@Test
+	void publishesManagedCacheEvents() {
+
+		RecordingApplicationEventPublisher publisher = new RecordingApplicationEventPublisher();
+		CassandraCacheManager manager = managerFor(new InMemoryCacheDocumentStore(), Object::toString, null, publisher,
+				null);
+		Cache cache = manager.getCache("users");
+
+		cache.put("42", new CachedUser("42", "ada"));
+		cache.evict("42");
+
+		assertThat(publisher.events.get(0)).isInstanceOf(CacheInsertedEvent.class);
+		assertThat(publisher.events.get(1)).isInstanceOf(CacheEvictedEvent.class);
+	}
+
+	@Test
+	void evictsOnlyExpiredEntriesAcrossCaches() throws InterruptedException {
+
+		CassandraCacheManager manager = managerFor(new InMemoryCacheDocumentStore(), Object::toString, null, null,
+				Duration.ofMillis(50));
+		Cache users = manager.getCache("users");
+		Cache products = manager.getCache("products");
+
+		users.put("1", new CachedUser("1", "ada"));
+		Thread.sleep(75);
+		products.put("2", new CachedUser("2", "grace"));
+
+		assertThat(manager.evictExpired()).isEqualTo(1);
+		assertThat(users.get("1")).isNull();
+		assertThat(products.get("2", CachedUser.class)).isEqualTo(new CachedUser("2", "grace"));
+	}
+
+	@Test
+	void periodicallyEvictsExpiredEntries() throws InterruptedException {
+
+		CassandraCacheManager manager = managerFor(new InMemoryCacheDocumentStore(), Object::toString,
+				Duration.ofMillis(10), null, Duration.ofMillis(30));
+
+		try {
+
+			Cache users = manager.getCache("users");
+			users.put("1", new CachedUser("1", "ada"));
+
+			assertThat(manager.isPeriodicClearEnabled()).isTrue();
+			assertEventually(Duration.ofSeconds(2), () -> users.get("1") == null);
+		} finally {
+			manager.close();
+		}
+	}
+
+	@Test
+	void doesNotScheduleWithoutPositiveInterval() {
+
+		CassandraCacheManager absent = managerFor(new InMemoryCacheDocumentStore(), Object::toString, null, null, null);
+		CassandraCacheManager zero = managerFor(new InMemoryCacheDocumentStore(), Object::toString, Duration.ZERO, null,
+				Duration.ZERO);
+
+		try {
+			assertThat(absent.isPeriodicClearEnabled()).isFalse();
+			assertThat(zero.isPeriodicClearEnabled()).isFalse();
+		} finally {
+			absent.close();
+			zero.close();
+		}
+	}
+
+	private CassandraCacheManager managerFor(CacheDocumentStore store, Function<Object, String> keySerializer,
+			Duration clearInterval, RecordingApplicationEventPublisher publisher, Duration entryTtl) {
+
+		ObjectMapper objectMapper = CassandraCacheImpl.defaultObjectMapper();
+
+		return new CassandraCacheManager(
+				cacheName -> new CassandraCacheImpl<>(cacheName, String.class, SpringCacheEntry.class, store, objectMapper,
+						null, entryTtl),
+				objectMapper, keySerializer, clearInterval, publisher, entryTtl);
+	}
+
+	private void assertEventually(Duration timeout, Condition condition) throws InterruptedException {
+
+		long deadline = System.nanoTime() + timeout.toNanos();
+
+		while (System.nanoTime() < deadline) {
+
+			if (condition.evaluate()) {
+				return;
+			}
+
+			Thread.sleep(10);
+		}
+
+		assertThat(condition.evaluate()).as("Condition was not met within %s", timeout).isTrue();
+	}
+
+	@FunctionalInterface
+	interface Condition {
+
+		boolean evaluate();
+	}
+
+	record CachedUser(String id, String username) {
+	}
+
+	record LookupKey(String id) {
+	}
+
+	static final class InMemoryCacheDocumentStore implements CacheDocumentStore {
+
+		private final Map<String, CacheDocument> documents = new LinkedHashMap<>();
+
+		@Override
+		public CacheDocument get(String cacheName, String cacheKey) {
+			return documents.get(documentKey(cacheName, cacheKey));
+		}
+
+		@Override
+		public void put(CacheDocument document) {
+			documents.put(documentKey(document.cacheName(), document.cacheKey()), document);
+		}
+
+		@Override
+		public CacheDocument delete(String cacheName, String cacheKey) {
+			return documents.remove(documentKey(cacheName, cacheKey));
+		}
+
+		@Override
+		public List<CacheDocument> findAll(String cacheName) {
+
+			return documents.values().stream().filter(document -> document.cacheName().equals(cacheName)).toList();
+		}
+
+		private String documentKey(String cacheName, String cacheKey) {
+			return cacheName + "::" + cacheKey;
+		}
+	}
+}

--- a/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/cache/RecordingApplicationEventPublisher.java
+++ b/spring-data-cassandra/src/test/java/org/springframework/data/cassandra/cache/RecordingApplicationEventPublisher.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.cassandra.cache;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * {@link ApplicationEventPublisher} that records every published event for test assertions.
+ *
+ * @author Anıl Şenocak
+ */
+final class RecordingApplicationEventPublisher implements ApplicationEventPublisher {
+
+	final List<Object> events = new ArrayList<>();
+
+	@Override
+	public void publishEvent(Object event) {
+		events.add(event);
+	}
+}


### PR DESCRIPTION
A full Spring Cache using Cassandra that implement Spring's cache abstraction on top of Cassandra, storing each entry as a document via the store-independent CassandraTemplate API.

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
